### PR TITLE
docs(fix): restore the Licenses link in the References sidebar

### DIFF
--- a/docs/Editing sidebar.wikitext
+++ b/docs/Editing sidebar.wikitext
@@ -18,6 +18,9 @@ Each top-level <code>*</code> line is a heading, and each <code>**</code> line b
 </syntaxhighlight>
 
 <translate>
+<!--T:7-->
+A link target is looked up as a message too, and an entry whose target resolves to a message reading <code>-</code> is dropped from the sidebar without a trace. MediaWiki defines <code>licenses</code>, the upload form's list of license options, as <code>-</code>, so a page named <code>Licenses</code> disappears when written as a plain target. Prefix such a target with a colon, as in <code>:Licenses</code>, to link the page itself.
+
 <!--T:3-->
 == What is removed ==
 

--- a/docs/Editing sidebar/ko.wikitext
+++ b/docs/Editing sidebar/ko.wikitext
@@ -4,6 +4,9 @@
 <!--T:2 @d8441aef-->
 최상위 <code>*</code> 줄은 각각 제목이고, 그 아래 <code>**</code> 줄은 각각 <code>page|label</code> 형식으로 쓴 링크입니다. 제목과 라벨은 먼저 시스템 메시지로 조회되고, 그런 메시지가 없을 때만 적힌 글자를 그대로 씁니다(그래서 <code>mainpage</code>와 <code>mainpage-description</code>은 대문서와 그 라벨로 해석됩니다). 라벨을 번역할 수 있게 해 주는 것이 바로 메시지이므로, 여러분의 것도 메시지 이름으로 쓰세요. 영어 문구(<code>Docs</code>)는 <code>MediaWiki:Sidebar-docs.wikitext</code>에, 한국어 문구(<code>설명서</code>)는 <code>MediaWiki:Sidebar-docs/ko.wikitext</code>에 다른 문서들과 나란히 둡니다. 예를 들어 이 사이트의 사이드바는 다음과 같습니다:
 
+<!--T:7 @36c877e2-->
+링크 대상도 메시지로 조회되며, 대상이 <code>-</code>인 메시지로 해석되는 항목은 아무 흔적 없이 사이드바에서 빠집니다. MediaWiki는 업로드 양식의 라이선스 선택 목록인 <code>licenses</code>를 <code>-</code>로 정의해 두었으므로, <code>Licenses</code>라는 이름의 문서를 대상에 그대로 쓰면 그 항목이 사라집니다. 그런 대상 앞에는 <code>:Licenses</code>처럼 콜론을 붙여 문서 자체로 연결하세요.
+
 <!--T:3 @7a669193-->
 == 제거되는 것 ==
 

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -18,6 +18,8 @@
 ** Standalone binary|sidebar-standalone-binary
 ** Development|sidebar-development
 ** Version|sidebar-version
-** Licenses|sidebar-licenses
+<!-- ":Licenses", not "Licenses": a target is read as a message name first, and MediaWiki defines
+     "licenses" (the upload form's license list) as "-", which drops the entry from the sidebar. -->
+** :Licenses|sidebar-licenses
 *
 ** helppage|help-mediawiki


### PR DESCRIPTION
## The bug

The `Licenses` entry of the References menu renders nowhere on the deployed site — not in English, not in Korean — while every other entry in that section renders fine and `Licenses.html` itself builds and is reachable. On the current `gh-pages` build, `Getting_Started.html` has exactly four items in `#p-References` and no `Licenses` anywhere in the DOM. This predates #252 (it was already missing when the entry read `** Licenses|Licenses`).

## Root cause

A sidebar target is looked up as a message *before* it is treated as a page name, and an entry whose target message reads `-` is dropped silently. `includes/Skin/Skin.php` (MediaWiki 1.46, `Skin::createSidebarItem()`, called from `addToSidebarPlain()`):

```php
$msgLink = $this->msg( $target )->page( $messageTitle )->inContentLanguage();
if ( $msgLink->exists() ) {
    $link = $msgLink->text();
    // Extra check in case a message does fancy stuff with {{#if:… and such
    if ( $link === '-' ) {
        return null;
    }
}
```

Core does define a `licenses` message — the upload form's list of license options — and its English value is `-`. It is easy to miss because it does not live in `languages/i18n/en.json`; it sits in the `nontranslatable` message directory that `LocalisationCache` loads alongside core (`languages/i18n/nontranslatable/en.json`, line 188):

```json
"licenses": "-",
```

So `** Licenses|…` resolves its target to `-` and the item is thrown away before it ever reaches the skin template. `** Version|…` survives because `version` resolves to `Version` (a normal string), not `-`, and the other four targets match no message at all.

Verified against a real MediaWiki 1.46 (`REL1_46`) install rather than by inspection: feeding this repo's `MediaWiki:Sidebar` through `Skin::addToSidebarPlain()` reproduces the drop exactly, and only for `Licenses`.

## The fix

Write the target as `:Licenses`. A leading colon means no message key matches (`msg( ':Licenses' )` does not exist), so the target falls through to `Title::newFromText()`, which strips the colon and yields the same mainspace page and the same href as before. The entry keeps its position, its `sidebar-licenses` label, and `id="n-sidebar-licenses"`; nothing else in the sidebar changes.

Verified on that same 1.46 install, with core's `licenses` message at its default `-`:

| | before | after |
|---|---|---|
| `en` | entry absent | `text=sidebar-licenses href=…/Licenses id=n-sidebar-licenses` |
| `ko` | entry absent | `text=라이선스 href=…/Licenses id=n-sidebar-licenses` |

in both cases last in `sidebar-references`, after `Version`.

### Alternatives considered

- **Add `docs/MediaWiki:Licenses.wikitext` containing `Licenses`.** It works (tested), but it shadows an unrelated core message for the whole wiki: `licenses` drives the upload form's license dropdown, which would then offer a bogus option under `wikven serve`. It also leaves a one-word message page in `docs/` whose purpose is invisible, and it fixes the symptom one page name at a time.
- **Point the entry at `Special:MyLanguage/Licenses`.** Would sidestep the lookup and give Korean readers the Korean page, but it would make one entry behave differently from the other seventeen, which all link the source page.
- **Rename the `Licenses` page.** Changes a published URL to work around a message collision.
- **Post-process the sidebar in `Hider`.** Extension code to paper over a content-level collision; far more surprising than a colon.

## Documentation

`Editing sidebar` said only that *headings and labels* are looked up as messages; the target lookup — and the `-` trapdoor behind it — was undocumented, and any site with a page named `Licenses` (or another `-` message) hits it. A new unit explains it in English, with the Korean translation added and stamped alongside. The sidebar file itself carries a two-line comment so the colon does not read as a typo (`addToSidebarPlain()` ignores lines that do not start with `*`).

## Commit type

`docs(fix):`, following #250. The defect is in the site's output, but the change is entirely documentation source — no extension code moves — so a bare `fix:` would have release-please cut a patch release and a changelog entry for software that did not change.

## Verification

- Reproduced the drop and confirmed the fix on a real MediaWiki 1.46 install (`REL1_46`, SQLite), in `en` and `ko`, using this repo's actual `MediaWiki:Sidebar` and `MediaWiki:Sidebar-licenses` files.
- Translation survey stays at **0** not-ok units; `StalenessComputer::mark()` is a no-op on the edited English page (the new unit is numbered as the tool would number it) and the new Korean unit carries the matching `@36c877e2` stamp.
- **Not** verified locally: a full site bake. Docker is unavailable in this environment (`docker info`: `failed to connect to the docker API at unix:///var/run/docker.sock`), so the Smoke test and PR preview here are the first end-to-end check — the References menu on the preview should now list five items.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hLcb7wmT5nYb5SVUBij2s)_