### PR TITLE
fix: build the image when a Translate dev dependency has an advisory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,18 @@ RUN arch="$TARGETARCH" \
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ARG TRANSLATE_VERSION=REL1_46
 ARG ULS_VERSION=REL1_46
-RUN git clone --depth 1 --branch "$ULS_VERSION" \
+# Composer refuses to resolve at all when any package in the tree carries a security advisory,
+# including a require-dev one that --no-dev then never installs. Translate's dev requirements pin
+# a phpcs release that has one, which broke every build reaching this layer without a warm cache.
+# The audit still reports on what is installed; only the hard stop is off.
+RUN composer config --global policy.advisories.block false \
+ && git clone --depth 1 --branch "$ULS_VERSION" \
       https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector.git \
       /var/www/html/extensions/UniversalLanguageSelector \
  && git clone --depth 1 --branch "$TRANSLATE_VERSION" \
       https://github.com/wikimedia/mediawiki-extensions-Translate.git \
       /var/www/html/extensions/Translate \
- && composer update --no-dev --no-interaction \
+ && composer install --no-dev --no-interaction \
       --working-dir=/var/www/html/extensions/Translate
 
 COPY ./ /var/www/html/extensions/Wikven


### PR DESCRIPTION
The image has not been buildable without a warm layer cache since the advisory that caused #263. I hit it while working on #260 and worked around it locally; this is the actual fix.

## The failure

`PKSA-rdkp-vv9z-mjkg` is published against `squizlabs/php_codesniffer` 3.13.5, which Translate's `require-dev` pins through `mediawiki-codesniffer` 50.0.0. Building the committed Dockerfile with this layer cold:

```
- mediawiki/mediawiki-codesniffer v50.0.0 requires squizlabs/php_codesniffer 3.13.5
  -> found squizlabs/php_codesniffer[3.13.5] but these were not loaded, because they
     are affected by security advisories ("PKSA-rdkp-vv9z-mjkg")
```

CI is green only because `cache-from: type=gha` reuses the layer. A cache miss, an eviction, or a `TRANSLATE_VERSION` bump would take the image build, the nightly and the standalone binary down at once, for a reason unrelated to whatever change triggered it. The same advisory already broke `mago`, `phpcs`, `phan` and `composer-test`, fixed in #263.

Worth noting where else this reaches: `maintenance/fetchExtensions.php:226` runs the same `composer update --no-dev` at bake time for third-party extensions, so a user's bake can fail the same way. The global setting below covers that path too.

## What does not work

Measured, each by building the layer cold:

| attempt | result |
| --- | --- |
| `composer update --no-dev` (today) | fails |
| `composer install --no-dev` | fails |
| `composer install --no-dev --no-audit` | fails |
| `composer config --global policy.advisories.block false` + `install --no-dev` | succeeds |
| `policy.advisories.ignore` for the package + `install --no-dev` | succeeds |

`--no-dev` does not help on `update`, which resolves `require-dev` regardless. Composer says so itself: *"Running update with --no-dev does not mean require-dev is ignored"*. And `install` from the lock still fails, because the block rejects a tree that contains an advisory even for a package it is not going to install. `--no-audit` is a different thing: it suppresses the report, not the block.

## The change

**Install from Translate's committed `composer.lock`** rather than re-resolving. That is what the lock is for, it pins what upstream tested, and it suits an image whose base layers are digest-pinned. It installs exactly two packages, `composer/installers` and `mustangostang/spyc`, which is what the existing comment says this line is for.

**Turn off the advisory block.** Since `install --no-dev` alone still fails, something has to give. The audit still reports on the packages actually installed; only the hard stop goes away.

## The alternative, if you would rather keep the block

`policy.advisories.ignore` also works, naming the offending package:

```dockerfile
composer config --global --json policy.advisories.ignore '["squizlabs/php_codesniffer"]'
```

That keeps a hard failure for anything that really ships, at the cost of a Dockerfile edit each time an upstream extension's dev tooling picks up an advisory, which is what just happened twice in a week. I went with `block false` because the failure mode it removes is a false positive by construction: with `--no-dev` from a lock, dev packages are never installed. Say the word and I will switch it.

## Verification

Built the committed Dockerfile with this layer cold: succeeds, and `spyc/Spyc.php` is present in Translate's `vendor/`. A bake of `docs/` through the resulting image renders the Korean translations (`Getting_Started/ko.html`) and their language bar (`lang="ko"`), and the e2e suite passes 13/13 against the served output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
