### PR TITLE
fix: require UniversalLanguageSelector explicitly and disable its webfonts

### DIFF
--- a/docs/Translating.wikitext
+++ b/docs/Translating.wikitext
@@ -4,12 +4,15 @@ __TOC__
 
 == Enabling translation ==
 
-Add <code>Translate</code> to <code>extensions</code> in your [[Configuration|<code>.wikven.yaml</code>]], the same way you enable any other extension. It is bundled in the {{wikven}} image, along with its UniversalLanguageSelector dependency, which {{wikven}} loads for you, so there is nothing to install.
+Add <code>Translate</code> to <code>extensions</code> in your [[Configuration|<code>.wikven.yaml</code>]], along with <code>UniversalLanguageSelector</code>, which Translate depends on. Both are bundled in the {{wikven}} image, so there is nothing to install.
 
 <syntaxhighlight lang="yaml">
 extensions:
+  - UniversalLanguageSelector
   - Translate
 </syntaxhighlight>
+
+A static export cannot serve UniversalLanguageSelector's runtime webfonts (they load from a live endpoint), so {{wikven}} turns them off; readers see each script in their own system fonts.
 
 You do not list the languages you translate into: as with Translate itself, a language exists as soon as a translation for it does. The language you write your pages in stays the source language.
 

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -167,16 +167,6 @@ if ($wikvenBuildSkin !== false && in_array($wikvenBuildSkin, $wgWikvenSkins, tru
 	}
 }
 
-// Listing Translate turns on content i18n. It hard-depends on UniversalLanguageSelector, so pull
-// that in too (both are bundled in the image); the build's materialize step then discovers
-// translations and renders translated pages and <languages/>.
-if (
-	in_array('Translate', $config['extensions'], true)
-	&& !in_array('UniversalLanguageSelector', $config['extensions'], true)
-) {
-	$config['extensions'][] = 'UniversalLanguageSelector';
-}
-
 // Load each bundled extension; an unknown name is skipped with a warning.
 foreach ($config['extensions'] ?? [] as $extension) {
 	if (!is_string($extension)) {
@@ -187,6 +177,13 @@ foreach ($config['extensions'] ?? [] as $extension) {
 	} else {
 		error_log("Wikven: skipping extension '$extension' (not bundled in this image)");
 	}
+}
+
+// UniversalLanguageSelector (enabled for content i18n) would have the browser pull its webfont
+// module and font files from load.php, which a static export cannot serve. Turn webfonts off;
+// bundling them into the static site instead is tracked as a separate enhancement.
+if (in_array('UniversalLanguageSelector', $config['extensions'], true)) {
+	$GLOBALS['wgULSWebfontsEnabled'] = false;
 }
 
 // SifterSearch ships built in; default its Pagefind index into the build's dist dir, unless the


### PR DESCRIPTION
Follow-up to the i18n work (#214), found while dogfooding.

## Two changes

**Require ULS explicitly.** Translate hard-depends on UniversalLanguageSelector. #214 auto-injected ULS when Translate was listed; this removes that magic and asks you to list both, so the config shows exactly what loads:

```yaml
extensions:
  - UniversalLanguageSelector
  - Translate
```

A Translate-only list now surfaces MediaWiki's own clear "requires UniversalLanguageSelector" error, rather than wikven silently adding an extension.

**Disable ULS webfonts.** ULS webfonts have the browser pull a module (`ext.uls.webfonts.repository`) and font files from `load.php` at runtime — which a static export can't serve, so a Translate-enabled page 404s on it (caught by the smoke test's browser check). Set `$wgULSWebfontsEnabled = false` whenever ULS is loaded; readers see each script in their own system fonts.

## Verification

- Docker build of a `UniversalLanguageSelector` + `Translate` site: `Intro/ko` renders with the native `<languages/>` bar; the page no longer references `ext.uls.webfonts*` or `wgULSWebfontsEnabled`.
- **Headless browser (playwright, `networkidle`) over the rendered pages: zero `load.php` requests.**

Baking the fonts into the static output instead (so scripts without system fonts still render) is a realistic follow-up — the font files are static woff2 and the repository is a relocatable, per-language-scopable config — tracked separately.