### PR TITLE
chore: gate every pull request on the same checks

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,13 +1,15 @@
 ---
 name: Docker image
 
+# Runs on every pull request, with no path filter: this is a required check, and a required check
+# that does not report leaves the pull request unmergeable for good. Pushes to main keep skipping
+# docs-only changes, which cannot affect the image and would only republish an identical one.
 on:
   push:
     branches: [main]
-    paths-ignore: &paths-ignore
+    paths-ignore:
       - 'docs/**'
   pull_request:
-    paths-ignore: *paths-ignore
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -5,10 +5,13 @@ name: Smoke test
 # self-contained site. The unit suite covers only helper classes, so without
 # this a regression anywhere in the bake pipeline (maintenance/, AssetLocalizer,
 # hooks, Dockerfile) would produce a broken site yet pass every other gate.
+# Runs on every pull request, with no path filter: this is a required check, and a required check
+# that does not report leaves the pull request unmergeable for good. Pushes to main stay filtered,
+# since a change outside these paths cannot alter the bake.
 on:
   push:
     branches: [main]
-    paths: &paths
+    paths:
       - 'Dockerfile'
       - 'bin/entrypoint'
       - 'default.yml'
@@ -24,7 +27,6 @@ on:
       - 'playwright.config.js'
       - 'tests/e2e/**'
   pull_request:
-    paths: *paths
 
 permissions:
   contents: read

--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -55,11 +55,15 @@ resource "github_repository_ruleset" "default" {
       dynamic "required_check" {
         for_each = [
           "biome",
+          "build",
+          "build-and-check",
+          "caddy",
           "composer-test",
           "coverage",
           "mago",
           "phan (REL1_46)",
           "phan (master)",
+          "phpcs",
           "phpunit (REL1_46)",
           "phpunit (master)",
           "rumdl",


### PR DESCRIPTION
Answers "should more checks be required so `--auto` is always safe to arm". Yes, but two of them could not simply be switched on.

## Why not just add them

A required check that a path filter skips leaves the pull request unmergeable for good: GitHub keeps waiting for a report that never arrives. So the two most valuable checks were stuck as advisory, because both were filtered:

| check | filter | skipped on |
| --- | --- | --- |
| `build-and-check` (`smoke.yml`) | `paths:` Dockerfile, includes/**, maintenance/**, docs/**, tests/e2e/** … | a `.tf`-only or workflow-only change |
| `build` (`docker-build.yml`) | `paths-ignore: docs/**` | a docs-only change |

The two filters point in opposite directions, so which gates a pull request got depended on what it happened to touch.

## It already cost something

`build-and-check` is the only check that caught the first version of #271. That version froze `page_touched` before the skin passes, which disabled the parser cache invalidation the build depends on, and shipped `Getting_Started.html` with the Korean link missing from its language bar:

```
expected: <ul class="mw-pt-languages-list"><li>English</li><li><a lang="ko" …>한국어</a></li>
actual:   <ul class="mw-pt-languages-list"><li>English</li></ul>
```

Every other check was green. Had auto-merge been armed, that would have merged. Meanwhile #264 and #267 changed only `.tf` and never ran the check at all.

## The change

Drop the path filter from both `pull_request` triggers, so every pull request runs the same gates, and require four more contexts:

```
build, build-and-check, caddy, phpcs
```

`caddy` and `phpcs` were already unfiltered and could have been required at any time; they are simply the rest of the set.

Pushes to `main` keep their filters. Nothing outside `smoke.yml`'s paths can change the bake, and a docs-only change would have `docker-build` republish a byte-identical image.

Required goes from 14 contexts to 18. `preview` stays advisory, which is right: it is a deployment, and it also runs on `pull_request: closed` to clean up after itself, so it has no business gating a merge.

## Cost

About four minutes of CI on the minority of pull requests that skip these today (`build` 59s, `build-and-check` 3m28s on recent runs), both using the shared layer cache. In exchange, `--auto` is safe to arm on any pull request.

## Applying

The ruleset only changes on `tofu apply`. Sequencing matters, so I will merge this first and apply after, once `main` already has the filter-free triggers: applying earlier would deadlock a pull request whose checks were computed under the old triggers. The only pull request open now is the release-please draft, which will pick the new triggers up on its next update.

`yamllint --strict`, `tofu fmt -check` and `tofu validate` all pass; the plan for the ruleset shows on this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
