### PR TITLE
docs: make doc code-example comments translatable

### DIFF
--- a/docs/Configuration.wikitext
+++ b/docs/Configuration.wikitext
@@ -92,25 +92,28 @@ Sources for the third-party extensions and skins you list in <code>extensions</c
 Each entry chooses one of three methods by the key it carries:
 </translate>
 
+<translate nowrap>
+<!--T:34-->
 <syntaxhighlight lang="yaml">
-config:
-  WikvenRepositories:
+<tvar name="1">config:
+  WikvenRepositories:</tvar>
     # 1. A tarball, e.g. from Special:ExtensionDistributor, whose archive already
     #    bundles the extension's dependencies. Add sha256 to verify the download.
-    Foo:
+    <tvar name="2">Foo:
       tarball: https://extdist.wmflabs.org/dist/extensions/Foo-REL1_46-abc1234.tar.gz
-      sha256: 4f5e...  # 64 hex characters; the build aborts on a mismatch
+      sha256: 4f5e...</tvar>  # 64 hex characters; the build aborts on a mismatch
     # 2. A Git repository. Pin it with commit (an exact SHA, reproducible) or
     #    reference (a tag or branch). Add composer: true to run Composer inside
     #    the cloned directory.
-    Bar:
+    <tvar name="3">Bar:
       repository: https://github.com/example/Bar.git
       commit: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
-      composer: true
+      composer: true</tvar>
     # 3. A Composer package, resolved through MediaWiki's composer.local.json.
-    SemanticMediaWiki:
-      package: mediawiki/semantic-media-wiki:~4.1
+    <tvar name="4">SemanticMediaWiki:
+      package: mediawiki/semantic-media-wiki:~4.1</tvar>
 </syntaxhighlight>
+</translate>
 
 <translate>
 <!--T:23-->


### PR DESCRIPTION
## What
Explanatory comments inside doc code examples were frozen in English. Each `<syntaxhighlight>` block sits outside `<translate>`, so the Translate extension copies it verbatim into every language — the `# …` comments never got translated. This makes the comments in the `WikvenRepositories` YAML example on **Configuration** translatable, while the code stays byte-for-byte identical, using Translate's own unit + hash tracking.

## Mechanism
Put the `<syntaxhighlight>` block inside a `<translate nowrap>` unit, wrap each run of verbatim code in `<tvar>`, and leave the `#` comment lines as bare translatable text. On render, `$N` is replaced by the verbatim `<tvar>` values, so the code is guaranteed unchanged; only the comments differ per language. `nowrap` suppresses the per-language `<span lang=…>` wrapper. This is the standard mediawiki.org idiom for translatable code and fits wikven's render order (Translate strips its own markup before `<syntaxhighlight>` parses on the base page, and pre-substitutes the unit on `Page/<lang>`).

### Alternatives rejected
- **`<tvar>` the comment** — tvar values are substituted verbatim and are not translated per language, so this translates nothing.
- **`<translate>` inside `<syntaxhighlight>`** — wikven deliberately treats that as a non-real example (#239); the content is verbatim at parse time.
- **Splitting the example** into prose units — fragments the single highlighted block and loses the code↔comment association.
- **Build-side per-language substitution** — needs a new post-render pass and comment-string data format, bypassing Translate's staleness tracking.

## Korean translation left to lag (per project policy)
This PR edits only the English source. The new comment unit (`T:34`) is therefore untranslated on `Configuration/ko`, and the unit whose tracked body shrank (`T:22`) reads as outdated — both surfacing in the translation-completion percentage, to be filled in later. Untranslated/outdated units render via Translate's normal fallback (English text / fuzzy marker), so nothing breaks and CI stays green.

## Verification
- English render unchanged: the `<tvar>` values inline back to the original block byte-for-byte.
- `StalenessComputer::mark()` is idempotent on the edited source; the page is still detected translatable.
- No PHP changed. Please eyeball the rendered code box on `Configuration`, and the untranslated comment on `Configuration/ko`, in the PR preview — live MediaWiki+Translate rendering was not available in the sandbox.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hLcb7wmT5nYb5SVUBij2s)_