### PR TITLE
feat: add a mark command to number translation units

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -11,8 +11,9 @@ shift || true
 if [ "$command" = "serve" ]; then
   # Serve the built site for local preview; the container listens on 8080.
   exec php -S "0.0.0.0:8080" -t "$WIKVEN_WORKDIR/dist"
-elif [ "$command" != "build" ] && [ "$command" != "check" ] && [ "$command" != "stamp" ]; then
-  echo "wikven: unknown command '$command'; expected 'build', 'check', 'stamp' or 'serve'" >&2
+elif [ "$command" != "build" ] && [ "$command" != "check" ] \
+  && [ "$command" != "mark" ] && [ "$command" != "stamp" ]; then
+  echo "wikven: unknown command '$command'; expected 'build', 'check', 'mark', 'stamp' or 'serve'" >&2
   exit 2
 fi
 
@@ -33,6 +34,14 @@ php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/fetchExtensi
 # Wire in WikvenSettings once; a persistent install tree would otherwise duplicate require_once.
 grep -qF "require_once 'WikvenSettings.php';" LocalSettings.php \
   || echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
+
+# "mark" numbers the unmarked <translate> units in src/ with <!--T:n--> markers, so translations
+# can reference them. Run it after wrapping content in <translate>. Needs the src mount writable.
+if [ "$command" = "mark" ]; then
+  exec php maintenance/run.php \
+    /var/www/html/extensions/Wikven/maintenance/markTranslations.php \
+    --source "$WIKVEN_WORKDIR/src" "$@"
+fi
 
 # "check" only needs MediaWiki booted (to autoload Translate); it parses src/ files
 # directly and never imports content. Passed-through flags (e.g. --gate) make it exit

--- a/docs/Translating.wikitext
+++ b/docs/Translating.wikitext
@@ -28,7 +28,13 @@ It runs a real MediaWiki at build time.
 </translate>
 </syntaxhighlight>
 
-The <code><nowiki><!--T:n--></nowiki></code> numbers are the unit identity; keep them stable and unique within the page. The build renders the language bar and, for each language, a page at <code>Page/lang</code>.
+You do not number the units by hand. Wrap the content in <code><nowiki><translate></nowiki></code> and add <code><nowiki><languages/></nowiki></code>, then run the <code>mark</code> command to insert the <code><nowiki><!--T:n--></nowiki></code> markers, mounting your source directory writable:
+
+<syntaxhighlight lang="console">
+$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven mark --all
+</syntaxhighlight>
+
+Pass a single file instead of <code>--all</code> to mark just that page. Marking is idempotent and stable: it keeps the numbers already there and only adds markers for new units, so re-run it whenever you add content. The numbers are the unit identity; a translation references them to line its units up with the source. The build renders the language bar and, for each language, a page at <code>Page/lang</code>.
 
 == Adding a translation ==
 

--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -25,6 +25,37 @@ class StalenessComputer {
 	}
 
 	/**
+	 * Assign <!--T:n--> markers to the still-unmarked units inside a page's <translate> blocks.
+	 *
+	 * Units are the blank-line-separated blocks Translate segments on; an already-marked unit keeps
+	 * its number and new ones continue from the highest on the page. The marker goes on its own line
+	 * before the unit, which both splitUnits() and Translate's own re-parse honour. Idempotent.
+	 */
+	public static function mark(string $text): string {
+		preg_match_all('/<!--T:(\d+)/', $text, $existing);
+		$next = $existing[1] === [] ? 1 : max(array_map('intval', $existing[1])) + 1;
+
+		return preg_replace_callback(
+			'#(<translate(?:\s[^>]*)?>)(.*?)(</translate>)#s',
+			static function (array $block) use (&$next): string {
+				$units = preg_split('/(\n[ \t]*\n)/', $block[2], -1, PREG_SPLIT_DELIM_CAPTURE);
+				$marked = '';
+				foreach ($units as $index => $segment) {
+					// Odd indices are the blank-line separators between units; keep them verbatim.
+					if (( $index % 2 ) === 1 || trim($segment) === '' || str_contains($segment, '<!--T:')) {
+						$marked .= $segment;
+						continue;
+					}
+					preg_match('/^(\s*)(.*)$/s', $segment, $parts);
+					$marked .= $parts[1] . '<!--T:' . $next++ . "-->\n" . $parts[2];
+				}
+				return $block[1] . $marked . $block[3];
+			},
+			$text
+		);
+	}
+
+	/**
 	 * Split page text into units keyed by their <!--T:n--> marker id.
 	 *
 	 * @return array<string,array{hash:?string,text:string}> id => [synced-source hash (translations only), unit text]

--- a/maintenance/markTranslations.php
+++ b/maintenance/markTranslations.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use Maintenance;
+use MediaWiki\Extension\Wikven\PageTranslation\StalenessComputer;
+use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/** Insert <!--T:n--> markers into the still-unmarked units of translatable source pages. */
+class MarkTranslations extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription('Number the unmarked <translate> units of source pages with <!--T:n--> markers.');
+		$this->addOption('source', 'Source directory (default: $wgWikvenSourceDirectory).', false, true);
+		$this->addOption('all', 'Mark every translatable page under the source directory.');
+		$this->addArg('file', 'A single source file to mark (omit when using --all).', false);
+	}
+
+	public function execute() {
+		$source = rtrim((string)$this->getOption('source', $GLOBALS['wgWikvenSourceDirectory'] ?? ''), '/');
+
+		if ($this->hasOption('all')) {
+			if ($source === '' || !is_dir($source)) {
+				$this->fatalError("Wikven: source directory '$source' does not exist.");
+			}
+			foreach (TranslationSource::baseFiles($source) as $baseFile) {
+				$this->markFile($baseFile);
+			}
+			return;
+		}
+
+		$file = $this->getArg(0);
+		if ($file === null) {
+			$this->fatalError('Wikven: pass a source file, or --all.');
+		}
+		if (!is_file($file)) {
+			$this->fatalError("Wikven: '$file' does not exist.");
+		}
+		$this->markFile($file);
+	}
+
+	/** Mark one file in place, reporting whether it changed. */
+	private function markFile(string $file): void {
+		$before = (string)file_get_contents($file);
+		$after = StalenessComputer::mark($before);
+		if ($after === $before) {
+			$this->output("unchanged: $file\n");
+			return;
+		}
+		file_put_contents($file, $after);
+		$this->output("marked:    $file\n");
+	}
+}
+
+$maintClass = MarkTranslations::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\PageTranslation\StalenessComputer;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\PageTranslation\StalenessComputer
+ */
+class StalenessComputerTest extends MediaWikiUnitTestCase {
+	public function testMarkNumbersUnmarkedUnits() {
+		$this->assertSame(
+			"<translate>\n<!--T:1-->\nFirst.\n\n<!--T:2-->\nSecond.\n</translate>",
+			StalenessComputer::mark("<translate>\nFirst.\n\nSecond.\n</translate>")
+		);
+	}
+
+	public function testMarkTreatsAHeadingAsItsOwnUnit() {
+		$this->assertSame(
+			"<translate>\n<!--T:1-->\nIntro.\n\n<!--T:2-->\n== Heading ==\n\n<!--T:3-->\nBody.\n</translate>",
+			StalenessComputer::mark("<translate>\nIntro.\n\n== Heading ==\n\nBody.\n</translate>")
+		);
+	}
+
+	public function testMarkKeepsExistingNumbersAndContinuesFromTheHighest() {
+		$this->assertSame(
+			"<translate>\n<!--T:5-->\nOld.\n\n<!--T:6-->\nNew.\n</translate>",
+			StalenessComputer::mark("<translate>\n<!--T:5-->\nOld.\n\nNew.\n</translate>")
+		);
+	}
+
+	public function testMarkNumbersContinueAcrossBlocks() {
+		$this->assertSame(
+			"<translate>\n<!--T:1-->\nA.\n</translate>\nx\n<translate>\n<!--T:2-->\nB.\n</translate>",
+			StalenessComputer::mark("<translate>\nA.\n</translate>\nx\n<translate>\nB.\n</translate>")
+		);
+	}
+
+	public function testMarkIsIdempotentAndIgnoresTextOutsideTranslate() {
+		$marked = StalenessComputer::mark("outside.\n\n<translate>\nInside.\n</translate>");
+		$this->assertSame("outside.\n\n<translate>\n<!--T:1-->\nInside.\n</translate>", $marked);
+		$this->assertSame($marked, StalenessComputer::mark($marked));
+	}
+
+	public function testAnalyzeFlagsAChangedSourceUnitStale() {
+		$source = "<translate>\n<!--T:1-->\nHello.\n\n<!--T:2-->\nWorld.\n</translate>";
+		$fresh = StalenessComputer::restamp($source, "<!--T:1-->\n안녕.\n\n<!--T:2-->\n세계.\n");
+		$this->assertSame(
+			[StalenessComputer::OK, StalenessComputer::OK],
+			array_column(StalenessComputer::analyze($source, $fresh), 'status')
+		);
+
+		$changed = str_replace('World.', 'Everyone.', $source);
+		$this->assertSame(
+			[StalenessComputer::OK, StalenessComputer::STALE],
+			array_column(StalenessComputer::analyze($changed, $fresh), 'status')
+		);
+	}
+
+	public function testAnalyzeReportsMissingAndOrphanUnits() {
+		$source = "<translate>\n<!--T:1-->\nHello.\n</translate>";
+		$translation = "<!--T:9 @00000000-->\nOrphan.\n";
+		$statuses = array_column(StalenessComputer::analyze($source, $translation), 'status');
+		$this->assertContains(StalenessComputer::UNTRANSLATED, $statuses);
+		$this->assertContains(StalenessComputer::ORPHAN, $statuses);
+	}
+}


### PR DESCRIPTION
Follow-up to #214.

## Why

Wrapping content in `<translate>` is only half of preparing a page: each unit needs a `<!--T:n-->` marker so a translation can line its units up with the source. On a live wiki Translate assigns these when you "mark for translation"; the file-based build had no equivalent, so authors had to number units by hand.

## What

A new `mark` command fills them in:

```console
$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven mark --all
```

It numbers the blank-line-separated units inside each `<translate>` block, keeps any numbers already present, and continues from the highest — so it is idempotent and stable as content grows. Pass a single file instead of `--all` to mark just that page.

The pure rewrite is `StalenessComputer::mark` (unit-tested). The marker sits on its own line before the unit, which both the staleness split and Translate's own re-parse honour, headings included.

## Verification

- `StalenessComputerTest` unit tests: numbering, heading-as-own-unit, keeping existing numbers, continuing across blocks, idempotence, ignoring text outside `<translate>` (plus analyze/restamp, previously only covered ad hoc).
- Full docker build: `mark --all` numbers an unmarked page with a heading; translating + `stamp` + build renders `Guide/ko` at 100% with the heading translated, confirming the marker-before-heading placement round-trips through Translate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)