### PR TITLE
fix: keep $wgCacheEpoch out of module versions

### DIFF
--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -18,6 +18,10 @@ $wgFileCacheDirectory = $wikvenDist;
 $wgWikvenSourceDirectory = $wikvenSrc;
 $wgWikvenHtmlDirectory = $wikvenDist;
 
+// $wgCacheEpoch would otherwise follow LocalSettings.php's mtime, which the entrypoint rewrites
+// every bake, and it is a version input of any module carrying a versionCallback.
+$wgInvalidateCacheOnLocalSettingsChange = false;
+
 // A build parses every page many times over (the import, the job queue, the translated pages, one
 // pass per skin), and each parse of a page embedding a Wikimedia Commons image asks
 // commons.wikimedia.org for that image's thumbnail URL again. MediaWiki caches those lookups in


### PR DESCRIPTION
First of a stack for #260. Fixes one of the three drifting modules; the other two follow in the next PR.

## The cause

`mediawiki.languageselector.core` is not DB-backed, unlike what #260 assumes. It builds `supportedLanguages.json` as a package file with a `versionCallback` (`resources/Resources.php:150-156`):

```php
'versionCallback' => static function ( Context $context ) {
    return [ $context->getLanguage(), ...->get( 'CacheEpoch' ) ];
},
```

and `SetupDynamicConfig.php:324-327` does:

```php
if ( $wgInvalidateCacheOnLocalSettingsChange && defined( 'MW_CONFIG_FILE' ) ) {
    $wgCacheEpoch = max( $wgCacheEpoch, gmdate( 'YmdHis', @filemtime( MW_CONFIG_FILE ) ) );
}
```

`bin/entrypoint` runs the installer on every bake and appends `require_once 'WikvenSettings.php';`, so `LocalSettings.php` is always minutes old and `$wgCacheEpoch` is effectively the build clock.

A static export has no cache to invalidate: the setting exists to expire caches when an operator edits their config, and here the config is regenerated by construction. Turning it off leaves `$wgCacheEpoch` at its constant default.

## Measured

Two bakes of `docs/` through the image, clean workdir each time, dumping each module's `getDefinitionSummary()` from inside the container.

Before:

```
CacheEpoch                       20260809152034 -> 20260809152226
mediawiki.languageselector.core  2rwhd -> 1woq5   DRIFT
```

After:

```
CacheEpoch                       20030516000000 -> 20030516000000
mediawiki.languageselector.core  59043 -> 59043   STABLE
```

`startup-static.js` goes from 14 differing bytes to 10, and `modules-static.js` from 5 regions to 1. What remains is `site.styles` and `ext.gadget.PersistTabber`.

## A correction to #260

The issue attributes the drift to "revision ids and `page_touched`". The probe shows `page_latest` is **stable** across bakes for all three modules:

```
site.styles               page_latest 19 -> 19,  page_touched 20260809152040 -> 20260809152235
ext.gadget.PersistTabber  page_latest 20 -> 20,  page_touched 20260809152040 -> 20260809152235
```

So the only varying input for those two is `page_touched`, a wall clock. That makes the next PR much smaller than it would otherwise be: no need for content-based module versioning, just a stable `page_touched`.

(Revision ids of *content* pages do vary between bakes, 631 vs 629 in `index.html`. That affects the HTML, not these modules, and is recorded in #269.)

## Scope

`dist/` has more sources of churn than the module hashes: 350 of 649 files differ between two bakes, from HTML timestamps, request ids, thumbnail metadata and the pagefind index built on top of them. Those are catalogued in #269 and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
