### PR TITLE
fix(tf): skip the vulnerability-alerts import when the resource is absent

### DIFF
--- a/.tf/vulnerability_alert.tf
+++ b/.tf/vulnerability_alert.tf
@@ -1,6 +1,8 @@
+# Skip the import too when the resource is absent; an import block with no target fails the plan.
 import {
-  id = "wikven"
-  to = github_repository_vulnerability_alerts.this[0]
+  for_each = var.github_actions ? {} : { alerts = 0 }
+  id       = "wikven"
+  to       = github_repository_vulnerability_alerts.this[each.value]
 }
 resource "github_repository_vulnerability_alerts" "this" {
   count = var.github_actions ? 0 : 1


### PR DESCRIPTION
The Tofu workflow has failed on every run since `694874c` ("chore(tf): Split resources", 3 days ago). No plan has been posted on a PR and no drift issue has been filed since. I hit it on #264, which is the first `.tf` change since.

## The cause

`vulnerability_alert.tf` gates the resource on `var.github_actions`, since CI's token cannot manage vulnerability alerts, but its `import` block is unconditional:

```hcl
import {
  id = "wikven"
  to = github_repository_vulnerability_alerts.this[0]   # always
}
resource "github_repository_vulnerability_alerts" "this" {
  count = var.github_actions ? 0 : 1                    # zero under CI
}
```

The workflow sets `TF_VAR_github_actions: true`, so `count` is 0, `this[0]` does not exist, and the plan aborts:

```
Error: Configuration for import target does not exist

The configuration for the given import
github_repository_vulnerability_alerts.this[0] does not exist. All target
instances must have an associated configuration to be imported.
```

## The fix

Put the same condition on the import block with `for_each`, so it disappears alongside the resource. A `tuple`/`list(number)` is rejected there (`for_each` wants a map or set of strings), hence the small map.

## Verification

Reproduced and verified against the real repository with a clean state, which is what CI has on a fresh checkout:

| `var.github_actions` | before | after |
| --- | --- | --- |
| `true` (CI) | plan aborts with the error above | `3 to import, 0 to add, 1 to change, 0 to destroy` |
| `false` (local PAT, the path applies run on) | plan aborts with the error above | `4 to import, 0 to add, 0 to change, 0 to destroy` |

Two things worth stating plainly about those numbers:

- **Nothing is destroyed on either path.** An early local run of mine did show the alerts resource being destroyed, but that was an artifact of a stale `terraform.tfstate` left in a working directory; with the clean state CI actually uses, the resource is simply unmanaged when `github_actions = true`, which is the existing design for every CI-gated block here.
- The `1 to change` under CI is the `bypass_actors` block, which `var.github_actions` deliberately omits from the config while it exists on the real ruleset. That is pre-existing, shows up on `main` too, and CI does not apply.

On the local path the plan is `0 to change`, so the repository currently matches the config as written.

## Order

#264 (requiring the quibble checks) needs this first, otherwise its own `plan` job cannot report. Once this lands I will rebase #264 so its plan is visible for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
