### PR TITLE
feat: resolve Special:MyLanguage/ links in the static export

### DIFF
--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-/** Rebases a page's root-relative references when it moves into an output subdirectory. */
+/** Rewrites a page's output links: depth reparenting, and Special:MyLanguage resolution. */
 class RelativeUrl {
 	/**
 	 * Add a "../" per level to every root-relative reference in a page moved $depth subdirectories down.
@@ -50,6 +50,27 @@ class RelativeUrl {
 			'#\burl\((["\']?)(\.\.?)/#',
 			static function (array $m) use ($rebase): string {
 				return 'url(' . $m[1] . $rebase($m[2]);
+			},
+			$html
+		);
+	}
+
+	/**
+	 * Resolve Translate's "Special:MyLanguage/Target" links (that special page is not exported) to a
+	 * static target: "Target/<lang>.html" when a translation for the page's language exists, else the
+	 * source "Target.html". The link's existing relative prefix (already depth-correct after reparent)
+	 * and any "#fragment" are kept, so the target stays reachable from any page depth.
+	 *
+	 * @param string $html
+	 * @param string|null $lang The page's language, or null for a source page (always the source target).
+	 * @param callable(string):bool $hasTranslation Whether target page $1 has a translation in $lang.
+	 */
+	public static function resolveMyLanguage(string $html, ?string $lang, callable $hasTranslation): string {
+		return preg_replace_callback(
+			'~(href="(?:\.\./)*(?:\./)?)Special:MyLanguage/([^"#]+)\.html(#[^"]*)?"~',
+			static function (array $m) use ($lang, $hasTranslation): string {
+				$base = $lang !== null && $hasTranslation($m[2]) ? "/$lang.html" : '.html';
+				return $m[1] . $m[2] . $base . ( $m[3] ?? '' ) . '"';
 			},
 			$html
 		);

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -103,6 +103,8 @@ class Build extends Maintenance {
 		$this->step(RewriteScripts::class, "$own/rewriteScripts.php");
 		$this->step(StoreImages::class, "$own/storeImages.php");
 		$this->step(Rename::class, "$own/rename.php");
+		// Rename has expanded translation pages into "<Page>/<lang>.html"; resolve MyLanguage links now.
+		$this->step(ResolveTranslationLinks::class, "$own/resolveTranslationLinks.php");
 
 		// RebuildFileCache emits a per-page history/ tree the static host won't serve; drop it.
 		$history = "$dir/history";

--- a/maintenance/resolveTranslationLinks.php
+++ b/maintenance/resolveTranslationLinks.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use FilesystemIterator;
+use Maintenance;
+use MediaWiki\Languages\LanguageNameUtils;
+use MediaWiki\Registration\ExtensionRegistry;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/**
+ * Resolve Translate's Special:MyLanguage/ links in the exported HTML.
+ *
+ * Translation pages are parsed in the source-page context, so the page language is not known at
+ * render time; the exported path is (a translation is at "<Page>/<lang>.html"). This runs after
+ * Rename, over the final tree: it reads each file's language from its path, then rewrites every
+ * "Special:MyLanguage/Target" link to the target's translation in that language when it exists, or
+ * the source target otherwise, keeping the link's existing relative prefix.
+ */
+class ResolveTranslationLinks extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription('Resolve Special:MyLanguage/ links in the exported HTML to static pages.');
+	}
+
+	public function execute() {
+		if (!ExtensionRegistry::getInstance()->isLoaded('Translate')) {
+			return;
+		}
+		$htmlDir = rtrim($GLOBALS['wgWikvenHtmlDirectory'], '/');
+		if ($htmlDir === '' || !is_dir($htmlDir)) {
+			return;
+		}
+		$languageNameUtils = $this->getServiceContainer()->getLanguageNameUtils();
+
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($htmlDir, FilesystemIterator::SKIP_DOTS)
+		);
+		foreach ($iterator as $file) {
+			$path = $file->getPathname();
+			if (!$file->isFile() || !str_ends_with($path, '.html')) {
+				continue;
+			}
+			$lang = $this->fileLanguage($path, $htmlDir, $languageNameUtils);
+			$html = (string)file_get_contents($path);
+			$resolved = RelativeUrl::resolveMyLanguage(
+				$html,
+				$lang,
+				static function (string $target) use ($htmlDir, $lang): bool {
+					return is_file("$htmlDir/$target/$lang.html");
+				}
+			);
+			if ($resolved !== $html) {
+				file_put_contents($path, $resolved, LOCK_EX);
+			}
+		}
+	}
+
+	/** A translation page lives at "<Page>/<lang>.html"; return that language, or null for other pages. */
+	private function fileLanguage(string $path, string $htmlDir, LanguageNameUtils $languageNameUtils): ?string {
+		// Top-level files are source pages, never a "<Page>/<lang>" translation.
+		if (dirname($path) === $htmlDir) {
+			return null;
+		}
+		$segment = basename($path, '.html');
+		return $languageNameUtils->isKnownLanguageTag($segment) ? $segment : null;
+	}
+}
+
+$maintClass = ResolveTranslationLinks::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/tests/phpunit/unit/RelativeUrlTest.php
+++ b/tests/phpunit/unit/RelativeUrlTest.php
@@ -53,4 +53,60 @@ class RelativeUrlTest extends MediaWikiUnitTestCase {
 		$html = '<script>var x = {"path": "./y"};</script>';
 		$this->assertSame($html, RelativeUrl::reparent($html, 1));
 	}
+
+	public function testMyLanguageResolvesToTheTranslationWhenItExists() {
+		$this->assertSame(
+			'href="./B/ko.html"',
+			RelativeUrl::resolveMyLanguage('href="./Special:MyLanguage/B.html"', 'ko', static function () {
+				return true;
+			})
+		);
+	}
+
+	public function testMyLanguageFallsBackToTheSourceTargetWithoutATranslation() {
+		$this->assertSame(
+			'href="./B.html"',
+			RelativeUrl::resolveMyLanguage('href="./Special:MyLanguage/B.html"', 'ko', static function () {
+				return false;
+			})
+		);
+	}
+
+	public function testMyLanguageOnASourcePageUsesTheSourceTarget() {
+		$this->assertSame(
+			'href="./B.html"',
+			RelativeUrl::resolveMyLanguage('href="./Special:MyLanguage/B.html"', null, static function () {
+				return true;
+			})
+		);
+	}
+
+	public function testMyLanguageKeepsTheLinksExistingRelativePrefix() {
+		$this->assertSame(
+			'href="../B/ko.html"',
+			RelativeUrl::resolveMyLanguage('href="../Special:MyLanguage/B.html"', 'ko', static function () {
+				return true;
+			})
+		);
+	}
+
+	public function testMyLanguagePreservesASectionFragment() {
+		$this->assertSame(
+			'href="../Installation/ko.html#Binary"',
+			RelativeUrl::resolveMyLanguage(
+				'href="../Special:MyLanguage/Installation.html#Binary"',
+				'ko',
+				static function () {
+					return true;
+				}
+			)
+		);
+	}
+
+	public function testResolveMyLanguageLeavesOrdinaryLinksAlone() {
+		$html = 'href="./B.html" href="https://example.org/Special:MyLanguage/Y"';
+		$this->assertSame($html, RelativeUrl::resolveMyLanguage($html, 'ko', static function () {
+			return true;
+		}));
+	}
 }


### PR DESCRIPTION
Closes #224. Found while dogfooding translated pages.

## Problem

Translate's standard language-aware link `[[Special:MyLanguage/Target]]` pointed at `Special:MyLanguage/Target.html`, which 404s — that special page isn't exported. So there was no good way to link across languages (plain `[[Target]]` always goes to the source page).

## Fix

A new pass (after `Rename`, over the final `<Page>/<lang>.html` tree) rewrites each `Special:MyLanguage/Target` link to:
- `Target/<lang>.html` when a translation for the page's language exists, else
- the source `Target.html`,

keeping the link's already-depth-correct relative prefix.

The page's language comes from the **exported path** (`<Page>/<lang>.html`), not the render: translation pages are parsed in the source-page context, so `getTitle()`/`getLanguage()` are the source language at render time (verified while debugging — this is why a render-time `GetLocalURL` approach can't work). The path is the reliable signal.

The rewrite is the pure `RelativeUrl::resolveMyLanguage` (unit-tested for translation / fallback / source-page / prefix-preservation / leave-others-alone).

## Verification (docker e2e, A links to B two ways)

On the Korean page `A/ko.html`: `[[Special:MyLanguage/B]]` → `../B/ko.html` (B has a `ko` translation, resolves), `[[Special:MyLanguage/index]]` → `../index.html` (no translation, source fallback). On the source `A.html`: `[[Special:MyLanguage/B]]` → `./B.html`. All resolve; no 404.

The pass is gated on Translate being loaded (a no-op otherwise).