### PR TITLE
fix: dump ResourceLoader modules without load.php's HTTP response

### DIFF
--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -108,12 +108,10 @@ class AssetLocalizer {
 			$query['variant'] = $p['variant'];
 		}
 
-		ob_start();
-		$rl->respond(new Context($rl, new FauxRequest($query)));
-		$bytes = ob_get_clean();
+		$bytes = ModuleRenderer::render($rl, new Context($rl, new FauxRequest($query)));
 
-		$isSvg = $bytes !== false && str_contains($bytes, '<svg');
-		$isPng = $bytes !== false && strncmp($bytes, "\x89PNG\r\n\x1a\n", 8) === 0;
+		$isSvg = str_contains($bytes, '<svg');
+		$isPng = strncmp($bytes, "\x89PNG\r\n\x1a\n", 8) === 0;
 		if (!$isSvg && !$isPng) {
 			return null;
 		}

--- a/includes/ModuleRenderer.php
+++ b/includes/ModuleRenderer.php
@@ -99,18 +99,16 @@ class ModuleRenderer {
 		$rl->setLogger($collector);
 		try {
 			$body = $rl->makeModuleResponse($context, $modules, $missing);
+			if ($collector->failures !== []) {
+				throw new RuntimeException(
+					'Wikven: ResourceLoader failed to build ' . implode(', ', array_keys($modules)) . ":\n"
+						. implode("\n", $collector->failures)
+				);
+			}
+			return self::noteMissingModules($context, $missing) . $body;
 		} finally {
 			$rl->setLogger($previousLogger);
 		}
-
-		if ($collector->failures !== []) {
-			throw new RuntimeException(
-				'Wikven: ResourceLoader failed to build ' . implode(', ', array_keys($modules)) . ":\n"
-					. implode("\n", $collector->failures)
-			);
-		}
-
-		return self::noteMissingModules($context, $missing) . $body;
 	}
 
 	/**

--- a/includes/ModuleRenderer.php
+++ b/includes/ModuleRenderer.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use MediaWiki\ResourceLoader\Context;
+use MediaWiki\ResourceLoader\Module;
+use MediaWiki\ResourceLoader\ResourceLoader;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use RuntimeException;
+use Throwable;
+
+/** Renders ResourceLoader modules to a string, without the load.php HTTP response around them. */
+class ModuleRenderer {
+	/**
+	 * Render the modules named by $context and return the response body.
+	 *
+	 * ResourceLoader::respond() is load.php's web entry point: before echoing the module body it
+	 * calls sendResponseHeaders(), which emits Content-Type, ETag, Cache-Control and Expires with
+	 * header() (and, for an image request, Image::sendResponseHeaders()). The build drives it from
+	 * CLI maintenance scripts that have already written to stdout, so headers_sent() is true and
+	 * every one of those header() calls raises "Cannot modify header information - headers already
+	 * sent", hundreds of times per bake. Output buffering cannot help: ob_start() does not un-send
+	 * headers, which is why the ob_start()/ob_get_clean() pairs that used to wrap respond() here
+	 * captured the body but not the warnings.
+	 *
+	 * makeModuleResponse() is the same body generation without the response wrapper -- it is what
+	 * core itself calls to embed a module in HTML (ClientHtml::makeLoad()). This method adds back
+	 * the parts of respond() that shape the body rather than the response: splitting the requested
+	 * names into registered modules and missing ones, and preloading module info.
+	 *
+	 * @param ResourceLoader $rl
+	 * @param Context $context Modules, language, skin and 'only' mode to render.
+	 * @return string The rendered CSS, JS or image bytes.
+	 */
+	public static function render(ResourceLoader $rl, Context $context): string {
+		$modules = [];
+		$missing = [];
+		foreach ($context->getModules() as $name) {
+			$module = $rl->getModule($name);
+			if (!$module) {
+				// As in respond(): an unregistered module is reported in the body itself (a
+				// "missing" load state, or a comment in a styles response), not thrown.
+				$missing[] = $name;
+				continue;
+			}
+			if ($module->getGroup() === Module::GROUP_PRIVATE) {
+				// respond() refuses these ("Cannot build private module") because they carry
+				// per-user data (T36907). Nothing in the build should ask for one, so stop
+				// rather than write out a file whose only content is that error.
+				throw new RuntimeException("Wikven: refusing to dump the private module '$name'.");
+			}
+			$modules[$name] = $module;
+		}
+
+		// Batches the version and message-blob lookups the modules would otherwise make one at a
+		// time, exactly as respond() does before generating. respond() turns a failure here into an
+		// error comment in the response; the build wants it to stop, so let it escape.
+		$rl->preloadModuleInfo(array_keys($modules), $context);
+
+		// makeModuleResponse() catches a throwing module, logs it and leaves an "error" load state
+		// in the body -- respond() would additionally have written the exception into the dumped
+		// file, which is no way to notice it either. Watch the logger instead and fail the build.
+		$previousLogger = $rl->getLogger();
+		$collector = new class extends AbstractLogger {
+			/** @var string[] Messages logged for a module that could not be built. */
+			public array $failures = [];
+
+			/** @var LoggerInterface The logger this one stands in front of. */
+			public LoggerInterface $inner;
+
+			/**
+			 * @param mixed $level
+			 * @param string $message
+			 * @param array $context
+			 */
+			public function log($level, $message, array $context = []): void {
+				// ResourceLoader::outputErrorAndLog(), the one place a module-generation
+				// exception is swallowed, always logs it with the exception attached.
+				$levels = [
+					LogLevel::WARNING,
+					LogLevel::ERROR,
+					LogLevel::CRITICAL,
+					LogLevel::ALERT,
+					LogLevel::EMERGENCY
+				];
+				if (isset($context['exception']) && in_array((string)$level, $levels, true)) {
+					$exception = $context['exception'];
+					$this->failures[] = $exception instanceof Throwable
+						? get_class($exception) . ': ' . $exception->getMessage()
+						: (string)$message;
+				}
+				$this->inner->log($level, $message, $context);
+			}
+		};
+		$collector->inner = $previousLogger;
+
+		$rl->setLogger($collector);
+		try {
+			$body = $rl->makeModuleResponse($context, $modules, $missing);
+		} finally {
+			$rl->setLogger($previousLogger);
+		}
+
+		if ($collector->failures !== []) {
+			throw new RuntimeException(
+				'Wikven: ResourceLoader failed to build ' . implode(', ', array_keys($modules)) . ":\n"
+					. implode("\n", $collector->failures)
+			);
+		}
+
+		return self::noteMissingModules($context, $missing) . $body;
+	}
+
+	/**
+	 * The comment respond() would have prefixed for modules that are not registered.
+	 *
+	 * A response that carries scripts reports them to the client itself, as a "missing" load state
+	 * built by makeModuleResponse(); one that does not (a styles response) can only say so in a
+	 * comment, and respond() is what prepends it. Nothing in the build asks for an unregistered
+	 * module -- the CSS files buildStyles renders are only created for modules ResourceLoader
+	 * knows (Hooks\Main::addStyleToList()) -- so this exists to keep a broken build's output what
+	 * it always was, rather than to be read.
+	 *
+	 * @param Context $context
+	 * @param string[] $missing Requested module names that are not registered.
+	 * @return string The comment, or '' when there is nothing to report.
+	 */
+	private static function noteMissingModules(Context $context, array $missing): string {
+		if ($missing === []) {
+			return '';
+		}
+		if ($context->shouldIncludeScripts() && !$context->getRaw()) {
+			return '';
+		}
+		$states = array_fill_keys($missing, 'missing');
+		// makeModuleResponse() silences encodeJson()'s warning here because the names came off a
+		// web request and invalid UTF-8 in one is a client error (T331641). The build's names come
+		// from its own registry and file names, where that would be worth hearing about.
+		return ResourceLoader::makeComment('Problematic modules: ' . $context->encodeJson($states));
+	}
+}

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -204,9 +204,7 @@ class BuildScripts extends Maintenance {
 			$extra
 		);
 		$context = new Context($rl, new FauxRequest($query));
-		ob_start();
-		$rl->respond($context);
-		return ob_get_clean();
+		return ModuleRenderer::render($rl, $context);
 	}
 }
 

--- a/maintenance/buildStyles.php
+++ b/maintenance/buildStyles.php
@@ -54,9 +54,7 @@ class BuildStyles extends Maintenance {
 				new FauxRequest($query)
 			);
 
-			ob_start();
-			$resourceLoader->respond($context);
-			$text = ob_get_clean();
+			$text = ModuleRenderer::render($resourceLoader, $context);
 
 			if (file_put_contents($filename, $text, LOCK_EX) === false) {
 				wfDebug(__METHOD__ . '() failed saving ' . $filename);
@@ -81,9 +79,7 @@ class BuildStyles extends Maintenance {
 			'styles'
 		);
 		$context = new Context($resourceLoader, new FauxRequest($query));
-		ob_start();
-		$resourceLoader->respond($context);
-		$siteStyles = ob_get_clean();
+		$siteStyles = ModuleRenderer::render($resourceLoader, $context);
 		if (trim($siteStyles) !== '') {
 			file_put_contents("$cssDir/site.styles.css", $siteStyles, LOCK_EX);
 		}

--- a/tests/phpunit/integration/ModuleRendererTest.php
+++ b/tests/phpunit/integration/ModuleRendererTest.php
@@ -18,6 +18,18 @@ use RuntimeException;
  * @covers \MediaWiki\Extension\Wikven\ModuleRenderer
  */
 class ModuleRendererTest extends MediaWikiIntegrationTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		// Hooks\Main's constructor reads WikvenHtmlDirectory, which WikvenSettings.php defines for
+		// a build but extension.json does not declare, so a bare wfLoadExtension() wiki (what the
+		// phpunit job installs) throws from every GetLocalURL hook -- including the ones
+		// ResourceLoader runs while calculating module versions. respond() catches that and dumps
+		// the backtrace into the response body, which is precisely the debris this class asserts
+		// render() no longer produces; give the wiki the value so the comparison is between two
+		// healthy responses rather than against error output.
+		$this->setMwGlobals('wgWikvenHtmlDirectory', $this->getNewTempDirectory());
+	}
+
 	/** Every response shape the build dumps, as (modules, only, extra query) for makeLoaderQuery. */
 	public static function provideResponseShapes(): array {
 		return [
@@ -139,10 +151,16 @@ class ModuleRendererTest extends MediaWikiIntegrationTestCase {
 		$this->assertNotSame([], $warnings, 'respond() is what used to warn');
 	}
 
-	/** A module that cannot be built must stop the build, not be dumped as a broken file. */
+	/**
+	 * The one place the two paths are meant to differ, pinned on purpose.
+	 *
+	 * A module that throws is caught by makeModuleResponse(), which logs it and leaves an "error"
+	 * load state. respond() then writes the exception text and its backtrace into the response --
+	 * so the build used to dump a CSS or JS asset with a stack trace inside it and carry on.
+	 * render() stops instead.
+	 */
 	public function testRenderThrowsOnAModuleThatCannotBeBuilt() {
 		$rl = $this->getServiceContainer()->getResourceLoader();
-		// makeModuleResponse() catches this, logs it and leaves an "error" load state in the body.
 		$rl->register('wikven.test.broken', [
 			'factory' => static function () {
 				return new class extends FileModule {
@@ -161,6 +179,14 @@ class ModuleRendererTest extends MediaWikiIntegrationTestCase {
 			null,
 			Context::DEBUG_OFF,
 			null
+		);
+
+		// What the build used to write to disk.
+		$dumped = $this->viaRespond($rl, new Context($rl, new FauxRequest($query)));
+		$this->assertStringContainsString(
+			'this module cannot be built',
+			$dumped,
+			'respond() puts the exception in the response body'
 		);
 
 		$this->expectException(RuntimeException::class);

--- a/tests/phpunit/integration/ModuleRendererTest.php
+++ b/tests/phpunit/integration/ModuleRendererTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\ModuleRenderer;
+use MediaWiki\Request\FauxRequest;
+use MediaWiki\ResourceLoader\Context;
+use MediaWiki\ResourceLoader\FileModule;
+use MediaWiki\ResourceLoader\ResourceLoader;
+use MediaWikiIntegrationTestCase;
+use RuntimeException;
+
+/**
+ * ResourceLoader reads module versions, dependencies and message blobs from the database, and
+ * both paths under test here refuse to make up an answer when it is unreachable.
+ *
+ * @group Database
+ * @covers \MediaWiki\Extension\Wikven\ModuleRenderer
+ */
+class ModuleRendererTest extends MediaWikiIntegrationTestCase {
+	/** Every response shape the build dumps, as (modules, only, extra query) for makeLoaderQuery. */
+	public static function provideResponseShapes(): array {
+		return [
+			'styles' => [['mediawiki.skinning.interface'], 'styles', []],
+			// An ImageModule: its CSS is what carries the load.php image= url()s.
+			'styles of an image module' => [['oojs-ui.styles.icons-editing-core'], 'styles', []],
+			// A WikiModule, empty on a fresh wiki: the site.styles file buildStyles renders.
+			'styles of a wiki module' => [['site.styles'], 'styles', []],
+			'styles of an unregistered module' => [['wikven.test.absent'], 'styles', []],
+			'no modules' => [[], 'styles', []],
+			'raw startup' => [['startup'], 'scripts', ['raw' => '1']],
+			'combined bundle' => [['jquery', 'mediawiki.base', 'mediawiki.util'], null, []],
+			'combined, unregistered module' => [['wikven.test.absent'], null, []]
+		];
+	}
+
+	/**
+	 * The build swapped ResourceLoader::respond() (load.php's entry point, which emits HTTP
+	 * headers) for ModuleRenderer::render(). Everything the static site serves is one of these
+	 * responses, so the two must produce the same bytes for every shape the build dumps -- a
+	 * quieter bake that changes the CSS or JS would be worse than the noise it removes.
+	 *
+	 * @dataProvider provideResponseShapes
+	 */
+	public function testRenderMatchesRespond(array $modules, ?string $only, array $extra) {
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		$query = ResourceLoader::makeLoaderQuery(
+			$modules,
+			'en',
+			'fallback',
+			null,
+			null,
+			Context::DEBUG_OFF,
+			$only,
+			false,
+			null,
+			$extra
+		);
+
+		$expected = $this->viaRespond($rl, new Context($rl, new FauxRequest($query)));
+		$actual = ModuleRenderer::render($rl, new Context($rl, new FauxRequest($query)));
+
+		$this->assertSame(strlen($expected), strlen($actual), 'response length');
+		$this->assertSame(sha1($expected), sha1($actual), 'response bytes');
+	}
+
+	/** The image endpoint is the other response the build dumps, via AssetLocalizer. */
+	public function testRenderMatchesRespondForImages() {
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		$query = [
+			'modules' => 'oojs-ui.styles.icons-editing-core',
+			'image' => 'edit',
+			'format' => 'original',
+			'lang' => 'en',
+			'skin' => 'fallback'
+		];
+		if (!( new Context($rl, new FauxRequest($query)) )->getImageObj()) {
+			$this->markTestSkipped('this MediaWiki has no oojs-ui "edit" icon to render');
+		}
+
+		$expected = $this->viaRespond($rl, new Context($rl, new FauxRequest($query)));
+		$actual = ModuleRenderer::render($rl, new Context($rl, new FauxRequest($query)));
+
+		$this->assertStringContainsString('<svg', $actual, 'an image was rendered');
+		$this->assertSame(sha1($expected), sha1($actual), 'image bytes');
+	}
+
+	/**
+	 * The point of the change: respond() calls header() for Content-Type, ETag, Cache-Control and
+	 * Expires, which warns once per call under a maintenance script that has already written to
+	 * stdout. render() must not reach any of them.
+	 */
+	public function testRenderSendsNoHeaders() {
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		$query = ResourceLoader::makeLoaderQuery(
+			['mediawiki.skinning.interface'],
+			'en',
+			'fallback',
+			null,
+			null,
+			Context::DEBUG_OFF,
+			'styles'
+		);
+
+		$warnings = [];
+		$collect = static function (int $no, string $message) use (&$warnings): bool {
+			$warnings[] = $message;
+			return true;
+		};
+
+		ob_start();
+		set_error_handler($collect, E_WARNING);
+		try {
+			$body = ModuleRenderer::render($rl, new Context($rl, new FauxRequest($query)));
+		} finally {
+			restore_error_handler();
+			$printed = (string)ob_get_clean();
+		}
+		// respond() writes the response to the output stream on its way to sending headers;
+		// render() only returns it, which is what keeps it away from header().
+		$this->assertSame('', $printed, 'nothing written to the output stream');
+		$this->assertNotSame('', $body, 'the response came back as a return value');
+		$this->assertSame([], $warnings, 'no PHP warning raised while rendering');
+
+		// Under PHPUnit the response is buffered, so header() has nothing to complain about and
+		// the check above cannot tell a fixed call from a lucky one. Where output has really been
+		// flushed -- a bake, which is the reported case -- respond() warns and render() does not.
+		if (!headers_sent()) {
+			return;
+		}
+		set_error_handler($collect, E_WARNING);
+		try {
+			ob_start();
+			$rl->respond(new Context($rl, new FauxRequest($query)));
+			ob_end_clean();
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertNotSame([], $warnings, 'respond() is what used to warn');
+	}
+
+	/** A module that cannot be built must stop the build, not be dumped as a broken file. */
+	public function testRenderThrowsOnAModuleThatCannotBeBuilt() {
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		// makeModuleResponse() catches this, logs it and leaves an "error" load state in the body.
+		$rl->register('wikven.test.broken', [
+			'factory' => static function () {
+				return new class extends FileModule {
+					/** @inheritDoc */
+					public function getModuleContent(Context $context): array {
+						throw new RuntimeException('this module cannot be built');
+					}
+				};
+			}
+		]);
+		$query = ResourceLoader::makeLoaderQuery(
+			['wikven.test.broken'],
+			'en',
+			'fallback',
+			null,
+			null,
+			Context::DEBUG_OFF,
+			null
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('wikven.test.broken');
+		ModuleRenderer::render($rl, new Context($rl, new FauxRequest($query)));
+	}
+
+	/** Private modules carry per-user data; respond() refuses them and so must the dump. */
+	public function testRenderRefusesPrivateModules() {
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		$rl->register('wikven.test.private', [
+			'class' => FileModule::class,
+			'group' => 'private'
+		]);
+		$query = ResourceLoader::makeLoaderQuery(
+			['wikven.test.private'],
+			'en',
+			'fallback',
+			null,
+			null,
+			Context::DEBUG_OFF,
+			null
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('wikven.test.private');
+		ModuleRenderer::render($rl, new Context($rl, new FauxRequest($query)));
+	}
+
+	/**
+	 * respond() writes its response to stdout; capture it the way the build used to.
+	 * The header() warnings it raises here are the very thing under test, so swallow those
+	 * (and only those) rather than let them fail the comparison.
+	 */
+	private function viaRespond(ResourceLoader $rl, Context $context): string {
+		set_error_handler(static function (int $no, string $message): bool {
+			return str_contains($message, 'Cannot modify header information');
+		}, E_WARNING);
+		try {
+			ob_start();
+			$rl->respond($context);
+			return (string)ob_get_clean();
+		} finally {
+			restore_error_handler();
+		}
+	}
+}


### PR DESCRIPTION
Fixes #240

## The cause, confirmed

Reproduced against a real MediaWiki `REL1_46` + SQLite install driving `buildStyles.php` and `buildScripts.php` as child maintenance scripts (i.e. after `Maintenance::output()` has written to stdout, exactly as `build.php` does): **442 warnings**, at the same lines the issue reports.

```
Warning: Cannot modify header information - headers already sent by
(output started at .../maintenance/includes/Maintenance.php:499)
in .../includes/ResourceLoader/ResourceLoader.php on line 854
```

| source | count |
| --- | --- |
| `ResourceLoader.php` 842 / 853 / 854 (`ETag`, `Cache-Control`, `Expires`) | 76 each |
| `Image.php` 323 / 324 / 326 (`Content-Type`, `Content-Disposition`, `Access-Control-Allow-Origin`) | 60 each |
| `ResourceLoader.php` 835 / 836 (styles `Content-Type`, CORS) | 12 each |
| `ResourceLoader.php` 858 (`SourceMap` extra header) | 6 |
| `ResourceLoader.php` 838 (JS `Content-Type`) | 4 |

All of them come from one place: `ResourceLoader::sendResponseHeaders()`, which `respond()` calls before echoing the body. `respond()` is `load.php`'s web entry point. The build drove it from three call sites — `buildStyles.php` (per-module CSS + `site.styles`), `buildScripts.php` (`startup` and the combined bundle), and `AssetLocalizer::dumpRlImage()` (the `load.php?…image=` endpoint, which is the `Image.php` group above).

The issue's suggested output buffering was already there — `ob_start()` / `ob_get_clean()` wrapped every one of those calls. It cannot work: `ob_start()` captures output, it does not un-send headers, so `headers_sent()` stays true and every `header()` still warns.

## The fix

Render through `ResourceLoader::makeModuleResponse()` — core's own way to get a module body with no response around it, which is what `ClientHtml::makeLoad()` uses to embed a module in a page. A new `ModuleRenderer::render()` wraps it and adds back the parts of `respond()` that shape the *body* rather than the response:

- split the requested names into registered modules and missing ones (`respond()` does this before generating; `makeModuleResponse()` reports missing ones itself);
- `preloadModuleInfo()`, the batch version/message-blob load;
- the "Problematic modules" comment `respond()` prefixes to a **styles** response for names that are not registered — kept only so a broken build's output stays what it was.

Both `Image.php` and `ResourceLoader.php` warnings have the same answer: `Image::sendResponseHeaders()` is only ever reached from `sendResponseHeaders()`, so not calling `respond()` removes both groups. Nothing is suppressed — no `error_reporting()` change, no `@`, no stderr redirection.

**Errors get louder, not quieter.** `makeModuleResponse()` catches a throwing module, logs it and leaves an `"error"` load state; `respond()` would additionally have written the exception text into the dumped CSS/JS file, where nothing reads it. `ModuleRenderer` watches ResourceLoader's logger for exactly that (a warning-or-worse record carrying an exception, which is what `outputErrorAndLog()` emits) and throws, failing the build. A failure from `preloadModuleInfo()` is likewise allowed to escape instead of becoming a comment, and a private module is refused rather than dumped.

## Effect on the bake log

`build-and-check` is the same job on both branches, so its log length is directly comparable:

| commit | branch | `build-and-check` log lines |
| --- | --- | --- |
| `2ac2cce` | main | 3659 |
| `6f85fe6` | main | 3929 |
| `40ec624` | this PR | 2845 |
| `cc5e1b4` | this PR | 2822 |

About 1100 lines of warning spam gone from a green run.

## Proof the output is unchanged

Against a real `REL1_46` install (MediaWiki + Vector + Wikven, SQLite), running the two dump steps back to back on the same database — once with this branch's code, once with `main`'s — and diffing `dist/`. 5 CSS files (including Vector's 87 KB sheet, an OOUI icon module and a non-empty `site.styles` from a real `MediaWiki:Common.css`), a 988 KB combined JS bundle, `startup-static.js`, and the 6 SVGs `AssetLocalizer` dumps from the `load.php` image endpoint:

```
diff -r main-dist pr-dist       → no differences
sha256sum over all 16 files     → identical
warnings                        → 442 (main) → 0 (this branch)
```

The useful lines are untouched: `Wikven: …` and `Wrote startup-static.js and modules-static.js (34 modules)` still print.

Response by response, a harness rendered the same context both ways and compared bytes, covering every shape the build dumps:

```
styles: vector                SAME  bytes=87453   warnings: respond=5 renderer=0
styles: icons (ImageModule)   SAME  bytes=14421   warnings: respond=5 renderer=0
styles: wiki module           SAME  bytes=0       warnings: respond=5 renderer=0
styles: extension module      SAME  bytes=618     warnings: respond=5 renderer=0
styles: unregistered module   SAME  bytes=56      warnings: respond=5 renderer=0
styles: none requested        SAME  bytes=196     warnings: respond=5 renderer=0
scripts: startup raw          SAME  bytes=33593   warnings: respond=5 renderer=0
combined: bundle              SAME  bytes=360369  warnings: respond=5 renderer=0
combined: unregistered module SAME  bytes=46      warnings: respond=5 renderer=0
image: oojs-ui edit icon      SAME  bytes=269     warnings: respond=6 renderer=0
```

**Scope of that claim.** Module *bodies* are byte-identical. Comparing the deployed preview against `main` also shows three module *version hashes* moving (`site.styles`, `mediawiki.languageselector.core`, `ext.gadget.PersistTabber`) — that is pre-existing per-build nondeterminism, measured here and filed as #260, not introduced by this change. It reproduces on unmodified `main` code, and it moved again between two consecutive bakes of this same branch.

## Two things the first CI run turned up

**1. `startup` differed by 11 KB under phpunit — that was respond()'s error debris, not a registry difference.**

Reproduced locally by removing `$wgWikvenHtmlDirectory`, which is what the phpunit job's wiki has (it loads Wikven with `wfLoadExtension()` alone). `Hooks\Main::__construct()` reads that option, `extension.json` does not declare it, so every `GetLocalURL` hook throws — including the ones ResourceLoader runs while calculating module versions.

```
respond() = 43635 bytes,  render() = 33603 bytes
cmp: render() output is byte-for-byte the FIRST 33603 bytes of respond()'s
```

So no module is dropped and no registry payload differs — the registry sits inside the shared prefix, and the two paths agree on it exactly. The extra 10032 bytes are the tail:

```
/*
MediaWiki\Config\ConfigException: … undefined option: 'WikvenHtmlDirectory'
Backtrace:
#0 …/includes/Hooks/Main.php(28): MediaWiki\Config\GlobalVarConfig->get()
… 25 frames …
*/
if (window.console && console.error) { console.error("…same text, JSON-encoded…"); }
```

That is `respond()` appending its error list to a scripts response — the same text twice, once as a comment and once JSON-encoded. With the option defined, both paths produce 33548 bytes and `cmp` reports them identical.

Running `render()` **first** (so no version hash is cached yet) makes it *throw* the `ConfigException` rather than return a body — the intended fail-loudly behaviour. In the failing test it stayed quiet only because `respond()` ran first and cached the failed hash.

The fix is to the test environment, not the assertion: `setUp()` gives the test wiki the config value a build has, so the byte comparison is between two healthy responses. Verified by negative control — with that line removed the CI failure reproduces locally (33603 vs 46975), with it the whole suite passes in a wiki that has no `WikvenHtmlDirectory`. The divergence is then pinned deliberately: `testRenderThrowsOnAModuleThatCannotBeBuilt` asserts both that `respond()` puts the exception into the body it would have dumped and that `render()` throws.

The undeclared `WikvenHtmlDirectory` is a pre-existing gap, not introduced here — filed as #261.

**2. phan: `$body` possibly undeclared.** It was assigned inside a `try` and used after the `finally`. Returning from inside the `try` fixes it and restores the previous logger on every exit path.

## Tests

`tests/phpunit/integration/ModuleRendererTest.php` keeps the byte comparison running in CI: every response shape through both `respond()` and `ModuleRenderer::render()`, the image endpoint, that rendering writes nothing to the output stream and raises no warning, that a module which cannot be built throws where `respond()` would have dumped its backtrace, and that a private module is refused. Extension suite: **149 tests, 219 assertions, OK**.

## What was rejected

- **Wrapping the render in `ob_start()`** (the issue's first suggestion) — already present, and structurally cannot help.
- **A scoped `set_error_handler()` swallowing the `headers already sent` warning** — suppresses the symptom while the build keeps calling a web entry point from CLI.
- **Reproducing `respond()`'s error-comment embedding** for module-generation failures — that is how those failures stayed invisible; throwing is better.
- **Relaxing the byte-equality assertion** to make the `startup` case pass — the divergence was environmental, and the assertion is the point of the test.

## Verified / not verified

Verified: warning count, byte-identical `dist/` against `main`'s code on the same database, per-response equality, PHPUnit (including in a wiki without `WikvenHtmlDirectory`), `mago format --check`, `mago lint`, `phpcs`, `minus-x`.

Not verified locally: Docker is unavailable here, so no full `docker run … wikven` bake, and phan needs `ext-ast` which this environment lacks — both covered by CI, both green.