### PR TITLE
fix: render every translated page after all pages are marked

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -58,6 +58,7 @@ class BuildTranslations extends Maintenance {
 		RequestContext::getMain()->setUser($user);
 		$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
 
+		$prepared = [];
 		foreach (TranslationSource::baseFiles($source) as $baseFile) {
 			$relative = substr($baseFile, strlen($source) + 1);
 			$title = Title::newFromText(SourceFile::filenameToTitle($relative));
@@ -66,14 +67,28 @@ class BuildTranslations extends Maintenance {
 				continue;
 			}
 			$languages = TranslationSource::translationLanguages($baseFile, $isKnownLanguage);
-			$this->materialize($title, (string)file_get_contents($baseFile), $languages, $user);
+			if ($this->prepare($title, (string)file_get_contents($baseFile), $languages, $user)) {
+				$prepared[] = $title;
+			}
+		}
+
+		// Render the translated pages only once every page is marked and its units are loaded. Rendering
+		// inline per page let the page marked just before another (the main page sorts last) render before
+		// the shared message index caught up, silently producing no <Page>/<lang> page for it.
+		$this->drainJobs();
+		foreach ($prepared as $title) {
+			$this->render($title);
 		}
 
 		return true;
 	}
 
-	/** Mark one page for translation, load its translations, and render the translated pages. */
-	private function materialize(Title $title, string $sourceText, array $languages, User $user): void {
+	/**
+	 * Mark one page for translation and load its translations from the source files.
+	 *
+	 * @return bool Whether the page was marked (false if it could not be loaded or had invalid units).
+	 */
+	private function prepare(Title $title, string $sourceText, array $languages, User $user): bool {
 		$services = $this->getServiceContainer();
 
 		// importWikitext saved the base as an old revision, which bypasses the PageSaveComplete hook
@@ -87,12 +102,12 @@ class BuildTranslations extends Maintenance {
 		$record = $services->getPageStore()->getPageByReference($title, IDBAccessObject::READ_LATEST);
 		if (!$record) {
 			$this->output("Wikven: could not load {$title->getPrefixedText()} for translation; skipping\n");
-			return;
+			return false;
 		}
 		$operation = $marker->getMarkOperation($record, null, true);
 		if (!$operation->getUnitValidationStatus()->isOK()) {
 			$this->output("Wikven: {$title->getPrefixedText()} has invalid translation units; skipping\n");
-			return;
+			return false;
 		}
 		// Body units only: the file model has no place to author a title translation, and a
 		// translatable title would leave every page short of 100%. No priority languages,
@@ -105,8 +120,11 @@ class BuildTranslations extends Maintenance {
 		$this->drainJobs();
 
 		$this->loadTranslations($title, $sourceText, $languages, $user);
+		return true;
+	}
 
-		// Render translated pages and refresh stats now that the units are in place.
+	/** Render one marked page's translated pages and refresh its stats. */
+	private function render(Title $title): void {
 		$translatable = TranslatablePage::newFromTitle($title);
 		foreach (UpdateTranslatablePageJob::getRenderJobs($translatable, true) as $job) {
 			$job->run();


### PR DESCRIPTION
## Problem

`buildTranslations` rendered each page's `<Page>/<lang>` translation **inline in the same loop iteration that marked it**. The page marked immediately before another — in the docs tree the main page (`index`) sorts last, so the page just before it — could render before the shared Translate message index reflected its group, so `getRenderJobs()` produced nothing and its translated page was never created. That page then had no `<languages/>` link and no `<Page>/<lang>.html`.

Concretely, with the Korean docs translations, every page materialized except `Why wikitext` (the page sorting immediately before `index`). See #241.

## Fix

Split the loop into two phases:

1. **Prepare** — mark every page for translation and load its translated units.
2. **Render** — after a final `drainJobs()`, render every marked page.

Rendering after all pages are marked means the message index is complete for every group, so no page renders "too early". It is idempotent for the pages that already rendered correctly, and the previously-missed last page now materializes.

## Verification

This branch is off `main`, which carries only `index/ko`, so its own build does not exercise the bug (only `index`, which sorts last, is translated). It is verified by rebasing the translations PR (#237) on top and confirming `Why wikitext/ko.html` is now produced in the preview — done as a follow-up.

Fixes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019hLcb7wmT5nYb5SVUBij2s)_