### PR TITLE
fix: strip the clocks ImageMagick writes into exported thumbnails

### DIFF
--- a/includes/Png.php
+++ b/includes/Png.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/** Rewrites PNG bytes for a reproducible export: drops the chunks that record a clock. */
+class Png {
+	/** The 8 bytes every PNG starts with. */
+	private const SIGNATURE = "\x89PNG\r\n\x1a\n";
+
+	/**
+	 * Return the PNG without the chunks whose payload is a timestamp.
+	 *
+	 * A thumbnail of unchanged source differs between bakes because ImageMagick stamps what it
+	 * writes: a tIME chunk, date:create/date:modify/date:timestamp text chunks, and, from the
+	 * -thumbnail operator, Thumb::MTime holding the source file's mtime. MediaWiki removes only
+	 * Thumb::URI (BitmapHandler, T108616) and offers no way to pass -strip, so the export strips
+	 * them on its way out instead.
+	 *
+	 * Only clocks are dropped. The comment naming the source file, the colour profile, the rest of
+	 * the Thumb::* family (size, dimensions, mimetype) and the image data are all kept, and
+	 * removing whole chunks leaves every remaining CRC valid.
+	 *
+	 * @param string $data Raw file contents.
+	 * @return string|null The rewritten PNG, or null if this is not a PNG whose chunks parse
+	 *   cleanly, in which case the caller should use the bytes unchanged.
+	 */
+	public static function withoutTimestamps(string $data): ?string {
+		if (!str_starts_with($data, self::SIGNATURE)) {
+			return null;
+		}
+		$total = strlen($data);
+		$offset = strlen(self::SIGNATURE);
+		$out = self::SIGNATURE;
+		// Each chunk is a 4-byte length, a 4-byte type, that many bytes of payload, and a 4-byte CRC.
+		while (( $offset + 12 ) <= $total) {
+			$size = unpack('N', substr($data, $offset, 4))[1];
+			$type = substr($data, $offset + 4, 4);
+			$end = $offset + 12 + $size;
+			if ($end > $total) {
+				return null;
+			}
+			if (!self::isTimestamp($type, substr($data, $offset + 8, $size))) {
+				$out .= substr($data, $offset, $end - $offset);
+			}
+			$offset = $end;
+			if ($type === 'IEND') {
+				// Bytes past IEND mean this is not a plain PNG; leave the file alone.
+				return $offset === $total ? $out : null;
+			}
+		}
+		return null;
+	}
+
+	/** Whether a chunk records a clock: tIME, or a text chunk keyed date:* or Thumb::MTime. */
+	private static function isTimestamp(string $type, string $payload): bool {
+		if ($type === 'tIME') {
+			return true;
+		}
+		if (!in_array($type, ['tEXt', 'zTXt', 'iTXt'], true)) {
+			return false;
+		}
+		$keyword = strstr($payload, "\0", true);
+		if (!is_string($keyword)) {
+			return false;
+		}
+		return str_starts_with($keyword, 'date:') || $keyword === 'Thumb::MTime';
+	}
+}

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -128,9 +128,20 @@ class StoreImages extends Maintenance {
 		$name = 'img-' . substr(md5($path), 0, 12) . '.' . $this->extension($path);
 		$dest = "$dir/$name";
 		if (!file_exists($dest)) {
-			copy($src, $dest);
+			$this->copyWithoutTimestamps($src, $dest);
 		}
 		return "./$name";
+	}
+
+	/** Copy a file, dropping the PNG chunks that record when it was written. */
+	private function copyWithoutTimestamps(string $src, string $dest): void {
+		$data = file_get_contents($src);
+		$stripped = $data === false ? null : Png::withoutTimestamps($data);
+		if ($stripped === null) {
+			copy($src, $dest);
+			return;
+		}
+		file_put_contents($dest, $stripped, LOCK_EX);
 	}
 
 	/**

--- a/tests/phpunit/unit/PngTest.php
+++ b/tests/phpunit/unit/PngTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\Png;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Png
+ */
+class PngTest extends MediaWikiUnitTestCase {
+	private const SIGNATURE = "\x89PNG\r\n\x1a\n";
+
+	/** Assemble a chunk the way a PNG encoder does: length, type, payload, CRC of type+payload. */
+	private function chunk(string $type, string $payload = ''): string {
+		return pack('N', strlen($payload)) . $type . $payload . pack('N', crc32($type . $payload));
+	}
+
+	/** A text chunk, whose payload is the keyword, a NUL, then the value. */
+	private function text(string $keyword, string $value): string {
+		return $this->chunk('tEXt', "$keyword\0$value");
+	}
+
+	/** A PNG carrying everything ImageMagick writes into a thumbnail, stamped at $written. */
+	private function thumbnail(string $written, string $sourceMtime): string {
+		return (
+			self::SIGNATURE
+			. $this->chunk('IHDR', str_repeat("\x01", 13))
+			. $this->chunk('tIME', pack('nC5', 2026, 8, 9, 15, 13, 28))
+			. $this->chunk('IDAT', 'not really deflate data')
+			. $this->text('comment', 'File source: File:logo.png.html')
+			. $this->text('date:create', $written)
+			. $this->text('date:modify', $written)
+			. $this->text('date:timestamp', $written)
+			. $this->text('software', 'https://imagemagick.org')
+			. $this->text('Thumb::MTime', $sourceMtime)
+			. $this->text('Thumb::Size', '6395B')
+			. $this->text('Thumb::Image::Width', '160')
+			. $this->chunk('IEND')
+		);
+	}
+
+	/**
+	 * The point of the class: the same image written at two different moments, from a source file
+	 * whose own mtime also moved, comes out as the same bytes.
+	 */
+	public function testTwoWritesOfTheSameImageBecomeIdentical() {
+		$first = $this->thumbnail('2026-08-09T15:12:08+00:00', '1786291435');
+		$second = $this->thumbnail('2026-08-09T15:15:33+00:00', '1786291559');
+		$this->assertNotSame($first, $second, 'the inputs differ to begin with');
+
+		$this->assertSame(
+			Png::withoutTimestamps($first),
+			Png::withoutTimestamps($second)
+		);
+	}
+
+	public function testClockChunksAreDropped() {
+		$stripped = Png::withoutTimestamps($this->thumbnail('2026-08-09T15:12:08+00:00', '1786291435'));
+		$this->assertStringNotContainsString('date:create', $stripped);
+		$this->assertStringNotContainsString('date:modify', $stripped);
+		$this->assertStringNotContainsString('date:timestamp', $stripped);
+		$this->assertStringNotContainsString('Thumb::MTime', $stripped);
+		$this->assertStringNotContainsString('tIME', $stripped);
+	}
+
+	/** Everything that describes the image, rather than when it was made, survives. */
+	public function testDescriptiveChunksAreKept() {
+		$stripped = Png::withoutTimestamps($this->thumbnail('2026-08-09T15:12:08+00:00', '1786291435'));
+		$this->assertStringStartsWith(self::SIGNATURE, $stripped);
+		$this->assertStringContainsString('IHDR', $stripped);
+		$this->assertStringContainsString('IDAT', $stripped);
+		$this->assertStringContainsString('File source: File:logo.png.html', $stripped);
+		$this->assertStringContainsString('software', $stripped);
+		$this->assertStringContainsString('Thumb::Size', $stripped);
+		$this->assertStringContainsString('Thumb::Image::Width', $stripped);
+		$this->assertStringEndsWith($this->chunk('IEND'), $stripped);
+	}
+
+	/** Chunks are removed whole, so the CRC of every chunk left behind still matches its bytes. */
+	public function testRemainingChunksKeepValidChecksums() {
+		$stripped = Png::withoutTimestamps($this->thumbnail('2026-08-09T15:12:08+00:00', '1786291435'));
+		$offset = strlen(self::SIGNATURE);
+		$seen = [];
+		while ($offset < strlen($stripped)) {
+			$size = unpack('N', substr($stripped, $offset, 4))[1];
+			$type = substr($stripped, $offset + 4, 4);
+			$payload = substr($stripped, $offset + 8, $size);
+			$crc = unpack('N', substr($stripped, $offset + 8 + $size, 4))[1];
+			$this->assertSame(crc32($type . $payload), $crc, "CRC of the $type chunk");
+			$seen[] = $type;
+			$offset += 12 + $size;
+		}
+		$this->assertSame(strlen($stripped), $offset, 'the chunks account for every byte');
+		$this->assertSame(['IHDR', 'IDAT', 'tEXt', 'tEXt', 'tEXt', 'tEXt', 'IEND'], $seen);
+	}
+
+	public function testStrippingIsIdempotent() {
+		$once = Png::withoutTimestamps($this->thumbnail('2026-08-09T15:12:08+00:00', '1786291435'));
+		$this->assertSame($once, Png::withoutTimestamps($once));
+	}
+
+	/** A PNG with nothing to drop is returned unchanged rather than rebuilt differently. */
+	public function testAPngWithoutTimestampsIsUnchanged() {
+		$png =
+			self::SIGNATURE
+			. $this->chunk('IHDR', str_repeat("\x01", 13))
+			. $this->chunk('IDAT', 'data')
+			. $this->chunk('IEND');
+		$this->assertSame($png, Png::withoutTimestamps($png));
+	}
+
+	/**
+	 * Anything the parser cannot account for is refused, so storeImages falls back to copying the
+	 * file as it found it rather than writing a mangled one.
+	 *
+	 * @dataProvider provideUnhandledInput
+	 */
+	public function testUnhandledInputIsRefused(string $label, string $data) {
+		$this->assertNull(Png::withoutTimestamps($data), $label);
+	}
+
+	public static function provideUnhandledInput(): array {
+		$signature = self::SIGNATURE;
+		$ihdr = pack('N', 13) . 'IHDR' . str_repeat("\x01", 13) . pack('N', 0);
+		$iend = pack('N', 0) . 'IEND' . pack('N', crc32('IEND'));
+		return [
+			'empty' => ['empty input', ''],
+			'jpeg' => ['a JPEG', "\xff\xd8\xff\xe0" . str_repeat("\x00", 64)],
+			'svg' => ['an SVG', '<svg xmlns="http://www.w3.org/2000/svg"/>'],
+			'signature only' => ['the signature alone', $signature],
+			'truncated chunk' => [
+				'a chunk shorter than its length claims',
+				$signature . pack('N', 999) . 'IDATshort'
+			],
+			'no IEND' => ['a file that never reaches IEND', $signature . $ihdr],
+			'trailing bytes' => ['bytes past IEND', $signature . $ihdr . $iend . 'extra']
+		];
+	}
+}


### PR DESCRIPTION
Third of the stack that began with #270 and #271. Those closed #260 (the module hashes); this takes the thumbnails, the first item on #269's list. After it, nothing outside the HTML differs between two bakes.

## Two kinds of timestamp, not one

#269 recorded the ImageMagick `date:*` chunks. Dropping those was not enough: the two files still differed, in a chunk the issue does not mention.

```
tEXt 23 DIFFER
   a: b'Thumb::MTime\x001786291435'
   b: b'Thumb::MTime\x001786291559'
```

`Thumb::MTime` appears nowhere in MediaWiki or the bundled extensions (`grep -rn 'Thumb::' /var/www/html` in the image finds only `BitmapHandler`). It comes from ImageMagick's `-thumbnail` operator, which writes a whole `Thumb::*` family. Core removes `Thumb::URI` to avoid leaking local paths (`BitmapHandler.php:270`, T108616) and leaves the rest. Verified by running `convert` with core's exact arguments inside the image:

```
tEXt 24 b'Thumb::Document::Pages\x001'
tEXt 24 b'Thumb::Image::Height\x00160'
tEXt 23 b'Thumb::Image::Width\x00160'
tEXt 25 b'Thumb::Mimetype\x00image/png'
tEXt 23 b'Thumb::MTime\x001782610648'
tEXt 17 b'Thumb::Size\x006395B'
```

Its value is the source file's mtime, and `importImages` uploads the image afresh on every bake, so it moves with the build. `date:modify` has the same origin.

So the full set of clocks in a thumbnail is `tIME`, `date:create`, `date:modify`, `date:timestamp` and `Thumb::MTime`.

## Where the fix goes

Core builds the ImageMagick command itself and offers no hook or setting to add `-strip`. The export therefore drops the chunks on the way out, in `storeImages`, which is where files are copied into `dist/` and is the boundary at which we own the bytes.

Only clocks are dropped. The comment naming the source page, the colour profile, the image data, and the rest of `Thumb::*` (size, dimensions, mimetype) are kept, since those follow from the image rather than from when it was made. Chunks are removed whole, so every remaining CRC stays valid without recomputation. Anything that does not parse as a plain PNG is refused and copied untouched, which covers every JPEG and SVG in the export as well as any malformed file.

The shipped thumbnail after the change:

```
IHDR, cHRM, bKGD, IDAT,
tEXt comment=File source: File:logo.png.html
tEXt software=https://imagemagick.org
tEXt Thumb::Document::Pages=1, Thumb::Image::Height=160, Thumb::Image::Width=160,
     Thumb::Mimetype=image/png, Thumb::Size=6395B
IEND
```

`file` still reports `PNG image data, 120 x 120, 8-bit/color RGBA, non-interlaced`.

## Tests

The byte parsing lives in `includes/Png` rather than inline in the maintenance script, so it is autoloaded and can be unit tested. `PngTest` covers the property that matters, that two writes of one image at different times come out identical, plus descriptive chunks surviving, checksums staying valid, idempotence, and each shape of unhandled input being refused rather than mangled (empty, JPEG, SVG, signature only, a chunk shorter than its declared length, no `IEND`, bytes past `IEND`).

## Result

Two bakes of `docs/`, clean workdir each time:

| | before this stack | now |
| --- | --- | --- |
| differing files | 350 of 649 | 300 of 638 |
| JS assets (3 skins × 2) | differ | identical (#270, #271) |
| thumbnails | 3 differ | **identical** |
| **anything outside the HTML** | 9 files | **none** |
| HTML pages | 171 | 171 |
| pagefind fragments | 170 | 129 |

Every remaining difference is an HTML page or a pagefind fragment named after one. The HTML causes are catalogued in #269 and untouched here. The e2e suite was run locally against the baked output, served as the smoke job serves it: 13 passed.

(The file count drops from 649 to 638 because the pagefind index has fewer fragments, which follows from the HTML, not from this change.)

## Verification

Real bakes in the wikven image throughout: chunk-level dumps of the shipped files, `diff -rq` over the two trees, `convert` run by hand in the container to find where `Thumb::MTime` comes from, and Playwright against the served result. The unit test's fixtures and assertions were also replicated in a standalone script and pass there, since this machine cannot run phpunit (no `pdo_sqlite`, `gd` or `sodium`, so MediaWiki will not install); the real run is left to CI.

The image still cannot be built without a layer cache, for the same advisory reason as #263; worked around locally. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
