### PR TITLE
fix: point prevnext navigation at the reader's-language pages

### DIFF
--- a/docs/Template:prevnext.wikitext
+++ b/docs/Template:prevnext.wikitext
@@ -6,7 +6,7 @@ Usage:
 
 --><templatestyles src="prevnext/styles.css" /><div class="wikven-prevnext"><!--
   -->{{#if:{{{2|}}}|
-    <div class="wikven-prevnext-prev">&larr;&nbsp;[[{{{1|}}}]]</div>
+    <div class="wikven-prevnext-prev">&larr;&nbsp;[[Special:MyLanguage/{{{1|}}}|{{{1|}}}]]</div>
   }}<!--
-  --><div class="wikven-prevnext-next">[[{{{2|{{{1|}}}}}}]]&nbsp;&rarr;</div><!--
+  --><div class="wikven-prevnext-next">[[Special:MyLanguage/{{{2|{{{1|}}}}}}|{{{2|{{{1|}}}}}}]]&nbsp;&rarr;</div><!--
 --></div>


### PR DESCRIPTION
## What
Route the footer prev/next navigation template through `Special:MyLanguage/` instead of linking bare page titles:

- `[[{{{1|}}}]]` → `[[Special:MyLanguage/{{{1|}}}|{{{1|}}}]]`
- `[[{{{2|{{{1|}}}}}}]]` → `[[Special:MyLanguage/{{{2|{{{1|}}}}}}|{{{2|{{{1|}}}}}}]]`

The visible label stays the page title; only the link target changes.

## Why
On a translated page (e.g. `index/ko`), the bare `[[Page]]` links pointed at the English source page rather than the reader's-language translation. Every other cross-page doc link already uses the `Special:MyLanguage/` form, which the build resolves per language. The prevnext template was the last gap.

The rendered href becomes `href="./Special:MyLanguage/Target.html"` — the exact shape `RelativeUrl::resolveMyLanguage` (driven by `maintenance/resolveTranslationLinks.php`) rewrites to `Target/<lang>.html` when a translation exists, else `Target.html`, preserving the relative prefix.

## Verification
- ko marker/stamp validator: `ALL OK` both before and after the change — the `{{prevnext|...}}` invocations sit after `</translate>` and the template is not a translation source, so no `<!--T:n @hash-->` stamps are affected.
- The rendered href shape matches the `resolveMyLanguage` regex, identical to the existing internal links. `tests/phpunit/unit/RelativeUrlTest.php` already covers this exact href shape (has-translation → `./Target/ko.html`, no-translation → `./Target.html`, plus prefix and fragment variants), so no new test was needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hLcb7wmT5nYb5SVUBij2s)_