### PR TITLE
fix: resolve translate mark/stamp file paths against the source directory

### DIFF
--- a/maintenance/markTranslations.php
+++ b/maintenance/markTranslations.php
@@ -39,6 +39,10 @@ class MarkTranslations extends Maintenance {
 		if ($file === null) {
 			$this->fatalError('Wikven: pass a source file, or --all.');
 		}
+		// A relative path is taken within the source directory (what the src mount maps to).
+		if (!str_starts_with($file, '/')) {
+			$file = "$source/$file";
+		}
 		if (!is_file($file)) {
 			$this->fatalError("Wikven: '$file' does not exist.");
 		}

--- a/maintenance/stampTranslations.php
+++ b/maintenance/stampTranslations.php
@@ -43,6 +43,10 @@ class StampTranslations extends Maintenance {
 		if ($translationFile === null) {
 			$this->fatalError('Wikven: pass a translation file, or --all.');
 		}
+		// A relative path is taken within the source directory (what the src mount maps to).
+		if (!str_starts_with($translationFile, '/')) {
+			$translationFile = "$source/$translationFile";
+		}
 		if (!is_file($translationFile)) {
 			$this->fatalError("Wikven: '$translationFile' does not exist.");
 		}


### PR DESCRIPTION
Found while dogfooding.

## Problem

A single-file argument to `translate mark` / `translate stamp` was resolved relative to the container's working directory (`/var/www/html`), not the mounted source. So the natural invocation failed:

```console
$ docker run --rm -v "$PWD:/workspace/src" wikven translate mark docs/index.wikitext
Wikven: 'docs/index.wikitext' does not exist.
```

## Fix

Take a relative file path within the source directory (what the `src` mount maps to); absolute paths are used as-is. Now `translate mark docs/index.wikitext` (repo mounted at the source) and `translate mark index.wikitext` (source dir mounted) both work.

## Verification

Docker build, reproducing the reported invocation: mounting a repo root at `/workspace/src` and running `translate mark docs/Guide.wikitext` marks `/workspace/src/docs/Guide.wikitext`; mounting the source dir and passing a bare filename resolves too.