### PR TITLE
docs: replace the Template:wikven template with {{SITENAME}}

### DIFF
--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -3,13 +3,13 @@ __TOC__
 <languages />
 <translate>
 <!--T:1-->
-{{wikven}} writes a self-contained <code>dist/</code> directory of static files, with no server or database behind it. Host it anywhere that serves static files.
+{{SITENAME}} writes a self-contained <code>dist/</code> directory of static files, with no server or database behind it. Host it anywhere that serves static files.
 
 <!--T:2-->
 == GitHub Pages ==
 
 <!--T:3-->
-This workflow rebuilds and publishes the site on every push. It bakes the source with the {{wikven}} [https://github.com/chaotic-ground/wikven/tree/main/action composite action], then uploads <code>dist/</code> to Pages. Actions are pinned to a full commit SHA, not a tag, so a moved tag cannot swap them under you:
+This workflow rebuilds and publishes the site on every push. It bakes the source with the {{SITENAME}} [https://github.com/chaotic-ground/wikven/tree/main/action composite action], then uploads <code>dist/</code> to Pages. Actions are pinned to a full commit SHA, not a tag, so a moved tag cannot swap them under you:
 </translate>
 
 <syntaxhighlight lang="yaml">
@@ -46,7 +46,7 @@ jobs:
 Enable Pages for the repository under '''Settings → Pages → Build and deployment → Source: GitHub Actions'''. This documentation site is published this way.
 
 <!--T:5-->
-{{note|A GitHub '''project''' page is served from a subdirectory (<code>username.github.io/repo/</code>). Page-to-page links keep working because {{wikven}} writes them relative, but anything that needs an absolute path must include that base path: set [[<tvar name="1">Special:MyLanguage/Searching</tvar>|search]]'s <code>SifterSearchBundlePath</code> to <code>/repo/pagefind/</code> (this site uses <code>/wikven/pagefind/</code>). A '''user/organization''' page (served at the domain root) needs no such setting.}}
+{{note|A GitHub '''project''' page is served from a subdirectory (<code>username.github.io/repo/</code>). Page-to-page links keep working because {{SITENAME}} writes them relative, but anything that needs an absolute path must include that base path: set [[<tvar name="1">Special:MyLanguage/Searching</tvar>|search]]'s <code>SifterSearchBundlePath</code> to <code>/repo/pagefind/</code> (this site uses <code>/wikven/pagefind/</code>). A '''user/organization''' page (served at the domain root) needs no such setting.}}
 
 <!--T:6-->
 == Any static host ==
@@ -58,7 +58,7 @@ Because <code>dist/</code> is just files, you can serve it from any static host 
 == Preview locally ==
 
 <!--T:9-->
-Open <code>dist/index.html</code> directly, or serve the directory so links and assets resolve exactly as they will in production. {{wikven}} has a built-in <code>serve</code> command for this.
+Open <code>dist/index.html</code> directly, or serve the directory so links and assets resolve exactly as they will in production. {{SITENAME}} has a built-in <code>serve</code> command for this.
 
 <!--T:10-->
 With the [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|standalone binary]], it serves <code>dist/</code> on <code>http://localhost:8080</code> (override with <code>--listen</code>):

--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -3,18 +3,18 @@ __TOC__
 <languages />
 <translate>
 <!--T:1-->
-This page explains how {{wikven}} is built, for people who want to work on it. {{wikven}} is a {{ml|MediaWiki}} extension plus a handful of maintenance scripts that turn a directory of wikitext into a static website; it does not add a new rendering engine, it drives MediaWiki itself and then captures the result.
+This page explains how {{SITENAME}} is built, for people who want to work on it. {{SITENAME}} is a {{ml|MediaWiki}} extension plus a handful of maintenance scripts that turn a directory of wikitext into a static website; it does not add a new rendering engine, it drives MediaWiki itself and then captures the result.
 
 <!--T:2-->
 == Architecture ==
 
 <!--T:3-->
-A {{wikven}} build has four moving parts:
+A {{SITENAME}} build has four moving parts:
 
 <!--T:4-->
-* The '''extension''' (<code>extension.json</code>, <code>includes/</code>). It registers {{wikven}}'s configuration and a few hooks that adapt MediaWiki's output for a static host: hiding the edit/history UI and the sidebar's wiki-only links, swapping footer links for the configured <code>WikvenFooterUrl</code>/<code>WikvenEditUrl</code>/<code>WikvenHistoryUrl</code>, and rewriting internal URLs so they point at <code>.html</code> files instead of <code>index.php?title=</code>.
+* The '''extension''' (<code>extension.json</code>, <code>includes/</code>). It registers {{SITENAME}}'s configuration and a few hooks that adapt MediaWiki's output for a static host: hiding the edit/history UI and the sidebar's wiki-only links, swapping footer links for the configured <code>WikvenFooterUrl</code>/<code>WikvenEditUrl</code>/<code>WikvenHistoryUrl</code>, and rewriting internal URLs so they point at <code>.html</code> files instead of <code>index.php?title=</code>.
 * The '''maintenance scripts''' (<code>maintenance/</code>). These are the build pipeline, described below.
-* '''<code>WikvenSettings.php</code>'''. The <code>LocalSettings.php</code> the build runs under: it loads the configuration, detects the image backend, and applies {{wikven}}'s defaults.
+* '''<code>WikvenSettings.php</code>'''. The <code>LocalSettings.php</code> the build runs under: it loads the configuration, detects the image backend, and applies {{SITENAME}}'s defaults.
 * The '''<code>bin/entrypoint</code>''' script and '''<code>Dockerfile</code>'''. They package MediaWiki 1.46 plus the extension into an image whose default command runs one build.
 
 <!--T:5-->
@@ -70,7 +70,7 @@ The <code>run</code> script:
 ; <code>RunJobs</code>
 : Runs MediaWiki's job queue, mainly thumbnail generation and link-table updates.
 ; <code>RebuildFileCache</code>
-: Renders every content page to an HTML file under <code>dist/</code>. This is MediaWiki's own file cache; {{wikven}} treats <code>File:</code> as a content namespace too, so file description pages are exported without dumping every template.
+: Renders every content page to an HTML file under <code>dist/</code>. This is MediaWiki's own file cache; {{SITENAME}} treats <code>File:</code> as a content namespace too, so file description pages are exported without dumping every template.
 ; <code>buildStyles</code>
 : Re-renders each CSS module the pages reference into a local file, and renders the <code>site.styles</code> module (<code>MediaWiki:Common.css</code> and the skin's site CSS) to its own file.
 ; <code>buildScripts</code>
@@ -86,7 +86,7 @@ The <code>run</code> script:
 == Configuration ==
 
 <!--T:15-->
-Configuration is layered. <code>default.yml</code> ships {{wikven}}'s baseline MediaWiki settings; the site's [[<tvar name="1">Special:MyLanguage/Configuration</tvar>|.wikven.yaml]] is merged on top. <code>WikvenSettings.php</code> reads both with MediaWiki's own YAML settings parser, applies the merged <code>config</code> map, loads the listed <code>extensions</code> and <code>skins</code>, and points <code>$wgLogos</code> at the uploaded <code>WikvenLogos</code> files. It also detects the thumbnailing backend at run time, ImageMagick and rsvg when available, otherwise the built-in GD library plus native inline SVG, so the same build works in the image and in a binary that has only GD.
+Configuration is layered. <code>default.yml</code> ships {{SITENAME}}'s baseline MediaWiki settings; the site's [[<tvar name="1">Special:MyLanguage/Configuration</tvar>|.wikven.yaml]] is merged on top. <code>WikvenSettings.php</code> reads both with MediaWiki's own YAML settings parser, applies the merged <code>config</code> map, loads the listed <code>extensions</code> and <code>skins</code>, and points <code>$wgLogos</code> at the uploaded <code>WikvenLogos</code> files. It also detects the thumbnailing backend at run time, ImageMagick and rsvg when available, otherwise the built-in GD library plus native inline SVG, so the same build works in the image and in a binary that has only GD.
 
 <!--T:16-->
 == Why these steps exist ==
@@ -98,13 +98,13 @@ A live wiki relies on <code>load.php</code>, an action API, and a database; a st
 == Third-party extensions and skins ==
 
 <!--T:19-->
-Names in <code>extensions</code>/<code>skins</code> that are not bundled with {{wikven}} are fetched at build time by <code>maintenance/fetchExtensions.php</code>, from a source declared in [[<tvar name="1">Special:MyLanguage/Configuration#WikvenRepositories</tvar>|<code>WikvenRepositories</code>]] (a tarball, a Git repository, or a Composer package). This runs after install but before <code>WikvenSettings.php</code> is wired in, so the components are on disk by the time MediaWiki loads them.
+Names in <code>extensions</code>/<code>skins</code> that are not bundled with {{SITENAME}} are fetched at build time by <code>maintenance/fetchExtensions.php</code>, from a source declared in [[<tvar name="1">Special:MyLanguage/Configuration#WikvenRepositories</tvar>|<code>WikvenRepositories</code>]] (a tarball, a Git repository, or a Composer package). This runs after install but before <code>WikvenSettings.php</code> is wired in, so the components are on disk by the time MediaWiki loads them.
 
 <!--T:20-->
 == Standalone binary ==
 
 <!--T:21-->
-The same MediaWiki + {{wikven}} tree is embedded into a single [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|FrankenPHP executable]] (see <code>binary.Dockerfile</code>), so a site can be built with no Docker. The binary extracts its app to a writable temporary directory at startup and runs the same pipeline, which is why all writable paths are kept under <code>WIKVEN_WORKDIR</code>.
+The same MediaWiki + {{SITENAME}} tree is embedded into a single [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|FrankenPHP executable]] (see <code>binary.Dockerfile</code>), so a site can be built with no Docker. The binary extracts its app to a writable temporary directory at startup and runs the same pipeline, which is why all writable paths are kept under <code>WIKVEN_WORKDIR</code>.
 
 <!--T:22-->
 == Continuous integration ==
@@ -112,7 +112,7 @@ The same MediaWiki + {{wikven}} tree is embedded into a single [[<tvar name="1">
 <!--T:23-->
 * <code>lint.yml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, yamllint, zizmor, and phpcs).
 * <code>docker-build.yml</code> builds the image and publishes it to <code>ghcr.io/chaotic-ground/wikven</code> on <code>main</code>.
-* <code>deploy-docs.yml</code> builds the <code>docs/</code> directory with the image and deploys the result to GitHub Pages, so this site is itself a {{wikven}} build.
+* <code>deploy-docs.yml</code> builds the <code>docs/</code> directory with the image and deploys the result to GitHub Pages, so this site is itself a {{SITENAME}} build.
 * <code>build-binary.yml</code> is a reusable workflow that builds the standalone [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|binary]] for each platform. <code>release-please.yml</code> calls it to attach the binaries to a version release, and <code>nightly.yml</code> calls it daily to publish a dated <code>nightly-YYYY-MM-DD</code> pre-release. Both create the release as a draft, attach the binaries, then publish it, because GitHub's immutable releases lock a release's assets once it is published.
 
 <!--T:24-->

--- a/docs/Editing sidebar.wikitext
+++ b/docs/Editing sidebar.wikitext
@@ -22,7 +22,7 @@ Each top-level <code>*</code> line is a heading, and each <code>**</code> line b
 == What is removed ==
 
 <!--T:4-->
-Some default sidebar blocks need a live wiki, so {{wikven}} drops them from the static export: the '''toolbox''' (What links here, Special pages, Printable version, and so on) and the '''search''' box. The navigation blocks you define in <code>MediaWiki:Sidebar</code> are kept as written.
+Some default sidebar blocks need a live wiki, so {{SITENAME}} drops them from the static export: the '''toolbox''' (What links here, Special pages, Printable version, and so on) and the '''search''' box. The navigation blocks you define in <code>MediaWiki:Sidebar</code> are kept as written.
 
 <!--T:5-->
 == See also ==

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -1,11 +1,11 @@
 <languages />
 <translate>
 <!--T:1-->
-On this page, we build a basic [[mw:en:"Hello, World!" program|Hello World]] page with {{wikven}}.
+On this page, we build a basic [[mw:en:"Hello, World!" program|Hello World]] page with {{SITENAME}}.
 {{note|This page assumes a unix-like shell. The standalone binary is Linux-only; on macOS or Windows, use the Docker image.}}
 
 <!--T:2-->
-{{wikven}} builds a static website from a directory of wikitext. There are three ways to install it: the standalone [[<tvar name="1">Special:MyLanguage/Installation#Binary</tvar>|binary]], the [[<tvar name="2">Special:MyLanguage/Installation#Docker</tvar>|Docker image]], or [[<tvar name="3">Special:MyLanguage/Installation#Build from source</tvar>|built from source]]. This guide uses the binary or Docker, pick whichever you have.
+{{SITENAME}} builds a static website from a directory of wikitext. There are three ways to install it: the standalone [[<tvar name="1">Special:MyLanguage/Installation#Binary</tvar>|binary]], the [[<tvar name="2">Special:MyLanguage/Installation#Docker</tvar>|Docker image]], or [[<tvar name="3">Special:MyLanguage/Installation#Build from source</tvar>|built from source]]. This guide uses the binary or Docker, pick whichever you have.
 
 <!--T:3-->
 ; Requirement
@@ -26,7 +26,7 @@ echo 'Hello, World!' > src/index.wikitext
 
 <translate>
 <!--T:5-->
-Then build the site. The rendered pages are written to <code>dist/</code>. Pick the tab for how you run {{wikven}}:
+Then build the site. The rendered pages are written to <code>dist/</code>. Pick the tab for how you run {{SITENAME}}:
 </translate>
 
 <tabber>
@@ -115,7 +115,7 @@ Build again: the home page now links to <code>Help.html</code>, and the link wor
 == Adding a template ==
 
 <!--T:18-->
-Templates, the main reason to reach for {{wikven}} over Markdown, let you reuse content. Put a <code>Template:</code> page in your source and transclude it with <code><nowiki>{{...}}</nowiki></code>:
+Templates, the main reason to reach for {{SITENAME}} over Markdown, let you reuse content. Put a <code>Template:</code> page in your source and transclude it with <code><nowiki>{{...}}</nowiki></code>:
 </translate>
 
 <syntaxhighlight lang="shell">

--- a/docs/Installation.wikitext
+++ b/docs/Installation.wikitext
@@ -3,7 +3,7 @@ __TOC__
 <languages />
 <translate>
 <!--T:1-->
-{{wikven}} runs in three ways. On Linux the standalone binary is the simplest, a single file with no Docker. On macOS or Windows, use the Docker image. Build from source if you want to modify {{wikven}} or run an unreleased version.
+{{SITENAME}} runs in three ways. On Linux the standalone binary is the simplest, a single file with no Docker. On macOS or Windows, use the Docker image. Build from source if you want to modify {{SITENAME}} or run an unreleased version.
 
 <!--T:2-->
 == Binary ==
@@ -40,7 +40,7 @@ The untagged image tracks the latest build; append a release tag such as <code>:
 == Build from source ==
 
 <!--T:9-->
-To modify {{wikven}} or run an unreleased commit, clone the repository and build the image yourself:
+To modify {{SITENAME}} or run an unreleased commit, clone the repository and build the image yourself:
 </translate>
 
 <syntaxhighlight lang="shell">
@@ -58,7 +58,7 @@ This produces a local <code>wikven</code> image you run exactly like the publish
 
 <translate>
 <!--T:11-->
-Once you have {{wikven}}, head to [[<tvar name="1">Special:MyLanguage/Getting Started</tvar>|Getting Started]] to build your first site.
+Once you have {{SITENAME}}, head to [[<tvar name="1">Special:MyLanguage/Getting Started</tvar>|Getting Started]] to build your first site.
 </translate>
 
 {{prevnext|Why wikitext|Getting Started}}

--- a/docs/JavaScript.wikitext
+++ b/docs/JavaScript.wikitext
@@ -1,7 +1,7 @@
 <languages />
 <translate>
 <!--T:1-->
-{{wikven}} bundles the wiki's own JavaScript into the static export at build time, so site scripts and gadgets run without a live server or <code>load.php</code>.
+{{SITENAME}} bundles the wiki's own JavaScript into the static export at build time, so site scripts and gadgets run without a live server or <code>load.php</code>.
 
 <!--T:2-->
 == MediaWiki:Common.js ==

--- a/docs/Licenses.wikitext
+++ b/docs/Licenses.wikitext
@@ -3,7 +3,7 @@ __TOC__
 <languages />
 <translate>
 <!--T:1-->
-{{wikven}} itself is licensed [https://github.com/chaotic-ground/wikven/blob/main/LICENSE GPL-3.0-or-later]. The Docker image and the standalone binary it produces redistribute third-party software under that software's own licenses, acknowledged here. (GPL-2.0-or-later and GPL-3.0-or-later are compatible, so this is attribution, not a conflict.)
+{{SITENAME}} itself is licensed [https://github.com/chaotic-ground/wikven/blob/main/LICENSE GPL-3.0-or-later]. The Docker image and the standalone binary it produces redistribute third-party software under that software's own licenses, acknowledged here. (GPL-2.0-or-later and GPL-3.0-or-later are compatible, so this is attribution, not a conflict.)
 
 <!--T:2-->
 {| class="wikitable"

--- a/docs/Pages.wikitext
+++ b/docs/Pages.wikitext
@@ -3,7 +3,7 @@ __TOC__
 <languages />
 <translate>
 <!--T:1-->
-Each file in your source directory becomes a page. {{wikven}} derives the page's title, and namespace, from the file's path, so the file name is how you choose them.
+Each file in your source directory becomes a page. {{SITENAME}} derives the page's title, and namespace, from the file's path, so the file name is how you choose them.
 
 <!--T:2-->
 == From file name to page ==
@@ -21,7 +21,7 @@ If a file name does not map cleanly to a title (MediaWiki would normalise it dif
 == Linking between pages ==
 
 <!--T:7-->
-Link with <code><nowiki>[[Title]]</nowiki></code>, or <code><nowiki>[[Title|label]]</nowiki></code>, the standard {{ml|Help:Links|wikitext link}}. {{wikven}} rewrites these to the matching <code>.html</code> paths in the static output, so internal links work with no server.
+Link with <code><nowiki>[[Title]]</nowiki></code>, or <code><nowiki>[[Title|label]]</nowiki></code>, the standard {{ml|Help:Links|wikitext link}}. {{SITENAME}} rewrites these to the matching <code>.html</code> paths in the static output, so internal links work with no server.
 
 <!--T:8-->
 == Subpages ==
@@ -47,7 +47,7 @@ Prefix the file name with a namespace to place the page there:
 Add <code><nowiki>[[Category:Name]]</nowiki></code> to a page to {{ml|Help:Categories|categorise}} it; the categories show in the page footer, as on any wiki.
 
 <!--T:15-->
-A category's own page is not exported by default, though. {{wikven}} writes only ''content'' pages to the static site, and counts just the main and File: namespaces as content. (Namespaces have numeric IDs: main is <code>0</code>, File: is <code>6</code>, and Category is <code>14</code>.) So a footer category links to a <code>Category:Name.html</code> the static host does not serve, a dead link, until you export the category page. To do that, set <code>ContentNamespaces</code> in your [[<tvar name="1">Special:MyLanguage/Configuration#ContentNamespaces</tvar>|<code>.wikven.yaml</code>]] and add a <code>Category:Name.wikitext</code> file to your source:
+A category's own page is not exported by default, though. {{SITENAME}} writes only ''content'' pages to the static site, and counts just the main and File: namespaces as content. (Namespaces have numeric IDs: main is <code>0</code>, File: is <code>6</code>, and Category is <code>14</code>.) So a footer category links to a <code>Category:Name.html</code> the static host does not serve, a dead link, until you export the category page. To do that, set <code>ContentNamespaces</code> in your [[<tvar name="1">Special:MyLanguage/Configuration#ContentNamespaces</tvar>|<code>.wikven.yaml</code>]] and add a <code>Category:Name.wikitext</code> file to your source:
 </translate>
 
 <syntaxhighlight lang="yaml">
@@ -84,7 +84,7 @@ saved as <code>Template:Note.wikitext</code> and used on a page as:
 
 <translate>
 <!--T:21-->
-renders as "'''Note:''' Back up your wiki first." Templates take positional (<code><nowiki>{{{1}}}</nowiki></code>) and named parameters and run {{ml|Help:Parser functions|parser functions}} exactly as in MediaWiki; this site's own pages transclude a <code>Template:wikven</code> that renders "{{wikven}}". The syntax itself is standard MediaWiki; see {{ml|Help:Templates}}.
+renders as "'''Note:''' Back up your wiki first." Templates take positional (<code><nowiki>{{{1}}}</nowiki></code>) and named parameters and run {{ml|Help:Parser functions|parser functions}} exactly as in MediaWiki. The syntax itself is standard MediaWiki; see {{ml|Help:Templates}}.
 </translate>
 
 {{prevnext|Getting Started|Editing sidebar}}

--- a/docs/Searching.wikitext
+++ b/docs/Searching.wikitext
@@ -1,7 +1,7 @@
 <languages />
 <translate>
 <!--T:1-->
-Static sites have no server to answer queries, so MediaWiki's built-in search does not work in the export. {{wikven}} ships [https://github.com/chaotic-ground/SifterSearch SifterSearch] built in and enabled by default: it builds a static search index at build time and serves results entirely in the browser, so every site has working search with no setup. This documentation site uses it.
+Static sites have no server to answer queries, so MediaWiki's built-in search does not work in the export. {{SITENAME}} ships [https://github.com/chaotic-ground/SifterSearch SifterSearch] built in and enabled by default: it builds a static search index at build time and serves results entirely in the browser, so every site has working search with no setup. This documentation site uses it.
 
 <!--T:2-->
 == How it works ==

--- a/docs/Standalone binary.wikitext
+++ b/docs/Standalone binary.wikitext
@@ -3,10 +3,10 @@ __TOC__
 <languages />
 <translate>
 <!--T:1-->
-Besides the [[<tvar name="1">Special:MyLanguage/Installation#Docker</tvar>|Docker image]], {{wikven}} ships as a single self-contained executable that embeds MediaWiki, so you can build a site without Docker. It is available for Linux on x86_64 and arm64.
+Besides the [[<tvar name="1">Special:MyLanguage/Installation#Docker</tvar>|Docker image]], {{SITENAME}} ships as a single self-contained executable that embeds MediaWiki, so you can build a site without Docker. It is available for Linux on x86_64 and arm64.
 
 <!--T:2-->
-On macOS and Windows, use the [[<tvar name="1">Special:MyLanguage/Installation#Docker</tvar>|Docker image]] instead. {{wikven}} provides no prebuilt macOS binary, for cost reasons: for a downloaded binary to run without Gatekeeper blocking it, Apple requires it to be signed and notarized through a paid Apple Developer Program account (US$99/year), and that cost is not justified for the project yet. The only alternative, telling users to clear the quarantine by hand, trains them to bypass a security check, so it is not offered. A macOS user who wants a binary regardless can compile one from source with [https://frankenphp.dev/docs/static/ FrankenPHP's static build]; a locally built binary is not quarantined.
+On macOS and Windows, use the [[<tvar name="1">Special:MyLanguage/Installation#Docker</tvar>|Docker image]] instead. {{SITENAME}} provides no prebuilt macOS binary, for cost reasons: for a downloaded binary to run without Gatekeeper blocking it, Apple requires it to be signed and notarized through a paid Apple Developer Program account (US$99/year), and that cost is not justified for the project yet. The only alternative, telling users to clear the quarantine by hand, trains them to bypass a security check, so it is not offered. A macOS user who wants a binary regardless can compile one from source with [https://frankenphp.dev/docs/static/ FrankenPHP's static build]; a locally built binary is not quarantined.
 
 <!--T:3-->
 There is no prebuilt Windows binary either: the toolchain that produces a single self-contained executable does not support Windows yet (see [https://github.com/chaotic-ground/wikven/issues/192 issue #192]).
@@ -108,7 +108,7 @@ WIKVEN_WORKDIR=/path/to/project wikven build
 
 <translate>
 <!--T:18-->
-The output is the same as the Docker image's: the binary embeds MediaWiki, the bundled extensions and skins, and every interface language, and it reads the same [[<tvar name="1">Special:MyLanguage/Configuration</tvar>|.wikven.yaml]] layered over {{wikven}}'s defaults.
+The output is the same as the Docker image's: the binary embeds MediaWiki, the bundled extensions and skins, and every interface language, and it reads the same [[<tvar name="1">Special:MyLanguage/Configuration</tvar>|.wikven.yaml]] layered over {{SITENAME}}'s defaults.
 
 <!--T:19-->
 == Optional host tools ==

--- a/docs/Template:wikven.wikitext
+++ b/docs/Template:wikven.wikitext
@@ -1,1 +1,0 @@
-<onlyinclude>'''Wikven'''</onlyinclude>

--- a/docs/Translating.wikitext
+++ b/docs/Translating.wikitext
@@ -1,10 +1,10 @@
 __TOC__
 
-{{wikven}} can build a site in more than one language using MediaWiki's {{ml|Help:Extension:Translate|Translate extension}}. Translate normally expects translators to work in an in-wiki editor, which a static build has no room for, so {{wikven}} drives it from your source tree instead: you translate by adding files and committing them, the same way you write any other page.
+{{SITENAME}} can build a site in more than one language using MediaWiki's {{ml|Help:Extension:Translate|Translate extension}}. Translate normally expects translators to work in an in-wiki editor, which a static build has no room for, so {{SITENAME}} drives it from your source tree instead: you translate by adding files and committing them, the same way you write any other page.
 
 == Enabling translation ==
 
-Add <code>Translate</code> to <code>extensions</code> in your [[Configuration|<code>.wikven.yaml</code>]], along with <code>UniversalLanguageSelector</code>, which Translate depends on. Both are bundled in the {{wikven}} image, so there is nothing to install.
+Add <code>Translate</code> to <code>extensions</code> in your [[Configuration|<code>.wikven.yaml</code>]], along with <code>UniversalLanguageSelector</code>, which Translate depends on. Both are bundled in the {{SITENAME}} image, so there is nothing to install.
 
 <syntaxhighlight lang="yaml">
 extensions:
@@ -12,7 +12,7 @@ extensions:
   - Translate
 </syntaxhighlight>
 
-A static export cannot serve UniversalLanguageSelector's runtime webfonts (they load from a live endpoint), so {{wikven}} turns them off; readers see each script in their own system fonts.
+A static export cannot serve UniversalLanguageSelector's runtime webfonts (they load from a live endpoint), so {{SITENAME}} turns them off; readers see each script in their own system fonts.
 
 You do not list the languages you translate into: as with Translate itself, a language exists as soon as a translation for it does. The language you write your pages in stays the source language.
 
@@ -24,7 +24,7 @@ Wrap the parts of a page that should be translated in <code><nowiki><translate><
 <languages/>
 <translate>
 <!--T:1-->
-{{wikven}} builds static sites from MediaWiki.
+{{SITENAME}} builds static sites from MediaWiki.
 
 <!--T:2-->
 It runs a real MediaWiki at build time.
@@ -73,7 +73,7 @@ Pass a single file instead of <code>--all</code> to stamp just that translation.
 
 == Keeping translations up to date ==
 
-When you change a source unit, its translations no longer match their stamp and are '''out of date'''. {{wikven}} does not hide this:
+When you change a source unit, its translations no longer match their stamp and are '''out of date'''. {{SITENAME}} does not hide this:
 
 * In the built site, an out-of-date unit is marked as an outdated translation, exactly as it would be on a wiki running Translate.
 * <code>translate check</code> reports every out-of-date or missing translation, and with <code>--gate</code> exits non-zero so continuous integration can fail the build:

--- a/docs/Troubleshooting.wikitext
+++ b/docs/Troubleshooting.wikitext
@@ -15,7 +15,7 @@ The [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|standalone bina
 == The search box does nothing ==
 
 <!--T:5-->
-Search is client-side, built into {{wikven}} via SifterSearch and on by default. If the box does not respond, search was turned off (an empty <code>SifterSearchOutputDir</code>), or its bundle path does not match where the site is served (set <code>SifterSearchBundlePath</code> for a subdirectory deploy). See [[<tvar name="1">Special:MyLanguage/Searching</tvar>|Searching]].
+Search is client-side, built into {{SITENAME}} via SifterSearch and on by default. If the box does not respond, search was turned off (an empty <code>SifterSearchOutputDir</code>), or its bundle path does not match where the site is served (set <code>SifterSearchBundlePath</code> for a subdirectory deploy). See [[<tvar name="1">Special:MyLanguage/Searching</tvar>|Searching]].
 
 <!--T:6-->
 == A page is missing from the site ==

--- a/docs/Why wikitext.wikitext
+++ b/docs/Why wikitext.wikitext
@@ -3,7 +3,7 @@ __TOC__
 <languages />
 <translate>
 <!--T:1-->
-{{wikven}} authors content in {{ml|Wikitext}}, MediaWiki's markup, rather than Markdown. If you are coming from a Markdown-based site generator, here is what changes, and why you might want it.
+{{SITENAME}} authors content in {{ml|Wikitext}}, MediaWiki's markup, rather than Markdown. If you are coming from a Markdown-based site generator, here is what changes, and why you might want it.
 
 <!--T:2-->
 == What wikitext adds ==
@@ -24,10 +24,10 @@ __TOC__
 * '''Lightweight rendering''' — Markdown renders with a small library, whereas wikitext normally needs MediaWiki itself.
 
 <!--T:6-->
-== Where {{wikven}} fits ==
+== Where {{SITENAME}} fits ==
 
 <!--T:7-->
-That last cost, running MediaWiki, is the one {{wikven}} removes: it renders your wikitext through MediaWiki once, at build time, and ships plain static HTML. You get templates, parser functions and the rest with nothing to run in production. Reach for {{wikven}} when that trade is worth it, typically when your content is already wikitext, or when templates and transclusion would save real work.
+That last cost, running MediaWiki, is the one {{SITENAME}} removes: it renders your wikitext through MediaWiki once, at build time, and ships plain static HTML. You get templates, parser functions and the rest with nothing to run in production. Reach for {{SITENAME}} when that trade is worth it, typically when your content is already wikitext, or when templates and transclusion would save real work.
 </translate>
 
 {{prevnext|Installation}}

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -1,13 +1,13 @@
 <languages />
 <translate>
 <!--T:1-->
-{{wikven}} is a static site generator built on [https://www.mediawiki.org/ MediaWiki], the software
+{{SITENAME}} is a static site generator built on [https://www.mediawiki.org/ MediaWiki], the software
 behind [https://www.wikipedia.org/ Wikipedia]. It turns a directory of wikitext
 into a plain HTML site you can host anywhere, with no server or database to run.
-This documentation site is itself built with {{wikven}}.
+This documentation site is itself built with {{SITENAME}}.
 
 <!--T:2-->
-Reach for {{wikven}} when your content is already MediaWiki wikitext, or when you
+Reach for {{SITENAME}} when your content is already MediaWiki wikitext, or when you
 want MediaWiki's templates, parser functions, gadgets and extensions but a static
 result with nothing to run: a project's documentation site, an archived wiki
 you can browse as plain HTML, or a personal wiki. Unlike a general static-site generator
@@ -15,7 +15,7 @@ such as Hugo or MkDocs, it renders real wikitext through MediaWiki itself, so it
 assumes you are comfortable with wikitext (see [[<tvar name="1">Special:MyLanguage/Why wikitext</tvar>|Why wikitext]] for the trade-offs).
 
 <!--T:3-->
-See [[<tvar name="1">Special:MyLanguage/Installation</tvar>|Installation]] for the three ways to install {{wikven}}, the standalone
+See [[<tvar name="1">Special:MyLanguage/Installation</tvar>|Installation]] for the three ways to install {{SITENAME}}, the standalone
 [[<tvar name="2">Special:MyLanguage/Installation#Binary</tvar>|binary]], the [[<tvar name="3">Special:MyLanguage/Installation#Docker</tvar>|Docker image]], or
 [[<tvar name="4">Special:MyLanguage/Installation#Build from source</tvar>|from source]], then [[<tvar name="5">Special:MyLanguage/Getting Started</tvar>|Getting Started]] to build
 your first site.
@@ -24,7 +24,7 @@ your first site.
 == Supported features ==
 
 <!--T:5-->
-With {{wikven}}, you can use the following features of MediaWiki.
+With {{SITENAME}}, you can use the following features of MediaWiki.
 
 <!--T:6-->
 * {{ml|Wikitext}} pages (see [[<tvar name="1">Special:MyLanguage/Pages</tvar>|Pages]])


### PR DESCRIPTION
## What
Remove the `Template:wikven` template. Every `{{wikven}}` transclusion **in the English sources** is replaced with MediaWiki's `{{SITENAME}}` magic word, and `docs/Template:wikven.wikitext` is deleted.

`default.yml` sets `Sitename: Wikven` and `docs/.wikven.yml` does not override it, so `{{SITENAME}}` renders "Wikven". This intentionally drops the bold the template used to add; the text is no longer wrapped in `'''`.

The `Pages` "Adding a template" section previously used this site's own `Template:wikven` as a live transclusion example; that English sentence is reworded to stop referencing the now-removed template.

## Why
The template did nothing but render bold "Wikven". It added indirection with no benefit, so the usage is folded into the built-in `{{SITENAME}}` and the template is removed (#242).

## Translations
Translation files are **untouched** — zero changes. No `docs/<Page>/ko.wikitext` appears in this diff; all 13 are byte-identical to `main`.

Two consequences, both intended:

- The Korean units that reference the template are now **stale**, which is the point: the Korean pages surface a translation-completion percentage. Nothing gates on this — no workflow runs `checkTranslations.php --gate`.
- The Korean files still contain literal `{{wikven}}` transclusions, so **the Korean pages will render a red link to the non-existent `Template:wikven`** until the translations are updated. This is a known, accepted trade-off of keeping translations out of English-only changes, not an oversight.

## Verification
- `git diff origin/main --name-only`: **no `docs/*/ko.wikitext` entries**.
- `git grep '{{wikven}}' -- docs`: matches **only** ko files; **zero** in any English source.
- `docs/Template:wikven.wikitext`: **deleted**.
- No CI check treats the missing-template red link as an error: the smoke test asserts only that `dist/index.html` exists and that dumped CSS has no `load.php`, and the Playwright e2e specs cover the search widget and backend-request absence on English pages. Nothing crawls links or validates transclusion targets.

Closes #242

---
_Generated by [Claude Code](https://claude.ai/code/session_019hLcb7wmT5nYb5SVUBij2s)_