### PR TITLE
chore(tf): require the quibble checks on the default branch

### DIFF
--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -46,7 +46,8 @@ resource "github_repository_ruleset" "default" {
       required_review_thread_resolution = false
     }
 
-    # Required: Lint jobs + semantic-pull-request (integration_id 15368 = GitHub Actions app).
+    # Required: lint jobs, semantic-pull-request and the quibble jobs, which are the ones that
+    # run the extension against a real MediaWiki (integration_id 15368 = GitHub Actions app).
     required_status_checks {
       do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
@@ -54,7 +55,11 @@ resource "github_repository_ruleset" "default" {
       dynamic "required_check" {
         for_each = [
           "biome",
+          "composer-test",
+          "coverage",
           "mago",
+          "phan (REL1_46)",
+          "phan (master)",
           "rumdl",
           "semantic-pull-request",
           "taplo",


### PR DESCRIPTION
The ruleset required eight contexts: `biome`, `mago`, `rumdl`, `semantic-pull-request`, `taplo`, `typos`, `yamllint`, `zizmor`. All of them are linters. Nothing that actually runs the extension against a MediaWiki could block a merge.

That is not theoretical. #262 merged at 06:47:08 the moment its eight required checks went green, while `phan (REL1_46)`, `phan (master)`, `composer-test`, `coverage` and `build-and-check` were all still running. Earlier the same hour, `phan` (both legs) and `composer-test` sat red for half an hour under the `php_codesniffer` advisory (#263) without holding anything back; only `mago` did, and only because a linter happened to share the broken `composer install` step.

## The change

Adds the four contexts that `quibble.yml` produces:

```
composer-test
coverage
phan (REL1_46)
phan (master)
```

Names are the contexts GitHub actually reports, matrix legs included, taken from `gh pr checks` output on #262 and #263 rather than guessed from the workflow file.

## Worth a second opinion

- **`coverage`** is the debatable one. It is a quibble job, so it is in by the letter of "the quibble checks", but it uploads to Codecov, which means an outage at a third party can block `main`. Say the word and I will drop it. The separate `codecov/patch` context is deliberately not included: it is posted by the Codecov app, not the Actions app, so it would need a different `integration_id` and carries the same external-dependency question more sharply.
- **Still not required**, and outside what was asked: `phpunit (REL1_46)`, `phpunit (master)`, `phpcs`, `build`, `build-and-check`, `caddy`, `preview`. `phpunit` in particular is the job that verified #262's fix, and it is currently advisory only. Worth deciding as a group rather than one at a time.
- `ruleset.tf:37` says "Merge commits are the only allowed merge method", but `repository.tf` sets `allow_merge_commit = false` and `allow_squash_merge = true`. The comment is stale and the justification it gives for `required_linear_history = false` no longer holds, since squash-only merges are always linear. Left alone here rather than folded into this change.

## Applying

`tofu fmt -check` and `tofu validate` both pass locally. The Tofu workflow runs on `.tf/**`, so the plan for this lands on the PR; the ruleset only changes once that is applied, which #235 tracks as a manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
