### PR TITLE
fix: freeze page_touched so wiki-page modules hash the same every bake

### DIFF
--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -9,9 +9,11 @@ use MediaWiki\Content\ContentHandler;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleValue;
 use MediaWiki\User\User;
 use RebuildFileCache;
 use RunJobs;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 	? getenv('MW_INSTALL_PATH')
@@ -21,6 +23,9 @@ require_once "$IP/maintenance/Maintenance.php";
 
 /** Build the static site: populate the wiki, then render each enabled skin in a fresh boot. */
 class Build extends Maintenance {
+	/** The page_touched every page is frozen to, chosen only for being a constant. */
+	private const FROZEN_TOUCHED = '20000101000000';
+
 	public function __construct() {
 		parent::__construct();
 		$this->addDescription('Run the full wikven static-site build in a single process.');
@@ -55,6 +60,30 @@ class Build extends Maintenance {
 		foreach ($skins as $skin) {
 			$this->renderSkinPass($skin);
 		}
+	}
+
+	/** Freeze page_touched once content is final; wiki-page modules fold it into their version hash. */
+	private function freezePageTouched(): void {
+		$dbw = $this->getPrimaryDB();
+		$dbw->newUpdateQueryBuilder()
+			->update('page')
+			->set(['page_touched' => $dbw->timestamp(self::FROZEN_TOUCHED)])
+			->where(ISQLPlatform::ALL_ROWS)
+			->caller(__METHOD__)
+			->execute();
+
+		// The modules read page_touched through LinkCache, not the row just written: it is warmed in
+		// process while the pages render, and MediaWiki: pages are cached in the object cache too.
+		$linkCache = $this->getServiceContainer()->getLinkCache();
+		$pages = $dbw->newSelectQueryBuilder()
+			->select(['page_namespace', 'page_title'])
+			->from('page')
+			->caller(__METHOD__)
+			->fetchResultSet();
+		foreach ($pages as $page) {
+			$linkCache->invalidateTitle(new TitleValue((int)$page->page_namespace, $page->page_title));
+		}
+		$linkCache->clear();
 	}
 
 	/** Render one skin in a fresh boot by re-invoking this script with WIKVEN_BUILD_SKIN set. */
@@ -100,6 +129,8 @@ class Build extends Maintenance {
 		$this->step(RebuildFileCache::class, "$ip/maintenance/rebuildFileCache.php", ['overwrite' => true]);
 		// RebuildFileCache renders in the content language; re-render translations in their own.
 		$this->step(RetranslateChrome::class, "$own/retranslateChrome.php");
+		// Every page is rendered by now, so freezing costs no staleness; the asset dumps below read it.
+		$this->freezePageTouched();
 		$this->step(BuildStyles::class, "$own/buildStyles.php");
 		$this->step(BuildScripts::class, "$own/buildScripts.php");
 		$this->step(RewriteScripts::class, "$own/rewriteScripts.php");


### PR DESCRIPTION
Second of the stack for #260, on top of #270. Closes the issue.

## The cause, measured

`site.styles` and `ext.gadget.PersistTabber` are built from wiki pages, and `WikiModule::getDefinitionSummary()` folds `titleInfo` into the version hash. Dumping that summary from inside two bakes:

```
site.styles               page_len 2613 -> 2613, page_latest 19 -> 19, page_touched 20260809152040 -> 20260809152235
ext.gadget.PersistTabber  page_len 7165 -> 7165, page_latest 20 -> 20, page_touched 20260809152040 -> 20260809152235
```

Only `page_touched` moves. #260 supposed revision ids were also involved; they are not, for these pages. That is what keeps this fix to a single field rather than content-based module versioning.

## Two things decide where and how

**It has to happen after the pages are rendered.** My first attempt froze `page_touched` right after the job queue, before the skin passes, and I claimed in this PR that a constant in the past was the safe direction because caches would look valid rather than expired. That was backwards, and `build-and-check` caught it. Making entries look valid is exactly the problem: the build relies on `page_touched` to invalidate parser cache entries created before `buildTranslations` ran. With the freeze there, `Getting_Started.html` came out with English alone in its language bar, and the e2e test that clicks the Korean link timed out.

```
before:  <ul class="mw-pt-languages-list"><li>English</li><li><a lang="ko" …>한국어</a></li>
broken:  <ul class="mw-pt-languages-list"><li>English</li></ul>
```

So the freeze now sits inside the skin pass, after `RebuildFileCache` and `RetranslateChrome` have rendered every page, and before `BuildStyles` / `BuildScripts`, which are what read the version hashes.

**The write alone is not enough.** The modules do not read the row that was just written. The path is `WikiModule::getTitleInfo()` → `Title::getTouched()` → `PageStore::getPageByNameViaLinkCache()` → `LinkCache`, which is warm from rendering. Worse, `LinkCache::usePersistentCache()` (`LinkCache.php:533-548`) returns true for `NS_MEDIAWIKI`, and both pages here are `MediaWiki:` pages, so their rows also live in the object cache, which wikven points at `CACHE_DB` and which therefore outlives the process. The `UPDATE` changed the database while every reader kept seeing the old value. Hence `LinkCache::invalidateTitle()`, which core documents as being for exactly this ("for use by ResourceLoader Wikimodule"), plus clearing the in-process entries.

## Nothing rendered reads the field

The visible "last edited" footer takes the revision timestamp, not `page_touched` (`SkinComponentFooter::lastModified()`, `SkinComponentFooter.php:384-405`).

## Result

Two bakes of `docs/` through the image, clean workdir each time:

| | before the stack | with #270 | with this |
| --- | --- | --- | --- |
| `startup-static.js` | 14 differing bytes | 10 | **identical** |
| `modules-static.js` | 5 differing bytes | 1 | **identical** |
| `citizen/`, `timeless/` copies | differ | differ | **identical** |
| `site.styles` hash | drifts | drifts | stable |
| `ext.gadget.PersistTabber` hash | drifts | drifts | stable |
| `mediawiki.languageselector.core` hash | drifts | stable | stable |

The e2e suite was also run locally against the baked output, serving it the way the smoke job does: 13 passed, including the skin-switcher test that failed on the earlier version of this branch.

The only non-HTML output still differing between bakes is the thumbnail PNGs, carrying ImageMagick's `tIME` and `date:*` chunks. That is #269, and the next PR in this stack.

## Verification

All of the above is from real bakes in the wikven image: a probe maintenance script dumped `getVersionHash()` and `getDefinitionSummary()` at the end of each bake, `dist/` trees were compared with `cmp`, and Playwright drove the served result.

Note the image cannot currently be built without a layer cache, for the same advisory reason as #263; I worked around it locally to get these numbers. Unrelated to this change, and worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
