### PR TITLE
fix: export subpage titles as real subdirectories

### DIFF
--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/** Rebases a page's root-relative references when it moves into an output subdirectory. */
+class RelativeUrl {
+	/**
+	 * Add a "../" per level to every root-relative reference in a page moved $depth subdirectories down.
+	 *
+	 * Wikven links everything relative to the output root ("./x", or "../x" one level above it, as the
+	 * non-main-skin canonical does). A subpage title such as "Manual/Config" caches to a flat file but
+	 * is exported into a real "Manual/" directory; its references then need a "../" per level so links
+	 * and files agree on a static host. Absolute, protocol-relative and data: URLs carry no leading
+	 * "./" and are left alone. Covers href/src/srcset attributes and CSS url().
+	 */
+	public static function reparent(string $html, int $depth): string {
+		if ($depth < 1) {
+			return $html;
+		}
+		$up = str_repeat('../', $depth);
+		$rebase = static function (string $dots) use ($up): string {
+			return $dots === '..' ? $up . '../' : $up;
+		};
+
+		$html = preg_replace_callback(
+			'#\b(href|src)="(\.\.?)/#',
+			static function (array $m) use ($rebase): string {
+				return $m[1] . '="' . $rebase($m[2]);
+			},
+			$html
+		);
+		$html = preg_replace_callback(
+			'#\bsrcset="([^"]*)"#',
+			static function (array $m) use ($rebase): string {
+				return (
+					'srcset="'
+					. preg_replace_callback(
+						'#(^|,\s*)(\.\.?)/#',
+						static function (array $u) use ($rebase): string {
+							return $u[1] . $rebase($u[2]);
+						},
+						$m[1]
+					)
+					. '"'
+				);
+			},
+			$html
+		);
+		return preg_replace_callback(
+			'#\burl\((["\']?)(\.\.?)/#',
+			static function (array $m) use ($rebase): string {
+				return 'url(' . $m[1] . $rebase($m[2]);
+			},
+			$html
+		);
+	}
+}

--- a/maintenance/rename.php
+++ b/maintenance/rename.php
@@ -53,6 +53,21 @@ class Rename extends Maintenance {
 			$newName = preg_replace('/%2E/', '.', $basename);
 			rename("$path/$basename", "$path/$newName");
 		}
+
+		// Subpage titles (e.g. "Manual/Config") cache to a flat "Manual%2FConfig.html", but links to
+		// them keep the slash. Move each into a real subdirectory and rebase its root-relative
+		// references by that depth, so links and files agree when served from a static host.
+		foreach (glob("$path/*%2F*") as $filename) {
+			$basename = basename($filename);
+			$depth = substr_count($basename, '%2F');
+			$destination = "$path/" . str_replace('%2F', '/', $basename);
+			$directory = dirname($destination);
+			if (!wfMkdirParents($directory)) {
+				$this->fatalError("Wikven: could not create directory $directory");
+			}
+			file_put_contents($destination, RelativeUrl::reparent(file_get_contents($filename), $depth), LOCK_EX);
+			unlink($filename);
+		}
 	}
 }
 

--- a/tests/phpunit/unit/RelativeUrlTest.php
+++ b/tests/phpunit/unit/RelativeUrlTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\RelativeUrl;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\RelativeUrl
+ */
+class RelativeUrlTest extends MediaWikiUnitTestCase {
+	public function testDepthZeroLeavesTheHtmlUntouched() {
+		$html = 'href="./index.html" src="././modules-static.js"';
+		$this->assertSame($html, RelativeUrl::reparent($html, 0));
+	}
+
+	public function testRootRelativeLinksGainOneLevelPerDepth() {
+		$this->assertSame('href="../index.html"', RelativeUrl::reparent('href="./index.html"', 1));
+		$this->assertSame('href="../../index.html"', RelativeUrl::reparent('href="./index.html"', 2));
+	}
+
+	public function testParentRelativeCanonicalGainsAFurtherLevel() {
+		$this->assertSame('href="../../Intro.html"', RelativeUrl::reparent('href="../Intro.html"', 1));
+	}
+
+	public function testScriptAndStyleReferencesAreRebased() {
+		$this->assertSame('src=".././modules-static.js"', RelativeUrl::reparent('src="././modules-static.js"', 1));
+		$this->assertSame(
+			'href=".././skins.vector.styles.css"',
+			RelativeUrl::reparent('href="././skins.vector.styles.css"', 1)
+		);
+	}
+
+	public function testEachSrcsetCandidateIsRebased() {
+		$this->assertSame(
+			'srcset="../img-a.png 1.5x, ../img-b.png 2x"',
+			RelativeUrl::reparent('srcset="./img-a.png 1.5x, ./img-b.png 2x"', 1)
+		);
+	}
+
+	public function testCssUrlIsRebased() {
+		$this->assertSame('url(../logo.png)', RelativeUrl::reparent('url(./logo.png)', 1));
+	}
+
+	public function testAbsoluteProtocolRelativeAnchorAndDataUrlsAreLeftAlone() {
+		$html =
+			'href="https://example.org/x" href="//cdn/x" href="/images/logo.png" '
+			. 'href="#top" src="data:image/svg+xml,%3Csvg/%3E"';
+		$this->assertSame($html, RelativeUrl::reparent($html, 2));
+	}
+
+	public function testNonAttributeDotSlashInScriptIsNotRewritten() {
+		$html = '<script>var x = {"path": "./y"};</script>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+}


### PR DESCRIPTION
## Problem

Main-namespace subpages (e.g. `Manual/Config`) are cached to a flat `Manual%2FConfig.html`, but links to them keep the slash (`./Manual/Config.html`). On a static host these disagree, so every subpage 404s. This has been latent (wikven content is normally flat) but it blocks anything hierarchical, e.g. `extension:Translate`'s `Page/lang` translation pages.

## Fix

The `rename` pass now expands `%2F` into a real subdirectory and rebases each moved page's root-relative references by its new depth, so links and files agree:

- `./x` → `../x` per level down
- `../x` (non-main-skin canonical) → one further level
- covers `href` / `src` / `srcset` attributes and CSS `url()`
- absolute, protocol-relative, anchor and `data:` URLs are left alone

Depth-0 pages never contain `%2F`, so they never enter this path — **existing flat output is byte-for-byte unchanged** (verified).

The rebasing logic lives in the pure `RelativeUrl::reparent`, covered by unit tests.

## Verification

- `RelativeUrlTest` unit tests (page links, canonical, script/style, srcset, `url()`, absolute/anchor/data left alone, non-attribute `./` in a script left alone, depth 0 no-op, depth 2).
- Full docker build over a demo with a `Manual/Config` subpage: the subpage becomes a real `Manual/Config.html` whose CSS/JS/page links all resolve via `../`; root pages stay flat with unchanged `./` links; cross-links resolve both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)