### PR TITLE
chore: stop paying twice for the same CI work

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,3 +99,19 @@ jobs:
       # mediawiki-phan-config pulls in phan (needs ext-ast); phpcs doesn't, so ignore that platform req.
       - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
       - run: composer phpcs
+
+  # "composer test" is minus-x, which checks file modes and shebangs and needs no wiki around it.
+  # It ran as a quibble stage, which spent 100 seconds booting MediaWiki to reach a check that
+  # reads the working tree. Keeping the job name keeps the required check.
+  composer-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
+        with:
+          php-version: "8.3"
+          tools: composer
+      - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
+      - run: composer test

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -52,8 +52,8 @@ jobs:
           context: .
           load: true
           tags: wikven
+          # Reader only; docker-build.yml exports this cache. See the note in smoke.yml.
           cache-from: type=gha,scope=wikven-image
-          cache-to: type=gha,mode=max,scope=wikven-image
 
       - name: Bake the docs site
         if: github.event.action != 'closed'

--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -27,19 +27,6 @@ jobs:
           # PHP 8.3 image so the container resolves wikven's dev deps (>= 8.2); phan runs in the action's testrun image.
           quibble-docker-image: quibble-bookworm-php83
 
-  composer-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: femiwiki/quibble-action@d799e5bb348756ea1588f2b5f2ca7fc09fdbdac9  # v2.0.1
-        with:
-          stage: composer-test
-          mediawiki-version: REL1_46
-          # PHP 8.3 image: wikven's dev deps (minus-x etc.) require >= 8.2.
-          quibble-docker-image: quibble-bookworm-php83
-
   coverage:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -41,7 +41,9 @@ jobs:
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
-      # Shared GHA layer cache (same scope as docker-build.yml); load locally so the bake can run it.
+      # Reads the layer cache docker-build.yml writes. Three jobs build this image per pull request;
+      # only that one exports, since concurrent mode=max writers each upload the whole cache to
+      # overwrite one another, and a reader gets the same layers either way.
       - name: Build and load the wikven image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
@@ -49,7 +51,6 @@ jobs:
           load: true
           tags: wikven
           cache-from: type=gha,scope=wikven-image
-          cache-to: type=gha,mode=max,scope=wikven-image
 
       - name: Bake the docs site
         run: |


### PR DESCRIPTION
Follow-up to #278, which made every pull request run every gate. Since they all run now, the duplication in them is worth removing.

## Where the time goes

Measured from #277's run, per pull request:

```
sum of job time : 21.7 min
wall clock      :  4.5 min
```

```
272s  build-and-check      63s  phpunit (master)
185s  coverage             43s  phpunit (REL1_46)
177s  preview              25s  phpcs
148s  phan (master)        22s  zizmor
128s  phan (REL1_46)       19s  caddy
101s  composer-test        14s  mago
 64s  build                ~6s  biome, rumdl, taplo, typos, yamllint, semantic-pull-request
```

## Two duplications, removed

**`composer-test` booted MediaWiki to run a check on the working tree.** The quibble stage exists to run `composer test`, which in this repo is `minus-x check .`: it looks at file modes and shebangs. It needs no wiki. Running it directly next to the other lint jobs takes a `composer install` instead of a container, so roughly 30s rather than 101s. The job keeps its name, so the required check keeps matching and no ruleset change is needed.

**Three jobs built the image and all three exported the layer cache.** `smoke`, `docker-build` and `pr-preview` each run `docker/build-push-action` against `scope=wikven-image`, and each had `cache-to: type=gha,mode=max`. Concurrent `mode=max` writers on one scope each upload the entire cache to overwrite one another; a reader gets the same layers regardless of who wrote last. `docker-build` keeps the export, being the workflow that publishes the image; the other two now only read.

## What is given up

One thing: wikven's `composer.json` is no longer installed inside a real MediaWiki tree. The `phpcs` job's own `composer install` covers that it installs at all, and nothing in `composer test` depends on the surroundings. Verified locally: `composer test` passes standalone (`All good!`).

Nothing else changes about what is checked. `yamllint --strict` passes over the whole workflow directory.

## What was left alone

**Wall clock, because there is little to take.** The critical path is `build-and-check` at 272s:

```
 72s  build and load the image
136s  bake the docs site
 34s  install the browser test tooling
  8s  run the tests
```

The bake is the product. The tooling install is already a considered tradeoff, per the comment in `smoke.yml`: no `setup-node` caching, because it trips the cache-poisoning audit and this job shares a build cache with the publishing workflow. I am not undoing that for 20 seconds.

**Three further candidates, each a real tradeoff rather than free:**

- `preview` (177s) repeats the image build and bake that `build-and-check` just did. Passing the `dist/` between them means restructuring two workflows into one.
- `coverage` (185s) re-runs on master the suite `phpunit (master)` (63s) already ran. Running it only on `main` would drop `codecov/patch` from pull requests.
- `build` (64s) duplicates the image build that `build-and-check` does; its own value is the publish path on `main`. Dropping it from pull requests would also mean undoing a required check added hours ago in #278.

Worth noting the whole exercise is about latency and cache churn, not money: this is a public repository, so the minutes are free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
