### PR TITLE
fix: inline static bundle icons as data URIs so subpages don't 404

### DIFF
--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -8,13 +8,21 @@ use MediaWiki\ResourceLoader\ResourceLoader;
 
 /** Rewrites image url()s in dumped CSS/JS to local copies, avoiding load.php references. */
 class AssetLocalizer {
-	/** Rewrite image url()s in the given dumped CSS/JS files to point at copies in $dir. */
+	/**
+	 * Rewrite image url()s in the given dumped CSS/JS files to point at copies in $dir.
+	 *
+	 * A CSS file resolves its url()s relative to itself, so a "./img-*.svg" next to it works from
+	 * any page depth. A JS bundle instead injects its CSS into the document, where url()s resolve
+	 * against the page, breaking on subpages ("index/ko.html" would fetch "index/img-*.svg"). Pass
+	 * $inline for JS bundles to embed the images as data: URIs, which are depth- and base-path-safe.
+	 */
 	public static function localizeImages(
 		ResourceLoader $rl,
 		string $dir,
 		array $files,
 		string $lang,
-		string $skin
+		string $skin,
+		bool $inline = false
 	): void {
 		$mwRoot = rtrim((string)( $GLOBALS['IP'] ?? '' ), '/');
 		$map = [];
@@ -27,7 +35,7 @@ class AssetLocalizer {
 			// (1) ResourceLoader image endpoint.
 			$text = preg_replace_callback(
 				'~url\(\s*[\'"]?([^)\'"]*load\.php\?[^)\'"]*image=[^)\'"]*?)[\'"]?\s*\)~',
-				static function ($m) use (&$map, $rl, $dir, $lang, $skin) {
+				static function ($m) use (&$map, $rl, $dir, $lang, $skin, $inline) {
 					// Decode the JSON-string escapes used inside JS bundles.
 					$url = str_replace(
 						['\\/', '\\u0026', '\\u003d', '\\u003D'],
@@ -35,7 +43,7 @@ class AssetLocalizer {
 						$m[1]
 					);
 					if (!array_key_exists($url, $map)) {
-						$map[$url] = self::dumpRlImage($rl, $url, $dir, $lang, $skin);
+						$map[$url] = self::dumpRlImage($rl, $url, $dir, $lang, $skin, $inline);
 					}
 					return $map[$url] !== null ? 'url(' . $map[$url] . ')' : $m[0];
 				},
@@ -47,10 +55,10 @@ class AssetLocalizer {
 				$text = preg_replace_callback(
 					'~url\(\s*[\'"]?(\\\\?/(?:skins|resources|extensions)/[^)\'"?]+'
 					. '\.(?:svg|png|gif|jpe?g))(?:\?[^)\'"]*)?[\'"]?\s*\)~',
-					static function ($m) use (&$map, $mwRoot, $dir) {
+					static function ($m) use (&$map, $mwRoot, $dir, $inline) {
 						$path = str_replace('\\/', '/', $m[1]);
 						if (!array_key_exists($path, $map)) {
-							$map[$path] = self::copyAsset($mwRoot, $path, $dir);
+							$map[$path] = self::copyAsset($mwRoot, $path, $dir, $inline);
 						}
 						return $map[$path] !== null ? 'url(' . $map[$path] . ')' : $m[0];
 					},
@@ -60,6 +68,11 @@ class AssetLocalizer {
 
 			file_put_contents($file, $text, LOCK_EX);
 		}
+	}
+
+	/** Encode raw image bytes as a data: URI usable unquoted inside url(). */
+	private static function dataUri(string $bytes, string $mime): string {
+		return 'data:' . $mime . ';base64,' . base64_encode($bytes);
 	}
 
 	/**
@@ -72,7 +85,8 @@ class AssetLocalizer {
 		string $url,
 		string $dir,
 		string $lang,
-		string $skin
+		string $skin,
+		bool $inline = false
 	): ?string {
 		$qs = parse_url($url, PHP_URL_QUERY);
 		if (!$qs) {
@@ -104,6 +118,10 @@ class AssetLocalizer {
 			return null;
 		}
 
+		if ($inline) {
+			return self::dataUri($bytes, $isSvg ? 'image/svg+xml' : 'image/png');
+		}
+
 		// Hash without the cache-busting version so filenames are stable across rebuilds.
 		$key = preg_replace('/[&?]version=[^&]*/', '', $url);
 		$name = 'img-' . substr(md5($key), 0, 12) . ( $isSvg ? '.svg' : '.png' );
@@ -116,7 +134,7 @@ class AssetLocalizer {
 	 *
 	 * @return string|null Relative url() target, or null if the file is missing.
 	 */
-	private static function copyAsset(string $mwRoot, string $path, string $dir): ?string {
+	private static function copyAsset(string $mwRoot, string $path, string $dir, bool $inline = false): ?string {
 		$src = $mwRoot . $path;
 		if (!is_readable($src)) {
 			return null;
@@ -126,6 +144,18 @@ class AssetLocalizer {
 			return null;
 		}
 		$ext = pathinfo($path, PATHINFO_EXTENSION) ?: 'svg';
+
+		if ($inline) {
+			$mimes = [
+				'svg' => 'image/svg+xml',
+				'png' => 'image/png',
+				'gif' => 'image/gif',
+				'jpg' => 'image/jpeg',
+				'jpeg' => 'image/jpeg'
+			];
+			return self::dataUri($bytes, $mimes[strtolower($ext)] ?? 'application/octet-stream');
+		}
+
 		$name = 'img-' . substr(md5($path), 0, 12) . ".$ext";
 		file_put_contents("$dir/$name", $bytes, LOCK_EX);
 		return "./$name";

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -67,13 +67,16 @@ class BuildScripts extends Maintenance {
 		$bundle = $this->dump($rl, $closure, $wgLanguageCode, $wgDefaultSkin, null, []);
 		file_put_contents("$outDir/modules-static.js", $bundle, LOCK_EX);
 
-		// Combined bundle embeds icon CSS pointing at load.php images; localize them to local files.
+		// Combined bundle embeds icon CSS pointing at load.php images. The bundle injects its CSS
+		// into the document, so url()s resolve against the page; inline the images as data: URIs
+		// so they load from any page depth (subpages like index/ko.html) and base path.
 		AssetLocalizer::localizeImages(
 			$rl,
 			$outDir,
 			["$outDir/modules-static.js", "$outDir/startup-static.js"],
 			$wgLanguageCode,
-			$wgDefaultSkin
+			$wgDefaultSkin,
+			true
 		);
 
 		$this->output('Wrote startup-static.js and modules-static.js (' . count($closure) . " modules)\n");

--- a/tests/phpunit/integration/AssetLocalizerTest.php
+++ b/tests/phpunit/integration/AssetLocalizerTest.php
@@ -56,4 +56,30 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 		$this->assertCount(1, $copies, 'deduplicated to a single dumped copy');
 		$this->assertSame('<svg>arrow</svg>', file_get_contents($copies[0]), 'asset bytes copied verbatim');
 	}
+
+	/**
+	 * A JS bundle injects its CSS into the document, so a "./img-*.svg" url() would
+	 * resolve against the page and 404 on any subpage. In $inline mode the image
+	 * must instead be embedded as a data: URI (depth- and base-path-safe) with no
+	 * file written out.
+	 */
+	public function testLocalizeImagesInlinesAssetsAsDataUris() {
+		$mwRoot = $this->getNewTempDirectory();
+		mkdir("$mwRoot/skins/Vector/images", 0777, true);
+		file_put_contents("$mwRoot/skins/Vector/images/arrow.svg", '<svg>arrow</svg>');
+		$this->setMwGlobals('IP', $mwRoot);
+
+		$dir = $this->getNewTempDirectory();
+		$js = "$dir/modules-static.js";
+		file_put_contents($js, '.a{background:url(/skins/Vector/images/arrow.svg)}' . "\n");
+
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		AssetLocalizer::localizeImages($rl, $dir, [$js], 'en', 'vector', true);
+
+		$out = file_get_contents($js);
+		$expected = 'url(data:image/svg+xml;base64,' . base64_encode('<svg>arrow</svg>') . ')';
+		$this->assertStringContainsString($expected, $out, 'asset inlined as a data: URI');
+		$this->assertStringNotContainsString('url(./img-', $out, 'no relative file reference emitted');
+		$this->assertCount(0, glob("$dir/img-*.svg"), 'no image file written in inline mode');
+	}
 }


### PR DESCRIPTION
## Problem

Surfaced while dogfooding i18n: every **translated page** (a subpage like `index/ko.html`) was throwing 404s for skin/OOUI icon SVGs.

Root cause: the combined JS bundle `modules-static.js` **injects its icon CSS into the document**, so its `url()`s resolve relative to the *page*, not the bundle. A `./img-*.svg` reference works on a root page but on a subpage `index/ko.html` it resolves to `index/img-*.svg`, which doesn't exist. Separate `.css` files are fine because a stylesheet's `url()` resolves relative to the stylesheet.

Translations make subpages common, so the mask-image icons rendered blank on every translated page.

## Fix

Add an `$inline` mode to `AssetLocalizer::localizeImages`. For the JS bundle, embed images as `data:` URIs instead of `./img-*` file references. Data URIs carry no path, so they load from any page depth and under any base path.

- The 35 bundle images are all small SVGs (~14 KB total) → negligible size cost, and it drops 35 HTTP requests.
- CSS files are unchanged: they keep writing `./img-*` copies (correct there).

## Verification

Built the docs (incl. a Korean translation) and loaded `index/ko.html` headless:

- **Before:** 7 × `HTTP 404 …/index/img-*.svg`
- **After:** `modules-static.js` has 0 `url(./img-` refs, 65 `url(data:image…`; **zero failed requests**, zero `load.php`/`api.php` calls; language switcher works.

Added an integration test asserting inline mode emits a `data:` URI and writes no file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)