### PR TITLE
refactor: group translation helpers under a translate subcommand

### DIFF
--- a/action-check/action.yml
+++ b/action-check/action.yml
@@ -60,4 +60,4 @@ runs:
         # --path-prefix makes the annotation file names repo-relative (they resolve under $SOURCE).
         docker run --rm \
           -v "$PWD/$SOURCE:/workspace/src:ro" \
-          "$IMAGE" check "${gate[@]}" --path-prefix "$SOURCE"
+          "$IMAGE" translate check "${gate[@]}" --path-prefix "$SOURCE"

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -11,9 +11,19 @@ shift || true
 if [ "$command" = "serve" ]; then
   # Serve the built site for local preview; the container listens on 8080.
   exec php -S "0.0.0.0:8080" -t "$WIKVEN_WORKDIR/dist"
-elif [ "$command" != "build" ] && [ "$command" != "check" ] \
-  && [ "$command" != "mark" ] && [ "$command" != "stamp" ]; then
-  echo "wikven: unknown command '$command'; expected 'build', 'check', 'mark', 'stamp' or 'serve'" >&2
+elif [ "$command" = "translate" ]; then
+  # Translation helpers: `translate mark|check|stamp`. Validate before the slow boot below.
+  subcommand="${1:-}"
+  shift || true
+  case "$subcommand" in
+    mark | check | stamp) ;;
+    *)
+      echo "wikven: 'translate' needs a subcommand: mark, check or stamp" >&2
+      exit 2
+      ;;
+  esac
+elif [ "$command" != "build" ]; then
+  echo "wikven: unknown command '$command'; expected 'build', 'translate' or 'serve'" >&2
   exit 2
 fi
 
@@ -35,28 +45,18 @@ php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/fetchExtensi
 grep -qF "require_once 'WikvenSettings.php';" LocalSettings.php \
   || echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
 
-# "mark" numbers the unmarked <translate> units in src/ with <!--T:n--> markers, so translations
-# can reference them. Run it after wrapping content in <translate>. Needs the src mount writable.
-if [ "$command" = "mark" ]; then
+# Translation helpers run once MediaWiki is booted (to autoload Translate and load config), then
+# work on src/ directly and exit without a build. "mark" numbers unmarked <translate> units and
+# "stamp" refreshes translation stamps (both rewrite src/, so need a writable mount); "check"
+# reads only and passes flags such as --gate through to gate on out-of-date translations.
+if [ "$command" = "translate" ]; then
+  case "$subcommand" in
+    mark) script=markTranslations.php ;;
+    check) script=checkTranslations.php ;;
+    stamp) script=stampTranslations.php ;;
+  esac
   exec php maintenance/run.php \
-    /var/www/html/extensions/Wikven/maintenance/markTranslations.php \
-    --source "$WIKVEN_WORKDIR/src" "$@"
-fi
-
-# "check" only needs MediaWiki booted (to autoload Translate); it parses src/ files
-# directly and never imports content. Passed-through flags (e.g. --gate) make it exit
-# non-zero when a translation is stale or missing.
-if [ "$command" = "check" ]; then
-  exec php maintenance/run.php \
-    /var/www/html/extensions/Wikven/maintenance/checkTranslations.php \
-    --source "$WIKVEN_WORKDIR/src" "$@"
-fi
-
-# "stamp" rewrites translation markers in src/ to the current source unit hashes; run it after
-# translating so up-to-date units read as fresh. Needs the src mount to be writable.
-if [ "$command" = "stamp" ]; then
-  exec php maintenance/run.php \
-    /var/www/html/extensions/Wikven/maintenance/stampTranslations.php \
+    "/var/www/html/extensions/Wikven/maintenance/$script" \
     --source "$WIKVEN_WORKDIR/src" "$@"
 fi
 

--- a/docs/Translating.wikitext
+++ b/docs/Translating.wikitext
@@ -28,10 +28,10 @@ It runs a real MediaWiki at build time.
 </translate>
 </syntaxhighlight>
 
-You do not number the units by hand. Wrap the content in <code><nowiki><translate></nowiki></code> and add <code><nowiki><languages/></nowiki></code>, then run the <code>mark</code> command to insert the <code><nowiki><!--T:n--></nowiki></code> markers, mounting your source directory writable:
+You do not number the units by hand. Wrap the content in <code><nowiki><translate></nowiki></code> and add <code><nowiki><languages/></nowiki></code>, then run <code>translate mark</code> to insert the <code><nowiki><!--T:n--></nowiki></code> markers, mounting your source directory writable:
 
 <syntaxhighlight lang="console">
-$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven mark --all
+$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven translate mark --all
 </syntaxhighlight>
 
 Pass a single file instead of <code>--all</code> to mark just that page. Marking is idempotent and stable: it keeps the numbers already there and only adds markers for new units, so re-run it whenever you add content. The numbers are the unit identity; a translation references them to line its units up with the source. The build renders the language bar and, for each language, a page at <code>Page/lang</code>.
@@ -48,14 +48,14 @@ Put a translation next to the page, named <code><Page>/<lang>.wikitext</code>: t
 빌드 시 실제 미디어위키를 실행합니다.
 </syntaxhighlight>
 
-The <code>@a1b2c3d4</code> after each marker is a stamp recording which version of the source unit the translation was made from. You do not write it by hand; add the markers and text, then run <code>stamp</code> (see below) to fill the stamps in. A translation may cover only some units; the rest stay untranslated and are shown in the source language.
+The <code>@a1b2c3d4</code> after each marker is a stamp recording which version of the source unit the translation was made from. You do not write it by hand; add the markers and text, then run <code>translate stamp</code> (see below) to fill the stamps in. A translation may cover only some units; the rest stay untranslated and are shown in the source language.
 
 == Stamping ==
 
-After translating, run the <code>stamp</code> command so every up-to-date unit records the source version it matches. Mount your source directory writable:
+After translating, run <code>translate stamp</code> so every up-to-date unit records the source version it matches. Mount your source directory writable:
 
 <syntaxhighlight lang="console">
-$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven stamp --all
+$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven translate stamp --all
 </syntaxhighlight>
 
 Pass a single file instead of <code>--all</code> to stamp just that translation.
@@ -65,13 +65,13 @@ Pass a single file instead of <code>--all</code> to stamp just that translation.
 When you change a source unit, its translations no longer match their stamp and are '''out of date'''. {{wikven}} does not hide this:
 
 * In the built site, an out-of-date unit is marked as an outdated translation, exactly as it would be on a wiki running Translate.
-* The <code>check</code> command reports every out-of-date or missing translation, and with <code>--gate</code> exits non-zero so continuous integration can fail the build:
+* <code>translate check</code> reports every out-of-date or missing translation, and with <code>--gate</code> exits non-zero so continuous integration can fail the build:
 
 <syntaxhighlight lang="console">
-$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven check --gate
+$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven translate check --gate
 ::warning file=src/Intro/ko.wikitext::Stale translation unit T:2 (ko)
 </syntaxhighlight>
 
-A companion GitHub Action runs the same check on pull requests. To bring a translation back up to date, edit it to match the new source, then <code>stamp</code> it again.
+A companion GitHub Action runs the same check on pull requests. To bring a translation back up to date, edit it to match the new source, then <code>translate stamp</code> it again.
 
 {{prevnext|Searching|Deploying}}


### PR DESCRIPTION
Follow-up to #214 / #216, before any of the i18n commands ship in a release.

## Why

`mark`, `check` and `stamp` were top-level image commands. A bare `mark` gives no hint that it is about translation, and `mark-for-translation` would be clear but too long to type often.

## What

Group them under a `translate` command:

```console
$ docker run ... ghcr.io/chaotic-ground/wikven translate mark --all
$ docker run ... ghcr.io/chaotic-ground/wikven translate check --gate
$ docker run ... ghcr.io/chaotic-ground/wikven translate stamp --all
```

Each subcommand stays short while reading unambiguously. A bare `translate`, or an unknown subcommand, prints the options and exits non-zero. The subcommand is validated before the (slow) MediaWiki boot.

Updates the `action-check` GitHub Action (`translate check`) and the Translating docs to match. Only the not-yet-released i18n commands change; `build`/`serve` are untouched.

## Verification

Full docker build, exercising the dispatch:
- `translate mark --all` numbers a page; `translate check` runs and reports.
- `translate` alone and `translate bogus` → clear message, exit 2.
- the old bare `mark` → `unknown command 'mark'; expected 'build', 'translate' or 'serve'`, exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)