### PR TITLE
feat: localize translated-page chrome and route Special:Translate links to the edit host

### DIFF
--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -48,6 +48,25 @@ class Main implements
 		}
 
 		global $wgWikvenEditUrl, $wgWikvenHistoryUrl;
+
+		// Translate's banner and "Translate" tab link to Special:Translate (the in-wiki translation UI),
+		// which is not exported. Point them at the translation's source file on the edit host: the
+		// query carries "group=page-<base>" and "language=<code>", so "<base>/<code>" is the file.
+		if ($wgWikvenEditUrl && $title->isSpecial('Translate')) {
+			$params = wfCgiToArray($query);
+			if (isset($params['language']) && str_starts_with($params['group'] ?? '', 'page-')) {
+				$translation = Title::newFromText(substr($params['group'], 5) . '/' . $params['language']);
+				if ($translation) {
+					$url = str_replace(
+						'$1',
+						SourceFile::titleToParam($translation->getPrefixedText()),
+						$wgWikvenEditUrl
+					);
+					return;
+				}
+			}
+		}
+
 		$name = Title::makeName($title->getNamespace(), $title->getDBkey());
 		// Parse query to name=>value; substring-matching "action=" would also match "veaction=edit".
 		$action = wfCgiToArray($query)['action'] ?? null;
@@ -67,19 +86,6 @@ class Main implements
 	 * @inheritDoc
 	 */
 	public function onSkinTemplateNavigation__Universal($sktemplate, &$links): void {
-		// Special pages are not exported. Translate turns the edit tab into a "Translate" link to
-		// Special:Translate, which would 404 statically; drop any nav link targeting it.
-		foreach ($links as $group => $entries) {
-			if (!is_array($entries)) {
-				continue;
-			}
-			foreach ($entries as $key => $link) {
-				if (is_array($link) && isset($link['href']) && str_contains($link['href'], 'Special:Translate')) {
-					unset($links[$group][$key]);
-				}
-			}
-		}
-
 		global $wgWikvenViewSourceUrl;
 		$title = $sktemplate->getTitle();
 		// A generated page (e.g. Version) has no source file; skip rather than emit a 404 link.

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -67,6 +67,19 @@ class Main implements
 	 * @inheritDoc
 	 */
 	public function onSkinTemplateNavigation__Universal($sktemplate, &$links): void {
+		// Special pages are not exported. Translate turns the edit tab into a "Translate" link to
+		// Special:Translate, which would 404 statically; drop any nav link targeting it.
+		foreach ($links as $group => $entries) {
+			if (!is_array($entries)) {
+				continue;
+			}
+			foreach ($entries as $key => $link) {
+				if (is_array($link) && isset($link['href']) && str_contains($link['href'], 'Special:Translate')) {
+					unset($links[$group][$key]);
+				}
+			}
+		}
+
 		global $wgWikvenViewSourceUrl;
 		$title = $sktemplate->getTitle();
 		// A generated page (e.g. Version) has no source file; skip rather than emit a 404 link.

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -98,6 +98,8 @@ class Build extends Maintenance {
 		}
 
 		$this->step(RebuildFileCache::class, "$ip/maintenance/rebuildFileCache.php", ['overwrite' => true]);
+		// RebuildFileCache renders in the content language; re-render translations in their own.
+		$this->step(RetranslateChrome::class, "$own/retranslateChrome.php");
 		$this->step(BuildStyles::class, "$own/buildStyles.php");
 		$this->step(BuildScripts::class, "$own/buildScripts.php");
 		$this->step(RewriteScripts::class, "$own/rewriteScripts.php");

--- a/maintenance/retranslateChrome.php
+++ b/maintenance/retranslateChrome.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Translate is an optional, image-bundled dependency that phan does not analyse, so its symbols
- * are undeclared to static analysis here. This script only does anything when Translate is loaded.
- *
- * @phan-file-suppress PhanUndeclaredClassMethod
- * @phan-file-suppress PhanUndeclaredClassConstant
- */
 
 namespace MediaWiki\Extension\Wikven;
 

--- a/maintenance/retranslateChrome.php
+++ b/maintenance/retranslateChrome.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Translate is an optional, image-bundled dependency that phan does not analyse, so its symbols
+ * are undeclared to static analysis here. This script only does anything when Translate is loaded.
+ *
+ * @phan-file-suppress PhanUndeclaredClassMethod
+ * @phan-file-suppress PhanUndeclaredClassConstant
+ */
+
+namespace MediaWiki\Extension\Wikven;
+
+use Maintenance;
+use MediaWiki\Cache\HTMLFileCache;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
+use MediaWiki\Page\Article;
+use MediaWiki\Registration\ExtensionRegistry;
+use MediaWiki\Title\Title;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/**
+ * RebuildFileCache renders every page in the wiki's content language, because HTMLFileCache only
+ * caches the canonical anonymous view (interface language == content language). That leaves a
+ * translated page such as "index/ko" with English chrome. Re-render each non-source-language
+ * translation page with its own language as the interface language and overwrite its cache file,
+ * so a reader browsing the Korean page gets a Korean interface too.
+ */
+class RetranslateChrome extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription('Re-render translated pages with their own language as the interface language.');
+	}
+
+	/** @return bool Always true; nothing to do without Translate or a source directory. */
+	public function execute() {
+		if (!ExtensionRegistry::getInstance()->isLoaded('Translate')) {
+			return true;
+		}
+		$source = rtrim((string)( $GLOBALS['wgWikvenSourceDirectory'] ?? '' ), '/');
+		if ($source === '' || !is_dir($source)) {
+			return true;
+		}
+
+		$services = $this->getServiceContainer();
+		$contentLang = $services->getContentLanguage()->getCode();
+		$isKnownLanguage = [$services->getLanguageNameUtils(), 'isKnownLanguageTag'];
+
+		foreach (TranslationSource::baseFiles($source) as $baseFile) {
+			$relative = substr($baseFile, strlen($source) + 1);
+			$baseTitle = SourceFile::filenameToTitle($relative);
+			foreach (TranslationSource::translationLanguages($baseFile, $isKnownLanguage) as $lang) {
+				// The source-language page already renders in the content language.
+				if ($lang === $contentLang) {
+					continue;
+				}
+				$title = Title::newFromText("$baseTitle/$lang");
+				if (!$title || !$title->exists()) {
+					continue;
+				}
+				$this->recache($title, $lang);
+			}
+		}
+
+		return true;
+	}
+
+	/** Render one page with $lang as the interface language and overwrite its view cache file. */
+	private function recache(Title $title, string $lang): void {
+		$context = new RequestContext();
+		$context->setTitle($title);
+		$context->setLanguage($lang);
+		$article = Article::newFromTitle($title, $context);
+		$context->setWikiPage($article->getPage());
+		// Some extensions read the main context's title.
+		RequestContext::getMain()->setTitle($title);
+
+		ob_start();
+		$article->view();
+		$context->getOutput()->output();
+		$context->getOutput()->clearHTML();
+		$html = ob_get_clean();
+
+		( new HTMLFileCache($title, 'view') )->saveToFileCache($html);
+		$this->output("Wikven: re-rendered {$title->getPrefixedText()} in $lang\n");
+	}
+}
+
+$maintClass = RetranslateChrome::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -117,6 +117,10 @@ class RewriteScripts extends Maintenance {
 			// Remove the appearance menu: its widgets pull codex+vue from load.php, which 404s statically.
 			$html = $this->removeElements($html, 'id="vector-appearance"');
 
+			// Translate's page-translation banner ("translated version"/"translate this page") links to
+			// Special:Translate, which is not exported; drop the banner.
+			$html = $this->removeElements($html, 'mw-pt-translate-header');
+
 			file_put_contents($file, $html, LOCK_EX);
 		}
 	}

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -117,10 +117,6 @@ class RewriteScripts extends Maintenance {
 			// Remove the appearance menu: its widgets pull codex+vue from load.php, which 404s statically.
 			$html = $this->removeElements($html, 'id="vector-appearance"');
 
-			// Translate's page-translation banner ("translated version"/"translate this page") links to
-			// Special:Translate, which is not exported; drop the banner.
-			$html = $this->removeElements($html, 'mw-pt-translate-header');
-
 			file_put_contents($file, $html, LOCK_EX);
 		}
 	}


### PR DESCRIPTION
Three fixes to how translated pages present in the static export, surfaced (and refined) while dogfooding the Korean docs translation on `index/ko.html`.

## 1 & 2 — `Special:Translate` banner link + "Translate" tab
The Translate extension adds a **"translated version" banner** and turns the edit tab into a **"Translate"** link, both pointing at `Special:Translate` (the in-wiki translation UI). Special pages aren't exported, so the tab 404d and the banner link rendered as broken literal text `[Special:Translate.html translated version]`.

Fix: resolve `Special:Translate` in `onGetLocalURL` to the translation's **source file on the edit host** (GitHub). Its query carries `group=page-<base>` and `language=<code>`, so the file is `<base>/<code>.wikitext`. The banner and tab are kept — clicking "번역한 것" or the tab now opens the GitHub edit page for `docs/<base>/<code>.wikitext`, matching wikven's edit-on-GitHub model.

## 3 — interface language on translated pages
`RebuildFileCache` renders every page in the wiki content language, because `HTMLFileCache::useFileCache` only caches the canonical anonymous view (interface language **==** content language) — forcing the interface language via a hook makes the page non-cacheable and it silently disappears. Instead, a new `RetranslateChrome` build step (after `RebuildFileCache`) re-renders each non-source-language translation page with its own language as the interface language and overwrites its view cache via `saveToFileCache`. Tabs, sidebar, and the language bar now match the content.

## Verified (real build + headless)
`index/ko.html`: `lang="ko"`, Korean chrome (읽기 / 번역하기 / 역사 보기 / 원본 보기 / 도구 / 다른 언어); banner reads "이 문서는 index 문서를 번역한 것이며 번역은 100% 완료했습니다" with "번역한 것" and the "번역하기" tab both linking to `.../edit/main/docs/index/ko.wikitext`; no `Special:Translate`, no broken `[…]`, zero failed requests, no `load.php`/`api.php`. `index.html` keeps English chrome.

Exercised in CI by `build-and-check`, which builds the merged Korean translation in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)