### PR TITLE
chore(tf): require the phpunit checks on the default branch

### DIFF
--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -46,8 +46,8 @@ resource "github_repository_ruleset" "default" {
       required_review_thread_resolution = false
     }
 
-    # Required: lint jobs, semantic-pull-request and the quibble jobs, which are the ones that
-    # run the extension against a real MediaWiki (integration_id 15368 = GitHub Actions app).
+    # Required: lint jobs, semantic-pull-request, and every job that runs the extension against a
+    # real MediaWiki (integration_id 15368 = GitHub Actions app).
     required_status_checks {
       do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
@@ -60,6 +60,8 @@ resource "github_repository_ruleset" "default" {
           "mago",
           "phan (REL1_46)",
           "phan (master)",
+          "phpunit (REL1_46)",
+          "phpunit (master)",
           "rumdl",
           "semantic-pull-request",
           "taplo",


### PR DESCRIPTION
Follow-up to #264, which required the quibble jobs and left `phpunit` advisory.

`phpunit` is the odd one out. It runs the extension's own test suite against a real MediaWiki on both `REL1_46` and `master`, and it is the check that verified #262's fix, at a time when nothing was forcing it to stay green. #262 in fact merged while it was still running.

Adds both matrix legs:

```
phpunit (REL1_46)
phpunit (master)
```

The comment above the list said "the quibble jobs"; `phpunit` lives in `test.yml`, not `quibble.yml`, so it now reads as every job that runs the extension against a real MediaWiki.

## Still not required

`build`, `build-and-check`, `caddy`, `phpcs`, `preview`. `phpcs` is the notable one: it is a linter like the others in the required set, but unlike them it needs a working `composer install`, which is exactly how the advisory in #263 took it down. Worth a separate decision rather than folding in here.

`tofu fmt -check` and `tofu validate` pass; the `plan` job on this PR shows the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
