### PR TITLE
ci: exclude vendor/ from taplo checks

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,2 @@
+# Dependency files under vendor/ are gitignored and not ours to format or validate.
+exclude = ["vendor/**"]


### PR DESCRIPTION
Found while committing during dogfooding.

## Problem

GrumPHP's `taplo fmt --check` / `taplo check` walked into `vendor/` (which is gitignored) and failed on a dependency's `vendor/chaotic-ground/mago-mediawiki-style/mago.toml` ("not properly formatted"), blocking local commits. CI's `taplo` job passes only because it doesn't `composer install`, so `vendor/` isn't present there.

## Fix

Add a `.taplo.toml` that excludes `vendor/**`, so taplo formats/validates only our own TOML (`.rumdl.toml`, `.typos.toml`, `mago.toml`, and `.taplo.toml` itself). Verified locally: taplo now reports `excluded=3` (the vendor files) and both `fmt --check` and `check` exit 0.

Note: the other local pre-commit noise (biome complaining about a schema version) is a contributor's local biome version differing from the pinned one, not a repo issue — out of scope here.