### PR TITLE
feat: add translate scaffold to generate translation skeletons

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -16,9 +16,9 @@ elif [ "$command" = "translate" ]; then
   subcommand="${1:-}"
   shift || true
   case "$subcommand" in
-    mark | check | stamp) ;;
+    mark | scaffold | check | stamp) ;;
     *)
-      echo "wikven: 'translate' needs a subcommand: mark, check or stamp" >&2
+      echo "wikven: 'translate' needs a subcommand: mark, scaffold, check or stamp" >&2
       exit 2
       ;;
   esac
@@ -46,18 +46,23 @@ grep -qF "require_once 'WikvenSettings.php';" LocalSettings.php \
   || echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
 
 # Translation helpers run once MediaWiki is booted (to autoload Translate and load config), then
-# work on src/ directly and exit without a build. "mark" numbers unmarked <translate> units and
-# "stamp" refreshes translation stamps (both rewrite src/, so need a writable mount); "check"
-# reads only and passes flags such as --gate through to gate on out-of-date translations.
+# work on src/ directly and exit without a build. "mark"/"scaffold"/"stamp" write into src/ (so
+# need a writable mount); "check" reads only and passes flags such as --gate through.
 if [ "$command" = "translate" ]; then
   case "$subcommand" in
     mark) script=markTranslations.php ;;
+    scaffold) script=scaffoldTranslations.php ;;
     check) script=checkTranslations.php ;;
     stamp) script=stampTranslations.php ;;
   esac
-  exec php maintenance/run.php \
+  php maintenance/run.php \
     "/var/www/html/extensions/Wikven/maintenance/$script" \
     --source "$WIKVEN_WORKDIR/src" "$@"
+  code=$?
+  # These run as root; hand any files they created/edited in src back to the mount owner so the
+  # translator can edit them without sudo. A no-op on a read-only mount (check).
+  chown -R "$(stat -c '%u:%g' "$WIKVEN_WORKDIR/src")" "$WIKVEN_WORKDIR/src" 2>/dev/null || true
+  exit "$code"
 fi
 
 # Apply extension schema updates (e.g. Translate's revtag/translate_* tables) that the installer

--- a/docs/Translating.wikitext
+++ b/docs/Translating.wikitext
@@ -41,17 +41,25 @@ Pass a single file instead of <code>--all</code> to mark just that page. Marking
 
 == Adding a translation ==
 
-Put a translation next to the page, named <code><Page>/<lang>.wikitext</code>: the Korean translation of <code>Intro.wikitext</code> is <code>Intro/ko.wikitext</code>. Mirror the source's <code><nowiki><!--T:n--></nowiki></code> markers and write each unit's translation under its marker:
+A translation lives next to the page, named <code><Page>/<lang>.wikitext</code>: the Korean translation of <code>Intro.wikitext</code> is <code>Intro/ko.wikitext</code>. Generate its skeleton with <code>translate scaffold</code>, which writes an empty <code><nowiki><!--T:n--></nowiki></code> marker for every source unit and lists each unit's source text as a guide:
+
+<syntaxhighlight lang="console">
+$ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven translate scaffold ko Intro.wikitext
+</syntaxhighlight>
+
+Pass <code>--all</code> in place of a file to scaffold every translatable page. Re-running is safe: it keeps what you have translated and only appends markers for new units.
+
+Then fill each unit's translation under its marker:
 
 <syntaxhighlight lang="wikitext">
-<!--T:1 @a1b2c3d4-->
+<!--T:1-->
 위크벤은 미디어위키로 정적 사이트를 만듭니다.
 
-<!--T:2 @e5f6a7b8-->
+<!--T:2-->
 빌드 시 실제 미디어위키를 실행합니다.
 </syntaxhighlight>
 
-The <code>@a1b2c3d4</code> after each marker is a stamp recording which version of the source unit the translation was made from. You do not write it by hand; add the markers and text, then run <code>translate stamp</code> (see below) to fill the stamps in. A translation may cover only some units; the rest stay untranslated and are shown in the source language.
+A unit left empty counts as not yet translated: <code>translate check</code> reports it and the build renders it in the source language, so you can translate a page a few units at a time. The <code>@a1b2c3d4</code> stamp is added by <code>translate stamp</code> (see below), not by hand.
 
 == Stamping ==
 

--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -93,7 +93,8 @@ class StalenessComputer {
 
 		$result = [];
 		foreach ($source as $id => $unit) {
-			if (!isset($translation[$id])) {
+			if (!isset($translation[$id]) || trim($translation[$id]['text']) === '') {
+				// Absent, or present but empty (a scaffolded unit not yet filled in).
 				$status = self::UNTRANSLATED;
 			} elseif ($translation[$id]['hash'] !== self::hashUnit($unit['text'])) {
 				$status = self::STALE;
@@ -129,6 +130,29 @@ class StalenessComputer {
 			},
 			$translationText
 		);
+	}
+
+	/**
+	 * Build (or extend) a translation skeleton: a <!--T:n--> marker with an empty body for every
+	 * source unit not already present. Empty bodies read as "not yet translated"; the translator
+	 * fills them and runs stamp. An existing translation is kept intact with only new-unit markers
+	 * appended, so it is safe to re-run as the source gains units.
+	 */
+	public static function scaffold(string $sourceText, ?string $existingTranslation = null): string {
+		$existing = $existingTranslation === null ? [] : self::splitUnits($existingTranslation);
+		$additions = '';
+		foreach (self::splitUnits($sourceText) as $id => $unit) {
+			if (!isset($existing[$id])) {
+				$additions .= '<!--T:' . $id . "-->\n\n";
+			}
+		}
+		if ($additions === '') {
+			return $existingTranslation ?? '';
+		}
+		if ($existingTranslation === null || trim($existingTranslation) === '') {
+			return $additions;
+		}
+		return rtrim($existingTranslation, "\n") . "\n\n" . $additions;
 	}
 
 	/** Strip <translate> wrapper tags and surrounding whitespace so the hash tracks unit content only. */

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -141,11 +141,12 @@ class BuildTranslations extends Maintenance {
 			}
 
 			foreach ($sourceUnits as $id => $sourceUnit) {
-				if (!isset($units[$id])) {
-					// Left untranslated; Translate reports it as such.
+				$text = isset($units[$id]) ? trim($units[$id]['text']) : '';
+				if ($text === '') {
+					// Absent, or an empty (scaffolded, not-yet-filled) unit: leave it untranslated
+					// so Translate renders the source language.
 					continue;
 				}
-				$text = trim($units[$id]['text']);
 				if (( $status[(string)$id] ?? '' ) === StalenessComputer::STALE) {
 					$text = TRANSLATE_FUZZY . $text;
 				}

--- a/maintenance/scaffoldTranslations.php
+++ b/maintenance/scaffoldTranslations.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use Maintenance;
+use MediaWiki\Extension\Wikven\PageTranslation\StalenessComputer;
+use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/** Create or extend a translation skeleton: a <!--T:n--> marker with an empty body per source unit. */
+class ScaffoldTranslations extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription('Write empty <!--T:n--> translation skeletons for a language.');
+		$this->addOption('source', 'Source directory (default: $wgWikvenSourceDirectory).', false, true);
+		$this->addOption('all', 'Scaffold every translatable page.');
+		$this->addArg('language', 'Target language code, e.g. ko.');
+		$this->addArg('file', 'A single source file to scaffold (omit when using --all).', false);
+	}
+
+	public function execute() {
+		$source = rtrim((string)$this->getOption('source', $GLOBALS['wgWikvenSourceDirectory'] ?? ''), '/');
+
+		$language = $this->getArg(0);
+		if ($language === null) {
+			$this->fatalError('Wikven: pass a language code, then a source file or --all.');
+		}
+		if (!$this->getServiceContainer()->getLanguageNameUtils()->isKnownLanguageTag($language)) {
+			$this->fatalError("Wikven: '$language' is not a known language code.");
+		}
+
+		if ($this->hasOption('all')) {
+			if ($source === '' || !is_dir($source)) {
+				$this->fatalError("Wikven: source directory '$source' does not exist.");
+			}
+			foreach (TranslationSource::baseFiles($source) as $baseFile) {
+				$this->scaffoldFile($baseFile, $language);
+			}
+			return;
+		}
+
+		$file = $this->getArg(1);
+		if ($file === null) {
+			$this->fatalError('Wikven: pass a source file, or --all.');
+		}
+		if (!str_starts_with($file, '/')) {
+			$file = "$source/$file";
+		}
+		if (!is_file($file)) {
+			$this->fatalError("Wikven: '$file' does not exist.");
+		}
+		$this->scaffoldFile($file, $language);
+	}
+
+	/** Scaffold one base page's translation for the language, then list its source units as a guide. */
+	private function scaffoldFile(string $baseFile, string $language): void {
+		$sourceText = (string)file_get_contents($baseFile);
+		if (!TranslationSource::isTranslatable($sourceText)) {
+			$this->output("not translatable, skipped: $baseFile\n");
+			return;
+		}
+
+		$translationFile = TranslationSource::translationPath($baseFile, $language);
+		$existing = is_file($translationFile) ? (string)file_get_contents($translationFile) : null;
+		$scaffolded = StalenessComputer::scaffold($sourceText, $existing);
+		if ($existing !== null && $scaffolded === $existing) {
+			$this->output("unchanged: $translationFile\n");
+			return;
+		}
+
+		$directory = dirname($translationFile);
+		if (!is_dir($directory) && !wfMkdirParents($directory)) {
+			$this->fatalError("Wikven: could not create directory $directory");
+		}
+		file_put_contents($translationFile, $scaffolded);
+		$this->output("scaffolded: $translationFile\n");
+
+		// List each source unit so the translator knows what each marker is for.
+		foreach (StalenessComputer::splitUnits($sourceText) as $id => $unit) {
+			$text = preg_replace('/<\/?translate[^>]*>/', '', $unit['text']);
+			$preview = trim(preg_replace('/\s+/', ' ', $text));
+			if (mb_strlen($preview) > 80) {
+				$preview = mb_substr($preview, 0, 79) . '…';
+			}
+			$this->output("  T:$id  $preview\n");
+		}
+	}
+}
+
+$maintClass = ScaffoldTranslations::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -65,4 +65,33 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 		$this->assertContains(StalenessComputer::UNTRANSLATED, $statuses);
 		$this->assertContains(StalenessComputer::ORPHAN, $statuses);
 	}
+
+	public function testScaffoldWritesEmptyMarkersCountedAsUntranslated() {
+		$source = "<translate>\n<!--T:1-->\nHello.\n\n<!--T:2-->\nWorld.\n</translate>";
+		$skeleton = StalenessComputer::scaffold($source);
+		$this->assertSame("<!--T:1-->\n\n<!--T:2-->\n\n", $skeleton);
+		$this->assertSame(
+			[StalenessComputer::UNTRANSLATED, StalenessComputer::UNTRANSLATED],
+			array_column(StalenessComputer::analyze($source, $skeleton), 'status')
+		);
+	}
+
+	public function testScaffoldKeepsTranslatedUnitsAndAppendsOnlyNewOnes() {
+		$source = "<translate>\n<!--T:1-->\nHello.\n\n<!--T:2-->\nWorld.\n</translate>";
+		$existing = "<!--T:1-->\n안녕.\n";
+		$this->assertSame(
+			"<!--T:1-->\n안녕.\n\n<!--T:2-->\n\n",
+			StalenessComputer::scaffold($source, $existing)
+		);
+	}
+
+	public function testAFilledUnitBesideAnEmptyOneIsTranslatedNotUntranslated() {
+		$source = "<translate>\n<!--T:1-->\nHello.\n\n<!--T:2-->\nWorld.\n</translate>";
+		// T:1 filled and stamped, T:2 left empty by the scaffold.
+		$partial = StalenessComputer::restamp($source, "<!--T:1-->\n안녕.\n\n<!--T:2-->\n\n");
+		$this->assertSame(
+			[StalenessComputer::OK, StalenessComputer::UNTRANSLATED],
+			array_column(StalenessComputer::analyze($source, $partial), 'status')
+		);
+	}
 }


### PR DESCRIPTION
Follow-up to the i18n work, requested while dogfooding: the last manual step in the authoring loop was hand-writing the translation file's markers.

## What

`translate scaffold <lang> <file>` (or `--all`) writes a `<!--T:n-->` marker with an **empty body** for every source unit, so you don't hand-copy markers. It:
- keeps any existing translation and only **appends** markers for new units (safe to re-run as the source grows),
- lists each unit's source text as a guide.

```console
$ docker run --rm -v "$PWD/docs:/workspace/src" ghcr.io/chaotic-ground/wikven translate scaffold ko Guide.wikitext
scaffolded: /workspace/src/Guide/ko.wikitext
  T:1  Wikven builds static sites.
  T:2  It runs a real MediaWiki.
```

## "Not yet translated" = an empty unit

An empty unit body now counts as untranslated (previously only an *absent* marker did): `translate check` reports it, and the build renders it in the source language. So you can translate a page a few units at a time, and a scaffolded-but-unfilled unit is correctly "untranslated" rather than "stale".

## Also: hand src files back to the mount owner

`mark`/`scaffold`/`stamp` run as root and write into `src/`. A newly *created* file (a scaffold skeleton) was left root-owned, so the translator couldn't edit it without sudo. The entrypoint now `chown`s src back to the mount owner after these commands (a no-op on the read-only `check` mount).

## Verification (docker e2e)

Scaffold a 2-unit page → skeleton is empty and owned by the mount user; fill unit 1, leave unit 2 empty; `stamp`; `check` reports only unit 2 untranslated; build renders **`Guide/ko` at 50%** — unit 1 in Korean, unit 2 falling back to the source language. Pure logic (`StalenessComputer::scaffold`, empty→untranslated) covered by unit tests.