### PR TITLE
chore(deps): bump mediawiki-codesniffer to 51.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	},
 	"require-dev": {
 		"chaotic-ground/mago-mediawiki-style": "^0.1",
-		"mediawiki/mediawiki-codesniffer": "51.0.0",
+		"mediawiki/mediawiki-codesniffer": "51.0.1",
 		"mediawiki/mediawiki-phan-config": "0.20.0",
 		"mediawiki/minus-x": "2.0.1",
 		"phpro/grumphp": "2.23.0"


### PR DESCRIPTION
CI is red on every open PR, and on `main` as of the next run, for a reason unrelated to any change: a Packagist security advisory (`PKSA-rdkp-vv9z-mjkg`) was published against `squizlabs/php_codesniffer` 3.13.5, the exact version `mediawiki/mediawiki-codesniffer` 51.0.0 pins.

`composer.lock` is not committed, so every job resolves from scratch and now refuses to install:

```
- Root composer.json requires mediawiki/mediawiki-codesniffer 51.0.0
  -> satisfiable by mediawiki/mediawiki-codesniffer[v51.0.0].
- mediawiki/mediawiki-codesniffer v51.0.0 requires squizlabs/php_codesniffer 3.13.5
  -> found squizlabs/php_codesniffer[3.13.5] but these were not loaded, because they
     are affected by security advisories ("PKSA-rdkp-vv9z-mjkg")
```

Four jobs die at `composer install` before running anything: `mago`, `phpcs`, `phan` (both matrix legs) and `composer-test`. `mago` is a required check, so nothing can merge.

## Why 51.0.1

| version | pins php_codesniffer | requires php |
| --- | --- | --- |
| v51.0.0 (current) | 3.13.5, the advisory | >= 8.2.0 |
| **v51.0.1** | **3.13.6, patched** | >= 8.2.0 |
| v52.0.0 | 3.13.6, patched | >= 8.3.0 |

A patch bump takes the fixed `php_codesniffer` and nothing else. `v52.0.0` would raise the PHP floor to 8.3, which the quibble jobs pick their image around (`quibble-bookworm-php83` is chosen so "wikven's dev deps (>= 8.2)" resolve), so it is a larger change than this needs to be.

## Verification

Locally, with the bump applied:

- `composer update` resolves, taking `squizlabs/php_codesniffer 3.13.5 => 3.13.6` and `mediawiki-codesniffer v51.0.0 => v51.0.1`, and reports `No security vulnerability advisories found` (it reported one before).
- `composer phpcs` passes on all 45 files, so 51.0.1 brings no new sniff findings.

## Note

The underlying fragility is that `composer.lock` is gitignored, so CI re-resolves on every run and a new advisory against any pinned transitive dependency breaks all jobs at once, with no warning and no relation to the PR under test. Committing the lock would make these breakages explicit and schedulable (Dependabot already groups composer updates weekly). Out of scope here; worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
