### PR TITLE
test: assert the search box suggests pages as you type

### DIFF
--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -52,10 +52,12 @@ test("the results page mounts the widget and returns results", async ({
 test("the search box suggests pages as you type", async ({ page }) => {
 	await page.goto("index.html");
 
-	// Focusing mounts the typeahead app; characters typed while it mounts carry
-	// over into the mounted input, so no explicit wait is needed.
+	// Focusing the raw search box mounts the Codex typeahead, which swaps in its own
+	// input; wait for that before typing so no keystrokes are dropped mid-mount.
 	await page.locator("#searchInput").click();
-	await page.keyboard.type("binary", { delay: 40 });
+	const searchInput = page.locator(".cdx-text-input__input");
+	await searchInput.waitFor({ state: "visible", timeout: 15000 });
+	await searchInput.pressSequentially("binary", { delay: 40 });
 
 	// A title suggestion, plus the "containing..." row aimed at the results page.
 	await expect(

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -48,3 +48,20 @@ test("the results page mounts the widget and returns results", async ({
 		timeout: 15000,
 	});
 });
+
+test("the search box suggests pages as you type", async ({ page }) => {
+	await page.goto("index.html");
+
+	// Focusing mounts the typeahead app; characters typed while it mounts carry
+	// over into the mounted input, so no explicit wait is needed.
+	await page.locator("#searchInput").click();
+	await page.keyboard.type("binary", { delay: 40 });
+
+	// A title suggestion, plus the "containing..." row aimed at the results page.
+	await expect(
+		page.locator('.cdx-menu-item a[href*="Standalone_binary"]').first(),
+	).toBeVisible({ timeout: 15000 });
+	await expect(
+		page.locator('.cdx-menu-item a[href*="Search.html?search="]').first(),
+	).toBeVisible();
+});

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -52,12 +52,14 @@ test("the results page mounts the widget and returns results", async ({
 test("the search box suggests pages as you type", async ({ page }) => {
 	await page.goto("index.html");
 
-	// Focusing the raw search box mounts the Codex typeahead, which swaps in its own
-	// input; wait for that before typing so no keystrokes are dropped mid-mount.
+	// Focusing the raw search box mounts the Codex typeahead and focuses its input; wait for a
+	// mounted input (there are two on the page) before typing so no keystrokes are dropped mid-mount.
 	await page.locator("#searchInput").click();
-	const searchInput = page.locator(".cdx-text-input__input");
-	await searchInput.waitFor({ state: "visible", timeout: 15000 });
-	await searchInput.pressSequentially("binary", { delay: 40 });
+	await page
+		.locator(".cdx-text-input__input")
+		.first()
+		.waitFor({ state: "visible", timeout: 15000 });
+	await page.keyboard.type("binary", { delay: 40 });
 
 	// A title suggestion, plus the "containing..." row aimed at the results page.
 	await expect(


### PR DESCRIPTION
**Draft: blocked on the SifterSearch release containing chaotic-ground/SifterSearch#35 reaching the Dockerfile pin.** The smoke job bakes with the pinned SifterSearch, whose retarget bug breaks Vector's typeahead, so this test correctly fails until the bump; mark ready after it.

## Why

The browser smoke covers the results page and the no-second-widget invariant, but not the typeahead itself. So when SifterSearch v0.6.0's retarget removed the hidden `title` input that Vector's search app requires to mount, **suggestions died on the live site while every gate stayed green** (the plain Enter submit kept working, masking it).

## What

A fourth smoke test: type into the search box and expect

- a title suggestion (`Standalone_binary`), and
- the "search for pages containing…" row aimed at the results page (`Search.html?search=`), which also pins the full-text affordance's routing.

## Verification

- **Fails against the currently deployed site** (broken typeahead) — reproduces the bug.
- **Passes (4/4) against a local bake with SifterSearch#35 mounted** — confirms the fix and no regression in the existing three tests.
- Screenshot of the fixed typeahead: suggestions + footer row, first suggestion → `Standalone_binary.html`, footer → `./Search.html?search=binary`.