### PR TITLE
fix: switch skins correctly from a translated page

### DIFF
--- a/resources/skin-switcher.js
+++ b/resources/skin-switcher.js
@@ -15,19 +15,33 @@
 	const main = mw.config.get("wgWikvenMainSkin");
 	const current = mw.config.get("skin");
 
-	// Map the current page's URL to the same page under another skin. The skin
-	// dir is the only segment that differs: the main skin has none, others sit in
-	// a "<skin>/" subdirectory right under the shared base.
+	// How many trailing path segments the page itself owns. Every slash in a title
+	// becomes a real directory in the export ("Getting Started/ko" is written to
+	// "Getting_Started/ko.html"), so the page owns one segment per slash plus the
+	// file; a namespace colon makes no directory ("File:logo.svg.html" is a single
+	// segment). Only the count is read, so the title's underscores and any
+	// percent-encoding of non-ASCII characters do not matter. This is the signal
+	// the build places the file by, and the only one to hand: a static export
+	// publishes no base path (no wgScriptPath/wgArticlePath in mw.config).
+	const owned = (mw.config.get("wgPageName") || "").split("/").length;
+
+	// Map the current page's URL to the same page under another skin. The skin dir
+	// is the only segment that differs: the main skin has none, others sit in a
+	// "<skin>/" subdirectory directly under the shared base. That base is not
+	// "everything before the file name" -- the page's own path may be several
+	// segments deep -- so drop the segments the page owns to find where it ends.
 	const targetUrl = (target) => {
-		const path = location.pathname;
-		const slash = path.lastIndexOf("/");
-		const file = path.slice(slash + 1);
-		let base = path.slice(0, slash + 1);
-		if (current !== main && base.endsWith(`/${current}/`)) {
-			base = base.slice(0, base.length - current.length - 1);
+		const segments = location.pathname.split("/");
+		const page = segments.splice(Math.max(segments.length - owned, 0), owned);
+		// What is left is "<base>" or "<base>/<skin>".
+		if (current !== main && segments[segments.length - 1] === current) {
+			segments.pop();
 		}
-		const prefix = target === main ? "" : `${target}/`;
-		return base + prefix + file + location.search + location.hash;
+		if (target !== main) {
+			segments.push(target);
+		}
+		const path = segments.concat(page).join("/");
+		return path + location.search + location.hash;
 	};
 
 	const init = () => {

--- a/tests/e2e/skin-switcher.spec.js
+++ b/tests/e2e/skin-switcher.spec.js
@@ -1,0 +1,136 @@
+// The footer skin switcher rewrites the current URL to the same page under
+// another skin's copy of the export. Both halves of that URL vary -- the base
+// path the site is served from, and how many directories deep the page sits --
+// and a translated page ("Getting Started/ko" exports to Getting_Started/ko.html)
+// is deeper than its source. Getting that wrong sends the reader to a path the
+// export does not contain, which no static-HTML assertion can see: the pages
+// themselves are all present and correct. These tests drive the switcher in a
+// browser, where the resulting 404 is visible.
+
+const { test, expect } = require("@playwright/test");
+
+// The article the sequence runs on, in each language.
+const ENGLISH_HEADING = "Getting Started";
+const KOREAN_HEADING = "시작하기";
+
+// One per page, rendered by the SkinAddFooterLinks hook with the current skin
+// preselected, so its value also names the skin the page was rendered for.
+const skinSelect = (page) => page.locator(".wikven-skin-switcher select");
+
+// Record every page the browser is sent to that the export does not have, so a
+// switch to a nonexistent path fails as the 404 it is.
+const watchForMissingPages = (page) => {
+	const missing = [];
+	page.on("response", (response) => {
+		if (
+			response.request().resourceType() === "document" &&
+			response.status() >= 400
+		) {
+			missing.push(`${response.status()} ${response.url()}`);
+		}
+	});
+	return missing;
+};
+
+// Choose a skin and wait out the navigation it triggers, returning the response
+// so a test can assert the page was actually served. The <select> is in the HTML
+// whether or not its module ever runs, so wait for the module rather than race
+// it: a change event nobody is listening for would just look like a hang.
+const chooseSkin = async (page, skin) => {
+	await page.waitForFunction(
+		() =>
+			window.mw &&
+			window.mw.loader.getState("ext.Wikven.skinSwitcher") === "ready",
+	);
+	const navigation = page.waitForResponse((response) =>
+		response.request().isNavigationRequest(),
+	);
+	await skinSelect(page).selectOption(skin);
+	const response = await navigation;
+	await page.waitForLoadState("domcontentloaded");
+	return response;
+};
+
+const expectKoreanArticle = async (page) => {
+	await expect(page.locator("#firstHeading")).toHaveText(KOREAN_HEADING);
+	await expect(page.locator("html")).toHaveAttribute("lang", "ko");
+};
+
+// The reported order: language first, then skin. (Skin first, then language,
+// always worked -- the language links are relative, so they keep the skin.)
+test("switching the skin after switching to Korean keeps the article", async ({
+	page,
+}) => {
+	const missing = watchForMissingPages(page);
+
+	await page.goto("Getting_Started.html");
+	await expect(page.locator("#firstHeading")).toHaveText(ENGLISH_HEADING);
+
+	await page.locator('.mw-pt-languages-list a[lang="ko"]').click();
+	await expect(page).toHaveURL("Getting_Started/ko.html");
+	await expectKoreanArticle(page);
+
+	const response = await chooseSkin(page, "timeless");
+
+	expect(response.status()).toBe(200);
+	await expect(page).toHaveURL("timeless/Getting_Started/ko.html");
+	await expectKoreanArticle(page);
+	await expect(skinSelect(page)).toHaveValue("timeless");
+	expect(missing, missing.join("; ")).toEqual([]);
+});
+
+// The other direction: back to the main skin, which lives at the export root
+// rather than in a directory of its own.
+test("switching back to the main skin from a Korean page returns to the root copy", async ({
+	page,
+}) => {
+	const missing = watchForMissingPages(page);
+
+	await page.goto("timeless/Getting_Started/ko.html");
+	await expect(skinSelect(page)).toHaveValue("timeless");
+
+	const response = await chooseSkin(page, "vector-2022");
+
+	expect(response.status()).toBe(200);
+	await expect(page).toHaveURL("Getting_Started/ko.html");
+	await expectKoreanArticle(page);
+	await expect(skinSelect(page)).toHaveValue("vector-2022");
+	expect(missing, missing.join("; ")).toEqual([]);
+});
+
+// And between two skins that both have a directory, where the old and the new
+// skin directory are at the same depth.
+test("switching between two non-main skins on a Korean page keeps the article", async ({
+	page,
+}) => {
+	const missing = watchForMissingPages(page);
+
+	await page.goto("timeless/Getting_Started/ko.html");
+
+	const response = await chooseSkin(page, "citizen");
+
+	expect(response.status()).toBe(200);
+	await expect(page).toHaveURL("citizen/Getting_Started/ko.html");
+	await expectKoreanArticle(page);
+	await expect(skinSelect(page)).toHaveValue("citizen");
+	expect(missing, missing.join("; ")).toEqual([]);
+});
+
+// A source page sits one directory higher than its translations; it worked
+// before and has to keep working.
+test("switching the skin on a source page keeps the article", async ({
+	page,
+}) => {
+	const missing = watchForMissingPages(page);
+
+	await page.goto("Getting_Started.html");
+
+	expect((await chooseSkin(page, "timeless")).status()).toBe(200);
+	await expect(page).toHaveURL("timeless/Getting_Started.html");
+	await expect(page.locator("#firstHeading")).toHaveText(ENGLISH_HEADING);
+
+	expect((await chooseSkin(page, "vector-2022")).status()).toBe(200);
+	await expect(page).toHaveURL("Getting_Started.html");
+	await expect(page.locator("#firstHeading")).toHaveText(ENGLISH_HEADING);
+	expect(missing, missing.join("; ")).toEqual([]);
+});


### PR DESCRIPTION
Switching to Korean and then changing the skin lands on a 404; changing the skin first and then switching to Korean works.

## The cause

`resources/skin-switcher.js` located the site base by taking everything before the file name:

```js
const slash = path.lastIndexOf("/");
const file = path.slice(slash + 1);
let base = path.slice(0, slash + 1);
```

That holds only for a page written straight to the export root. A translated page sits one directory deeper — the docs page `Getting Started/ko` is written to `Getting_Started/ko.html` — so the segment before the file is the page's own directory, not the skin's.

Traced against the deployed `gh-pages` tree (`Getting_Started/ko.html` and `timeless/Getting_Started/ko.html` both exist):

| from | switch to | old result | correct |
| --- | --- | --- | --- |
| `/wikven/Getting_Started/ko.html` (main skin) | `timeless` | `/wikven/Getting_Started/timeless/ko.html` — 404 | `/wikven/timeless/Getting_Started/ko.html` |
| `/wikven/timeless/Getting_Started/ko.html` | main skin | URL unchanged, page just reloads | `/wikven/Getting_Started/ko.html` |
| `/wikven/timeless/Getting_Started/ko.html` | `citizen` | `/wikven/timeless/Getting_Started/citizen/ko.html` — 404 | `/wikven/citizen/Getting_Started/ko.html` |

Running the old module under DOM stubs over every page/skin pair in the deployed tree: 24 of 48 switches broken — every translated page, in every direction. Every source page was fine, which is why "skin first, then language" works.

## The fix

The skin directory is a segment directly under the site base, so find where the base ends rather than reading it off the tail. How many trailing segments the page occupies comes from the slashes in `wgPageName`: `maintenance/rename.php` turns each `%2F` in the cached file name into a real directory, so a title's slash count is exactly the page's depth. Only the count is read, so underscores, a namespace colon (`File:logo.svg.html` is a single segment) and percent-encoded non-ASCII titles all come out right.

`wgPageName` is also the only signal available: the static export publishes no base path of its own — there is no `wgScriptPath` or `wgArticlePath` in `mw.config` on a baked page (checked in the rendered HTML and in `startup-static.js`). The per-page `../` prefixes `RelativeUrl::reparent()` writes onto assets encode the same depth, but only indirectly, and reading them would mean scraping the DOM for a link whose shape is an implementation detail of the CSS dump.

## Verification

Running the real `resources/skin-switcher.js` under DOM stubs against the file list of the deployed `gh-pages` tree — every page × every skin pair, asserting the computed URL names a file that actually exists and that `?search` and `#hash` survive:

- before: 24 of 48 switches broken
- after: 48 of 48 land on a file the export contains

Repeated with the site base at `/wikven/` (as GitHub Pages serves it), at a domain root, and at a `file:///` style path — all pass. Also covered: main and non-main skins, source and translated pages, deeper subpages, directory-index URLs (`/wikven/` → `/wikven/timeless/`), a `File:` page, and a base directory that happens to share a skin's name.

`resources/` is bundled through ResourceLoader into `modules-static.js` rather than parsed as a wiki page, and the bundle keeps arrow functions and template literals verbatim, so the ES2016 gadget constraint does not apply; the change stays at the syntax level the rest of `resources/` already uses. `biome ci` is clean on both files.

## Tests

`tests/e2e/skin-switcher.spec.js` drives the reported sequence in a real browser: land on `Getting_Started.html`, click 한국어 in the Translate language bar, then pick a skin from the footer, asserting the resulting page is served (not a 404), is the same article in Korean, and reports the chosen skin. It covers the failing direction back to the main skin, a hop between two non-main skins, and a source page as a guard on the direction that already worked.

Playwright could not run in the environment this was written in — `cdn.playwright.dev` is blocked there, so no browser could be downloaded. The Smoke test job on this PR did run it: 13 passed against a real bake served under `/wikven/`. The "fails without the fix" half is the DOM-stub run above, which drives the old module against the real deployed tree and shows it computing exactly the URLs these tests reject.
