### PR TITLE
fix: retry and cache the build's Wikimedia Commons lookups

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -40,7 +40,8 @@
 		"SkinAddFooterLinks": "adder",
 		"BeforePageDisplay": "adder",
 		"GetLocalURL": "main",
-		"OutputPageAfterGetHeadLinksArray": "main"
+		"OutputPageAfterGetHeadLinksArray": "main",
+		"SetupAfterCache": "retrier"
 	},
 	"HookHandlers": {
 		"main": {
@@ -52,6 +53,9 @@
 		},
 		"hider": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Hider"
+		},
+		"retrier": {
+			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Retrier"
 		}
 	},
 	"config": {

--- a/includes/Hooks/Retrier.php
+++ b/includes/Hooks/Retrier.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Hooks;
+
+use MediaWiki\Extension\Wikven\RetryingForeignRepo;
+use MediaWiki\FileRepo\ForeignAPIRepo;
+
+class Retrier implements \MediaWiki\Hook\SetupAfterCacheHook {
+	/**
+	 * @inheritDoc
+	 *
+	 * Let a remote file repository retry a request instead of treating the first failure as final;
+	 * see RetryingForeignRepo for why one failed request is otherwise fatal. Core fills in the rest
+	 * of each repository's settings (its directory and backend, and the InstantCommons entry
+	 * itself) in SetupDynamicConfig.php, which runs after LocalSettings.php, so the class is
+	 * swapped here rather than the repository being declared with it in the first place.
+	 */
+	public function onSetupAfterCache(): void {
+		$GLOBALS['wgForeignFileRepos'] = self::retrying($GLOBALS['wgForeignFileRepos']);
+	}
+
+	/**
+	 * The same repositories, with every plain ForeignAPIRepo among them made a retrying one.
+	 *
+	 * A repository already configured with its own class is left alone: it may well be a subclass
+	 * that overrides the very methods RetryingForeignRepo does.
+	 *
+	 * @param array[] $repos $wgForeignFileRepos, as core leaves it after SetupDynamicConfig.php.
+	 * @return array[]
+	 */
+	public static function retrying(array $repos): array {
+		foreach ($repos as &$repo) {
+			if (is_array($repo) && ( $repo['class'] ?? null ) === ForeignAPIRepo::class) {
+				$repo['class'] = RetryingForeignRepo::class;
+			}
+		}
+		unset($repo);
+		return $repos;
+	}
+}

--- a/includes/Hooks/Retrier.php
+++ b/includes/Hooks/Retrier.php
@@ -7,6 +7,13 @@ use MediaWiki\FileRepo\ForeignAPIRepo;
 
 class Retrier implements \MediaWiki\Hook\SetupAfterCacheHook {
 	/**
+	 * The classes a retrying repository stands in for. Core always registers the qualified name,
+	 * but it keeps a class_alias for the unqualified one, so a hand-written repository may still
+	 * name that.
+	 */
+	private const PLAIN_FOREIGN_API_REPOS = [ForeignAPIRepo::class, 'ForeignAPIRepo'];
+
+	/**
 	 * @inheritDoc
 	 *
 	 * Let a remote file repository retry a request instead of treating the first failure as final;
@@ -30,7 +37,11 @@ class Retrier implements \MediaWiki\Hook\SetupAfterCacheHook {
 	 */
 	public static function retrying(array $repos): array {
 		foreach ($repos as &$repo) {
-			if (is_array($repo) && ( $repo['class'] ?? null ) === ForeignAPIRepo::class) {
+			if (!is_array($repo)) {
+				continue;
+			}
+			$class = ltrim((string)( $repo['class'] ?? '' ), '\\');
+			if (in_array($class, self::PLAIN_FOREIGN_API_REPOS, true)) {
 				$repo['class'] = RetryingForeignRepo::class;
 			}
 		}

--- a/includes/RetryingForeignRepo.php
+++ b/includes/RetryingForeignRepo.php
@@ -3,22 +3,53 @@
 namespace MediaWiki\Extension\Wikven;
 
 use MediaWiki\FileRepo\ForeignAPIRepo;
+use RuntimeException;
 
 /**
  * A foreign file repository (Wikimedia Commons through InstantCommons, or any other api.php repo)
- * that gives a request the remote failed to answer a second and a third chance.
+ * that gives a request the remote failed to answer a second and a third chance, and that says so
+ * plainly when it still has no thumbnail to show for it.
  *
  * Every parse of a page embedding a Commons image asks commons.wikimedia.org for that image's
- * thumbnail URL, and MediaWiki makes that request once, with no retry. A request that comes back
- * empty is not merely a missing thumbnail: ForeignAPIFile::transform() then takes an error path
- * that reads the media handler's language, which nothing on that path ever sets, so the parse dies
- * with "Need to set language before accessing" instead of rendering the image. One hiccup at
- * Commons therefore aborts the whole build, which is why the request is worth repeating here, the
- * same way StoreImages already repeats the downloads of the images themselves.
+ * thumbnail URL, and MediaWiki makes that request once, with no retry. A lookup that comes back
+ * empty is not merely a missing thumbnail either: ForeignAPIFile::transform() then takes an error
+ * path that reads the media handler's language, which nothing on that path ever sets, so the parse
+ * dies with "Need to set language before accessing" and takes the whole build with it. Repeating
+ * the request, as StoreImages already repeats the downloads of the images themselves, means one
+ * hiccup at Commons no longer does that; failing the lookup loudly means that when the image
+ * really cannot be had, the build says which one and why instead of quoting that riddle.
  */
 class RetryingForeignRepo extends ForeignAPIRepo {
 	/** How many times one request is made before the repository reports it as failed. */
 	private const ATTEMPTS = 3;
+
+	/**
+	 * @inheritDoc
+	 *
+	 * Core's only caller of this is the ForeignAPIFile::transform() branch described above, which
+	 * cannot cope with a false: it reads a language off a media handler that has none, and throws.
+	 * A thumbnail this repository cannot produce is a build that cannot produce a self-contained
+	 * site, so end it here, where the file and the reason are still known, rather than three
+	 * frames later with neither. StoreImages already aborts the build on the same grounds when it
+	 * cannot download an image, "rather than publish output that still hotlinks images".
+	 *
+	 * This fails no build that would otherwise have passed: every false returned from here is
+	 * already fatal today, just unreadably so.
+	 */
+	public function getThumbUrlFromCache($name, $width, $height, $params = '') {
+		$url = parent::getThumbUrlFromCache($name, $width, $height, $params);
+		if ($url !== false) {
+			return $url;
+		}
+
+		$size = $height > 0 ? "{$width}x{$height}" : "{$width}px";
+		$attempts = self::ATTEMPTS;
+		$what = "Wikven: the '{$this->getName()}' repository has no thumbnail URL for \"$name\" at $size";
+		$tries = "after $attempts attempt(s).";
+		$why = 'The build cannot make that image local, and would publish a page missing it.';
+		$fix = 'Check the network connection and the system CA certificates, then build again.';
+		throw new RuntimeException("$what $tries $why $fix");
+	}
 
 	/** @inheritDoc */
 	public function httpGet($url, $timeout = 'default', $options = [], &$mtime = false) {

--- a/includes/RetryingForeignRepo.php
+++ b/includes/RetryingForeignRepo.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use MediaWiki\FileRepo\ForeignAPIRepo;
+
+/**
+ * A foreign file repository (Wikimedia Commons through InstantCommons, or any other api.php repo)
+ * that gives a request the remote failed to answer a second and a third chance.
+ *
+ * Every parse of a page embedding a Commons image asks commons.wikimedia.org for that image's
+ * thumbnail URL, and MediaWiki makes that request once, with no retry. A request that comes back
+ * empty is not merely a missing thumbnail: ForeignAPIFile::transform() then takes an error path
+ * that reads the media handler's language, which nothing on that path ever sets, so the parse dies
+ * with "Need to set language before accessing" instead of rendering the image. One hiccup at
+ * Commons therefore aborts the whole build, which is why the request is worth repeating here, the
+ * same way StoreImages already repeats the downloads of the images themselves.
+ */
+class RetryingForeignRepo extends ForeignAPIRepo {
+	/** How many times one request is made before the repository reports it as failed. */
+	private const ATTEMPTS = 3;
+
+	/** @inheritDoc */
+	public function httpGet($url, $timeout = 'default', $options = [], &$mtime = false) {
+		return self::retry(
+			function () use ($url, $timeout, $options, &$mtime) {
+				return parent::httpGet($url, $timeout, $options, $mtime);
+			},
+			self::ATTEMPTS,
+			'sleep'
+		);
+	}
+
+	/**
+	 * Run $request until it answers, at most $attempts times, waiting longer before each retry.
+	 *
+	 * @param callable():(string|false) $request Returns the response body, or false if it failed.
+	 * @param int $attempts How many times $request is run before its failure is passed on.
+	 * @param callable(int):mixed $pause Given the seconds to wait before the next attempt (1, then 2, ...).
+	 * @return string|false The first body $request returned, or false if every attempt failed.
+	 */
+	public static function retry(callable $request, int $attempts, callable $pause) {
+		$body = false;
+		for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+			if ($attempt > 1) {
+				$pause($attempt - 1);
+			}
+			$body = $request();
+			if ($body !== false) {
+				break;
+			}
+		}
+		return $body;
+	}
+}

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -18,6 +18,30 @@ $wgFileCacheDirectory = $wikvenDist;
 $wgWikvenSourceDirectory = $wikvenSrc;
 $wgWikvenHtmlDirectory = $wikvenDist;
 
+// A build parses every page many times over (the import, the job queue, the translated pages, one
+// pass per skin), and each parse of a page embedding a Wikimedia Commons image asks
+// commons.wikimedia.org for that image's thumbnail URL again. MediaWiki caches those lookups in
+// the main object cache, which the installer leaves at CACHE_NONE; all that is left then is a
+// three-entry per-process cache, which a site using more than three distinct Commons URLs
+// immediately thrashes. Point the main cache at the build's own database so each lookup is made
+// once per build instead of once per parse. The parser cache is unaffected: CACHE_ANYTHING already
+// resolved to the database.
+$wgMainCacheType = CACHE_DB;
+
+// Let a remote repository (Commons through InstantCommons, and any other api.php repo a site
+// configures) retry a request rather than treat the first failure as final; see
+// RetryingForeignRepo for why one failed request is fatal. Core fills in the rest of each
+// repository's settings during Setup, after this file has run, so the class is swapped once that
+// is done rather than the repository being declared here.
+$wgHooks['SetupAfterCache'][] = static function (): void {
+	foreach ($GLOBALS['wgForeignFileRepos'] as &$wikvenRepo) {
+		if (( $wikvenRepo['class'] ?? null ) === MediaWiki\FileRepo\ForeignAPIRepo::class) {
+			$wikvenRepo['class'] = MediaWiki\Extension\Wikven\RetryingForeignRepo::class;
+		}
+	}
+	unset($wikvenRepo);
+};
+
 // Let pages opt out of indexing with __NOINDEX__ in any namespace.
 $wgExemptFromUserRobotsControl = [];
 

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -25,22 +25,9 @@ $wgWikvenHtmlDirectory = $wikvenDist;
 // three-entry per-process cache, which a site using more than three distinct Commons URLs
 // immediately thrashes. Point the main cache at the build's own database so each lookup is made
 // once per build instead of once per parse. The parser cache is unaffected: CACHE_ANYTHING already
-// resolved to the database.
+// resolved to the database. The lookups still left are worth retrying rather than trusting to one
+// attempt; the Retrier hook handler sees to that.
 $wgMainCacheType = CACHE_DB;
-
-// Let a remote repository (Commons through InstantCommons, and any other api.php repo a site
-// configures) retry a request rather than treat the first failure as final; see
-// RetryingForeignRepo for why one failed request is fatal. Core fills in the rest of each
-// repository's settings during Setup, after this file has run, so the class is swapped once that
-// is done rather than the repository being declared here.
-$wgHooks['SetupAfterCache'][] = static function (): void {
-	foreach ($GLOBALS['wgForeignFileRepos'] as &$wikvenRepo) {
-		if (( $wikvenRepo['class'] ?? null ) === MediaWiki\FileRepo\ForeignAPIRepo::class) {
-			$wikvenRepo['class'] = MediaWiki\Extension\Wikven\RetryingForeignRepo::class;
-		}
-	}
-	unset($wikvenRepo);
-};
 
 // Let pages opt out of indexing with __NOINDEX__ in any namespace.
 $wgExemptFromUserRobotsControl = [];

--- a/tests/phpunit/integration/RetryingForeignRepoTest.php
+++ b/tests/phpunit/integration/RetryingForeignRepoTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\RetryingForeignRepo;
+use MediaWiki\Http\HttpRequestFactory;
+use MediaWiki\Http\MWHttpRequest;
+use MediaWiki\Status\Status;
+use MediaWikiIntegrationTestCase;
+use RuntimeException;
+use Wikimedia\FileBackend\FSFileBackend;
+use Wikimedia\ObjectCache\WANObjectCache;
+
+/**
+ * The repository as MediaWiki drives it: its own httpGet(), not just the retry helper.
+ *
+ * @covers \MediaWiki\Extension\Wikven\RetryingForeignRepo
+ */
+class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
+	/** A repository with its own empty cache, so one test's lookups cannot answer another's. */
+	private function newRepo(): RetryingForeignRepo {
+		return new RetryingForeignRepo([
+			'name' => 'testcommons',
+			'apibase' => 'https://commons.example.org/w/api.php',
+			'url' => 'https://upload.example.org/commons',
+			'thumbUrl' => 'https://upload.example.org/commons/thumb',
+			'hashLevels' => 2,
+			'apiThumbCacheExpiry' => 0,
+			'wanCache' => WANObjectCache::newEmpty(),
+			'backend' => new FSFileBackend([
+				'name' => 'testcommons-backend',
+				'domainId' => 'testcommons',
+				'basePath' => $this->getNewTempDirectory()
+			])
+		]);
+	}
+
+	/**
+	 * Make every HTTP request answer with the next of $responses, and count the requests made.
+	 *
+	 * @param array[] $responses Each either ['fail'] or ['body' => string, 'lastModified' => string].
+	 * @param int &$made Set to the number of requests the repository made.
+	 */
+	private function answerWith(array $responses, &$made): void {
+		$made = 0;
+		$factory = $this->createMock(HttpRequestFactory::class);
+		$factory->method('create')
+			->willReturnCallback(
+				function () use ($responses, &$made): MWHttpRequest {
+					$response = $responses[min($made, count($responses) - 1)];
+					$made++;
+					$request = $this->createMock(MWHttpRequest::class);
+					$request->method('execute')
+						->willReturn(
+							isset($response['body']) ? Status::newGood() : Status::newFatal('http-timed-out')
+						);
+					$request->method('getContent')->willReturn($response['body'] ?? '');
+					$request->method('getResponseHeader')->willReturn($response['lastModified'] ?? null);
+					return $request;
+				}
+			);
+		$this->setService('HttpRequestFactory', $factory);
+	}
+
+	/** An imageinfo response body, with a thumbnail URL unless $thumbUrl is null. */
+	private function imageInfo(?string $thumbUrl): string {
+		$info = $thumbUrl !== null ? ['thumburl' => $thumbUrl] : [];
+		return json_encode(['query' => ['pages' => [['imageinfo' => [$info]]]]]);
+	}
+
+	public function testARequestThatFailsIsRepeatedUntilItAnswers() {
+		$this->answerWith([['fail'], ['body' => 'answered', 'lastModified' => 'Mon, 03 Aug 2026 00:00:00 GMT']], $made);
+
+		$mtime = false;
+		$body = $this->newRepo()->httpGet('https://commons.example.org/w/api.php', 'default', [], $mtime);
+
+		$this->assertSame('answered', $body);
+		$this->assertSame(2, $made, 'the failed request should have been made again');
+		// $mtime is written by the innermost call; it only reaches the caller if the closure
+		// wrapping that call captured it by reference.
+		$this->assertSame(wfTimestamp(TS_UNIX, 'Mon, 03 Aug 2026 00:00:00 GMT'), (string)$mtime);
+	}
+
+	public function testARequestIsGivenUpOnAfterThreeAttempts() {
+		$this->answerWith([['fail']], $made);
+
+		$started = microtime(true);
+		$mtime = false;
+		$body = $this->newRepo()->httpGet('https://commons.example.org/w/api.php', 'default', [], $mtime);
+		$elapsed = microtime(true) - $started;
+
+		$this->assertFalse($body, 'the caller still sees the failure once the attempts run out');
+		$this->assertSame(3, $made);
+		$this->assertGreaterThan(2.5, $elapsed, 'the retries should have waited 1s and then 2s');
+	}
+
+	public function testAThumbnailUrlTheRemoteSuppliesIsPassedStraightThrough() {
+		$url = 'https://upload.example.org/commons/thumb/a/ab/Bakery_oven.jpg/32px-Bakery_oven.jpg';
+		$this->answerWith([['body' => $this->imageInfo($url)]], $made);
+
+		$this->assertSame($url, $this->newRepo()->getThumbUrlFromCache('Bakery oven.jpg', 32, -1));
+	}
+
+	public function testAThumbnailTheRemoteCannotSupplyEndsTheBuildWithAnAnswerableMessage() {
+		// The remote answers, but with no thumburl: core would hand that false to
+		// ForeignAPIFile::transform(), whose error path dies with "Need to set language
+		// before accessing" several frames away from anything that names the file.
+		$this->answerWith([['body' => $this->imageInfo(null)]], $made);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Xclamation SVG.svg');
+		$this->newRepo()->getThumbUrlFromCache('Xclamation SVG.svg', 32, -1);
+	}
+
+	public function testTheMessageSaysWhichRepositoryAndSizeAndWhatToDo() {
+		$this->answerWith([['body' => $this->imageInfo(null)]], $made);
+
+		try {
+			$this->newRepo()->getThumbUrlFromCache('Xclamation SVG.svg', 32, 64);
+			$this->fail('a thumbnail the remote cannot supply should end the build');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('testcommons', $e->getMessage());
+			$this->assertStringContainsString('32x64', $e->getMessage());
+			$this->assertStringContainsString('CA certificates', $e->getMessage());
+		}
+	}
+}

--- a/tests/phpunit/unit/RetrierTest.php
+++ b/tests/phpunit/unit/RetrierTest.php
@@ -51,6 +51,17 @@ class RetrierTest extends MediaWikiUnitTestCase {
 		$this->assertArrayNotHasKey('class', $repos[2]);
 	}
 
+	public function testTheDeprecatedUnqualifiedClassNameCountsToo() {
+		// Core registers the qualified name, but its class_alias keeps this spelling working.
+		$repos = Retrier::retrying([
+			['class' => 'ForeignAPIRepo', 'name' => 'unqualified'],
+			['class' => '\\' . ForeignAPIRepo::class, 'name' => 'leading-backslash']
+		]);
+
+		$this->assertSame(RetryingForeignRepo::class, $repos[0]['class']);
+		$this->assertSame(RetryingForeignRepo::class, $repos[1]['class']);
+	}
+
 	public function testEveryForeignApiRepositoryIsMadeRetrying() {
 		$second = ['class' => ForeignAPIRepo::class, 'name' => 'otherwiki'];
 		$repos = Retrier::retrying([$this->instantCommons(), $second]);

--- a/tests/phpunit/unit/RetrierTest.php
+++ b/tests/phpunit/unit/RetrierTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\Hooks\Retrier;
+use MediaWiki\Extension\Wikven\RetryingForeignRepo;
+use MediaWiki\FileRepo\ForeignAPIRepo;
+use MediaWiki\FileRepo\ForeignDBRepo;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Hooks\Retrier
+ */
+class RetrierTest extends MediaWikiUnitTestCase {
+	/** The InstantCommons entry, as SetupDynamicConfig.php leaves it in $wgForeignFileRepos. */
+	private function instantCommons(): array {
+		return [
+			'class' => ForeignAPIRepo::class,
+			'name' => 'wikimediacommons',
+			'apibase' => 'https://commons.wikimedia.org/w/api.php',
+			'apiThumbCacheExpiry' => 0,
+			'directory' => '/var/www/html/images',
+			'backend' => 'wikimediacommons-backend'
+		];
+	}
+
+	public function testTheInstantCommonsRepositoryIsMadeRetrying() {
+		$repos = Retrier::retrying([$this->instantCommons()]);
+
+		$this->assertSame(RetryingForeignRepo::class, $repos[0]['class']);
+	}
+
+	public function testEveryOtherSettingOfTheRepositoryIsLeftAsCoreLeftIt() {
+		$before = $this->instantCommons();
+		$after = Retrier::retrying([$before])[0];
+
+		unset($before['class'], $after['class']);
+		$this->assertSame($before, $after);
+	}
+
+	public function testARepositoryOfAnotherClassIsLeftAlone() {
+		// A subclass may already override what RetryingForeignRepo overrides; don't take it over.
+		$repos = Retrier::retrying([
+			['class' => ForeignDBRepo::class, 'name' => 'shared'],
+			['class' => RetryingForeignRepo::class, 'name' => 'already'],
+			['name' => 'classless']
+		]);
+
+		$this->assertSame(ForeignDBRepo::class, $repos[0]['class']);
+		$this->assertSame(RetryingForeignRepo::class, $repos[1]['class']);
+		$this->assertArrayNotHasKey('class', $repos[2]);
+	}
+
+	public function testEveryForeignApiRepositoryIsMadeRetrying() {
+		$second = ['class' => ForeignAPIRepo::class, 'name' => 'otherwiki'];
+		$repos = Retrier::retrying([$this->instantCommons(), $second]);
+
+		$this->assertSame(RetryingForeignRepo::class, $repos[0]['class']);
+		$this->assertSame(RetryingForeignRepo::class, $repos[1]['class']);
+	}
+
+	public function testNoRepositoryAtAllIsHarmless() {
+		$this->assertSame([], Retrier::retrying([]));
+	}
+}

--- a/tests/phpunit/unit/RetryingForeignRepoTest.php
+++ b/tests/phpunit/unit/RetryingForeignRepoTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\RetryingForeignRepo;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\RetryingForeignRepo
+ */
+class RetryingForeignRepoTest extends MediaWikiUnitTestCase {
+	/** A request answering with each of $results in turn, recording the calls it received. */
+	private function requestReturning(array $results, array &$calls): callable {
+		return static function () use ($results, &$calls) {
+			$calls[] = count($calls) + 1;
+			return $results[count($calls) - 1];
+		};
+	}
+
+	/** A pause that records the waits asked of it instead of sleeping. */
+	private function pauseRecording(array &$waits): callable {
+		return static function (int $seconds) use (&$waits): void {
+			$waits[] = $seconds;
+		};
+	}
+
+	public function testARequestThatAnswersIsMadeOnce() {
+		$calls = [];
+		$waits = [];
+		$body = RetryingForeignRepo::retry(
+			$this->requestReturning(['{"query":{}}'], $calls),
+			3,
+			$this->pauseRecording($waits)
+		);
+
+		$this->assertSame('{"query":{}}', $body);
+		$this->assertCount(1, $calls);
+		$this->assertSame([], $waits, 'a request that answered must not be waited on');
+	}
+
+	public function testAFailedRequestIsRetriedUntilItAnswers() {
+		$calls = [];
+		$waits = [];
+		$body = RetryingForeignRepo::retry(
+			$this->requestReturning([false, '{"query":{}}', '{"unreached":{}}'], $calls),
+			3,
+			$this->pauseRecording($waits)
+		);
+
+		$this->assertSame('{"query":{}}', $body);
+		$this->assertCount(2, $calls);
+		$this->assertSame([1], $waits);
+	}
+
+	public function testAnEmptyResponseIsNotMistakenForAFailure() {
+		// A repo answering "" did answer; only false means the request itself did not go through.
+		$calls = [];
+		$waits = [];
+		$body = RetryingForeignRepo::retry(
+			$this->requestReturning(['', '{"unreached":{}}'], $calls),
+			3,
+			$this->pauseRecording($waits)
+		);
+
+		$this->assertSame('', $body);
+		$this->assertCount(1, $calls);
+	}
+
+	public function testAPersistentFailureGivesUpAfterTheLastAttempt() {
+		$calls = [];
+		$waits = [];
+		$body = RetryingForeignRepo::retry(
+			$this->requestReturning([false, false, false], $calls),
+			3,
+			$this->pauseRecording($waits)
+		);
+
+		$this->assertFalse($body, 'the caller still sees the failure once the attempts run out');
+		$this->assertCount(3, $calls);
+		$this->assertSame([1, 2], $waits, 'each retry waits a second longer than the one before');
+	}
+}


### PR DESCRIPTION
## What fails

`Smoke test` → `build-and-check` aborts `maintenance/build.php` with

```
RuntimeException from line 65 of includes/Media/MediaHandler.php: Need to set language before accessing.
#0  includes/FileRepo/File/ForeignAPIFile.php(150): MediaHandler->getLanguage()
#1  includes/Linker/Linker.php(424): ForeignAPIFile->transform(Array)
...
#19 extensions/SifterSearch/includes/BuildIndexJob.php(134): WikiPage->getParserOutput(ParserOptions)
```

on some pushes to `main` (#251, #255) and not others (#250, #252, #254).

## What it actually is

The message points at a language, but nothing is missing from the page, the parser options or the context. Here is `ForeignAPIFile::transform()` in `REL1_46`:

```php
$thumbUrl = $this->repo->getThumbUrlFromCache( $this->getName(), $width, $height, $otherParams );  // ← line 134
…
if ( $thumbUrl === false ) {
    return $this->repo->getThumbError(
        $this->getName(), $width, $height, $otherParams,
        $this->handler->getLanguage()->getCode()   // ← line 150
    );
}
return $this->handler->getTransform( $this, 'bogus', $thumbUrl, $params );
```

`$this->handler` was built by `File::getHandler()` with no language, so `MediaHandler::getLanguage()` throws — and because it is evaluated as an *argument*, it throws before `getThumbError()` is even entered. The success path never reads it. The exception is therefore reachable **only** when `getThumbUrlFromCache()` returns `false`, and under InstantCommons (`'apiThumbCacheExpiry' => 0`, so `canCacheThumbs()` is false) that means one thing: a live request to `commons.wikimedia.org/w/api.php` did not come back with a `thumburl`.

I reproduced it deterministically on a stock `REL1_46` + SQLite install, with a `ForeignAPIRepo` whose lookup always fails and nothing else changed:

```
RuntimeException: Need to set language before accessing.
  thrown from ForeignAPIFile.php:150
```

The two failing runs agree, and they agree on nothing else:

| run | page parsed | Commons file | entry into `transform()` |
| --- | --- | --- | --- |
| 30914881138 (`5be9e8a`) | starts `__TOC__\n\n<langu…`, rev 166 — one of Configuration / Deploying / Standalone binary, the three pages that begin `__TOC__` and transclude `Template:note` | `Xclamation SVG.svg` at 32px | `Linker::makeImageLink`, Linker.php:424 |
| 30866192072 (`96448b8`) | starts `<languages />\n<…`, rev 14 — `Images` | `The Earth seen from Apollo 17.jpg` as a thumb | `Linker::makeThumbLink2`, Linker.php:657 |

Different pages, different files, different Linker helper, same line. SifterSearch is not implicated either: its `BuildIndexJob` builds a plain `ParserOptions::newFromAnon()` and re-renders every content page after each edit, so it is simply the first thing in the drain queue that renders these images. It is the lookup that failed, not the caller.

## Why it is intermittent

**It is not a difference between `preview` and `build-and-check`.** `./action` and the smoke job's inline `docker run` issue the identical command against the identical locally built image. And for #255 the *same* `Smoke test` workflow passed on the PR (run 30914838359, `f663ae9`) and failed on the push (`5be9e8a`) with the same tree. There is no structural difference to find — the smoke job lost a coin flip.

**The build flips that coin far more often than it should.** `ForeignAPIRepo::httpGetCached()` caches every Commons lookup in the main WAN cache, but `MainWANObjectCache` is built from `$wgMainCacheType`, and the CLI installer never sets `_MainCacheType`, so `LocalSettingsGenerator` writes `$wgMainCacheType = CACHE_NONE` (confirmed: that is exactly what a `maintenance/run.php install` produces) and the WAN cache is an `EmptyBagOStuff`. All that is left is the callback's `'pcGroup' => 'http-get:3'`, `'pcTTL' => TTL_PROC_LONG`: **three entries, thirty seconds**, per process. This site needs more than three distinct Commons URLs — a metadata query per file, plus a thumb-URL query per rendered width, and `Linker::processResponsiveImages` asks for 2× on top of 1× — so the cache thrashes.

Measured on that same install, three parses of a site needing four distinct Commons URLs:

| `$wgMainCacheType` | WAN store | network requests for 12 lookups |
| --- | --- | --- |
| `CACHE_NONE` (today) | `EmptyBagOStuff` | **12** |
| `CACHE_DB` (this PR) | `SqlBagOStuff` | **4** |

And a build parses everything many times over: the import, every `drainJobs()` in `buildTranslations` (each of which re-runs SifterSearch's `BuildIndexJob` across the wiki), the Translate render jobs, `RunJobs`, then `RebuildFileCache` once per skin. That is hundreds of live requests to `commons.wikimedia.org` per build, each with exactly one attempt and no retry. Losing one of them roughly every third push is what `main` has been doing. Both failing logs also show a 31 s and a 34 s gap of silence immediately before the trace, consistent with a request stalling out rather than answering.

## The fix

Three changes, in `includes/`.

**1. Give the lookups a cache — `includes/WikvenSettings.php`, `$wgMainCacheType = CACHE_DB;`** So each Commons lookup is made once per build instead of once per parse. Set before the `default.yml` / `.wikven.yaml` merge, so a site can still override it. Nothing else moves: `CACHE_ANYTHING` was already resolving to the database precisely *because* the main cache was `CACHE_NONE`, so the parser, message and session caches are unchanged — only `MainWANObjectCache` is.

**2. Give them a second and third chance — `includes/RetryingForeignRepo.php`.** A `ForeignAPIRepo` subclass whose `httpGet()` retries a failed request twice more, waiting 1 s then 2 s. This is the treatment `maintenance/storeImages.php` already gives the image *downloads* ("Commons may 4xx/5xx while generating an uncached thumbnail"); the parse-time lookups were the half that never got it. Against an unreachable API the plain repo gives up in 0.1 s, this one after 3 s. `includes/Hooks/Retrier.php` is a `SetupAfterCache` handler, declared in `extension.json` alongside `main`/`adder`/`hider`, that swaps the class into every `$wgForeignFileRepos` entry naming a plain `ForeignAPIRepo`; it has to run there because core adds the InstantCommons entry and fills in each repository's directory and backend in `SetupDynamicConfig.php`, after `LocalSettings.php`.

**3. Close the hole — `RetryingForeignRepo::getThumbUrlFromCache()`.** Retrying makes a *hiccup* survivable but not an *outage*: every lookup would then cost three timeouts plus 3 s of sleeping, repeated each time the 30 s negative-cache entry lapses (`adaptiveTTL()`'s `$minTTL`, not the 4 h metadata TTL, because the failure branch passes no `$mtime`), across every render pass — and still end at line 150. `getThumbUrlFromCache()` has **exactly one caller in all of core**: line 134, the branch above. Overriding it therefore closes the path completely for anything the parser renders, which always asks for a width. Same install, same outage, before and after:

```
plain ForeignAPIRepo (what main does today):
  RuntimeException: Need to set language before accessing.
  thrown from ForeignAPIFile.php:150

RetryingForeignRepo (this PR):
  RuntimeException: Wikven: the 'wikimediacommons' repository has no thumbnail URL for
  "Xclamation_SVG.svg" at 32px after 3 attempt(s). The build cannot make that image local,
  and would publish a page missing it. Check the network connection and the system CA
  certificates, then build again.
  thrown from ForeignAPIFile.php:134
```

**This aborts rather than degrading to a broken thumbnail, deliberately.** A degraded transform leaves no `upload.wikimedia.org` URL in the HTML at all, so `StoreImages` finds nothing to make local, does not fail, and the site publishes with a hole in it and nothing in the log — precisely the silent breakage the smoke test exists to catch. `StoreImages` already aborts in this exact situation, "rather than publish output that still hotlinks images"; this is that rule applied at parse time. **No build that passes today starts failing:** every `false` returned from here is already fatal, just unreadably so, and now it stops at the first bad image instead of grinding every other one into the same wall first.

### On the `fileFactory` route, and why not

`ForeignAPIRepo` does expose `protected $fileFactory = [ForeignAPIFile::class, 'newFromTitle']`, and overriding `transform()` on a `ForeignAPIFile` subclass would cover the last degenerate path too (`transform()` called with neither width nor height on a non-audio file — which `Linker` and `Parser` never do). I did not take it, for two reasons.

**It does not work on its own.** `ForeignAPIFile::newFromTitle()` builds its result with `new self( … )`, not `new static( … )`, so a `fileFactory` naming a subclass silently returns a plain `ForeignAPIFile`. Verified rather than assumed:

```
fileFactory named …ForeignAPIFile@anonymous, newFile() returned MediaWiki\FileRepo\File\ForeignAPIFile
the fileFactory override did NOT take effect (ForeignAPIFile::newFromTitle uses new self)
```

Taking the route therefore means also overriding `newFromTitle()` with a verbatim copy of core's ~28-line metadata query — the props list, `MediaHandler::getMetadataVersion()`, `iiextmetadatamultilang`, the redirect handling — on the path that fetches *all* Commons file metadata. That copy would drift silently across MediaWiki upgrades, and drift there loses attribution metadata rather than crashing. `getThumbUrlFromCache()` buys the same closure for the paths that actually occur, with one thin override and no copied logic.

**And the behaviour it buys is the wrong one here**, for the reason in bold above. Degrading is right for a wiki that serves pages live; wikven's promise is a self-contained directory of HTML, and its own `StoreImages` already says what to do when an image cannot be had.

**The upstream bug is still upstream.** `ForeignAPIFile::transform()` should not read a language off a handler `File::getHandler()` built without one; that belongs in core and is worth a Phabricator task. This PR does not paper over it — it makes it unreachable from wikven and replaces the riddle with an answer.

The smoke test, `docs/Images.wikitext` and `Template:note` are untouched.

## Tests

- `tests/phpunit/integration/RetryingForeignRepoTest.php` drives `httpGet()` and `getThumbUrlFromCache()` themselves, through a stubbed `HttpRequestFactory`: a failed request is repeated until it answers; it is given up on after exactly three attempts, having waited; a thumbnail URL the remote supplies passes straight through; one it cannot supply ends the build with a message naming the file, the size, the repository and what to check. The three mutations that would otherwise slip through were checked by making them: dropping the `&` from the closure's `$mtime` capture, setting `ATTEMPTS` to 1, and replacing `sleep` with a no-op each fail at least one test.
- `tests/phpunit/unit/RetryingForeignRepoTest.php` pins the retry contract itself, including that `''` counts as an answer — only `false` means the request did not go through.
- `tests/phpunit/unit/RetrierTest.php` pins what the hook rewrites and, more to the point, what it leaves alone: a repository already configured with its own class keeps it, an entry with no class is untouched, every other setting core filled in survives, and the deprecated unqualified `'ForeignAPIRepo'` spelling counts too (core keeps a `class_alias`).

All 136 wikven tests pass against `REL1_46`; `mago format --check`, `mago lint`, `phpcs` and `minus-x` are clean.

## What I could not verify

No Docker daemon here, so no local end-to-end bake, and reproducing the *intermittency* would need a real Commons hiccup. Everything above was instead checked against a real `REL1_46` + SQLite install. `ext-ast` is not available either, so phan is left to CI — where it passed on both `REL1_46` and `master`, as did the smoke bake.