### PR TITLE
fix: declare the build's directory settings in extension.json

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -67,6 +67,14 @@
 			"value": "Version",
 			"description": "Title of an auto-generated page (mirroring Special:Version) listing the installed software, extensions and skins, linked from the footer. Empty disables it; a same-named source page takes precedence."
 		},
+		"WikvenSourceDirectory": {
+			"value": "",
+			"description": "Absolute path to the directory the build reads pages and images from. Set by WikvenSettings.php from WIKVEN_WORKDIR; empty means no source directory, which is what a wiki running the extension outside a build has."
+		},
+		"WikvenHtmlDirectory": {
+			"value": "",
+			"description": "Absolute path to the directory the build writes the static site to. Set by WikvenSettings.php from WIKVEN_WORKDIR (per-skin passes point it at a subdirectory); empty means nothing is written, which is what a wiki running the extension outside a build has."
+		},
 		"WikvenStyleDirectory": {
 			"value": ".",
 			"description": "Relative path to the dist directory of CSS files, under the WIKVEN_WORKDIR output directory."

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -160,7 +160,8 @@ class Main implements
 	}
 
 	private function addStyleToList(string $name): void {
-		if (MW_ENTRY_POINT !== 'cli') {
+		// Empty outside a build: there is no static site to place the file in.
+		if (MW_ENTRY_POINT !== 'cli' || $this->htmlDirectory === '') {
 			return;
 		}
 

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -10,15 +10,20 @@ use MediaWikiIntegrationTestCase;
  * @covers \MediaWiki\Extension\Wikven\Hooks\Main
  */
 class MainTest extends MediaWikiIntegrationTestCase {
-	protected function setUp(): void {
-		parent::setUp();
-		// Read by Main's constructor; not set outside a build.
-		$this->overrideConfigValue('WikvenHtmlDirectory', $this->getNewTempDirectory());
-		$this->overrideConfigValue('WikvenStyleDirectory', '.');
-	}
-
 	private function main(): Main {
 		return new Main($this->getServiceContainer()->getMainConfig());
+	}
+
+	/**
+	 * The handler is constructible on a wiki that only ran wfLoadExtension(), without the
+	 * build's WikvenSettings.php: the directories it reads are declared in extension.json,
+	 * and default to empty, meaning "no static site to write".
+	 */
+	public function testConstructibleWithoutBuildSettings() {
+		$config = $this->getServiceContainer()->getMainConfig();
+		$this->assertSame('', $config->get('WikvenHtmlDirectory'));
+		$this->assertSame('', $config->get('WikvenSourceDirectory'));
+		$this->main();
 	}
 
 	/**

--- a/tests/phpunit/integration/ModuleRendererTest.php
+++ b/tests/phpunit/integration/ModuleRendererTest.php
@@ -18,18 +18,6 @@ use RuntimeException;
  * @covers \MediaWiki\Extension\Wikven\ModuleRenderer
  */
 class ModuleRendererTest extends MediaWikiIntegrationTestCase {
-	protected function setUp(): void {
-		parent::setUp();
-		// Hooks\Main's constructor reads WikvenHtmlDirectory, which WikvenSettings.php defines for
-		// a build but extension.json does not declare, so a bare wfLoadExtension() wiki (what the
-		// phpunit job installs) throws from every GetLocalURL hook -- including the ones
-		// ResourceLoader runs while calculating module versions. respond() catches that and dumps
-		// the backtrace into the response body, which is precisely the debris this class asserts
-		// render() no longer produces; give the wiki the value so the comparison is between two
-		// healthy responses rather than against error output.
-		$this->setMwGlobals('wgWikvenHtmlDirectory', $this->getNewTempDirectory());
-	}
-
 	/** Every response shape the build dumps, as (modules, only, extra query) for makeLoaderQuery. */
 	public static function provideResponseShapes(): array {
 		return [


### PR DESCRIPTION
Fixes #261

## The cause

`Hooks\Main::__construct()` reads `WikvenHtmlDirectory` through `MainConfig` (`includes/Hooks/Main.php:28`), but `extension.json` never declared it. The value existed only because `includes/WikvenSettings.php:19` sets `$wgWikvenHtmlDirectory` at build time. On a wiki that loads the extension with `wfLoadExtension( 'Wikven' )` alone, which is exactly what the `phpunit` job installs, the constructor throws `ConfigException` from every `GetLocalURL` hook, including the ones ResourceLoader runs while calculating module versions.

Checking the rest of the settings: Wikven uses 13 `wgWikven*` globals and four were undeclared, but this is the only one that can throw. `WikvenSourceDirectory` is read only via `global` (`includes/SourceFile.php:41`), so it comes back `null` and `SourceFile::exists()` bails on the cast. `WikvenSkins` and `WikvenMainSkin` are read with `?? []` / `?? null` (`Hooks/Adder.php:23`, `Hooks/Main.php:146`, `maintenance/build.php:51`).

## The fix

Declare `WikvenHtmlDirectory` and `WikvenSourceDirectory`, both defaulting to `""`, matching what `SourceFile::exists()` already treats as "not configured".

**A real bake is unaffected.** The issue asked for the ordering to be checked before changing this, so: `ExtensionRegistry::exportExtractedData()` sets the `extension.json` value only when the global is absent; when it exists and either side is not an array, "the global value will simply override the default" (`includes/Registration/ExtensionRegistry.php:514-517` on REL1_46). `wfLoadExtension()` only queues, and `Setup.php:280` drains that queue after `LocalSettings.php` has finished, so the `WIKVEN_WORKDIR`-derived assignments at `WikvenSettings.php:19` and `:177` are already in `$GLOBALS` and keep winning. Verified against both REL1_45.3 and REL1_46.0; the code is identical in the two.

`Main::addStyleToList()` needed one guard. With an empty directory it built `'' . '/' . '.'` = `/.` and ran `mkdir`/`touch` there. That path is gated on `MW_ENTRY_POINT === 'cli'`, which phpunit defines (`tests/phpunit/bootstrap.common.php:10` on REL1_46), so without the guard the tests would trade a caught exception for a permission error at the filesystem root.

## Tests

`MainTest` and `ModuleRendererTest` both worked around the missing setting in `setUp()`; both workarounds are gone. `MainTest` now constructs the handler straight from `MainConfig` with no overrides, which is the regression test: on `main` that constructor throws. `testConstructibleWithoutBuildSettings` states the contract explicitly.

## Not in this PR

Declaring these means `SiteConfig::lint()` (fed the `extension.json` config keys at `WikvenSettings.php:99`) stops warning about `WikvenHtmlDirectory:` in a user's `.wikven.yaml`. Setting it there already took effect before this change, since `$wgSettings->apply()` at `WikvenSettings.php:142` runs after the assignment at `:19`; the warning was the only guardrail, and the already-declared `WikvenStyleDirectory` and `WikvenScriptDirectory` never had it either. Worth a separate look at whether build internals should be lint-rejected as a group, rather than widening this fix.

## Verification

Not run locally: this machine's PHP lacks `pdo_sqlite`, `gd` and `sodium`, so MediaWiki will not install. `phpcs`, `mago format --check`, `mago lint` and `biome ci` pass on the changed files; the phpunit matrix (REL1_46 and master) is left to CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
