### PR TITLE
fix: run the job queue in a fixed order

### DIFF
--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -22,6 +22,13 @@ $wgWikvenHtmlDirectory = $wikvenDist;
 // every bake, and it is a version input of any module carrying a versionCallback.
 $wgInvalidateCacheOnLocalSettingsChange = false;
 
+// The database queue pops jobs in random order by default (JobQueueDB::optimalOrder), to spread
+// concurrent runners over different rows. A build has one runner and wants a fixed order: the jobs
+// that render translated pages create those pages, so a random order gives them different page and
+// revision ids on every bake.
+// Only the order is overridden, so the class and claimTTL core picked stay as they are.
+$GLOBALS['wgJobTypeConf']['default']['order'] = 'fifo';
+
 // A build parses every page many times over (the import, the job queue, the translated pages, one
 // pass per skin), and each parse of a page embedding a Wikimedia Commons image asks
 // commons.wikimedia.org for that image's thumbnail URL again. MediaWiki caches those lookups in

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -51,7 +51,7 @@ class Build extends Maintenance {
 		$this->dropDeadCategoryLink();
 		// Materialize content translations before RunJobs so rendered translation pages get exported.
 		$this->step(BuildTranslations::class, "$own/buildTranslations.php");
-		$this->step(RunJobs::class, "$ip/maintenance/runJobs.php");
+		$this->runJobs("$ip/maintenance/runJobs.php");
 
 		$skins = $GLOBALS['wgWikvenSkins'] ?? [];
 		if (!$skins) {
@@ -59,6 +59,23 @@ class Build extends Maintenance {
 		}
 		foreach ($skins as $skin) {
 			$this->renderSkinPass($skin);
+		}
+	}
+
+	/** Run the queue one type at a time, in name order: the runner otherwise shuffles the types. */
+	private function runJobs(string $file): void {
+		$group = $this->getServiceContainer()->getJobQueueGroup();
+		while (true) {
+			$types = $group->getQueuesWithJobs();
+			if (!$types) {
+				return;
+			}
+			sort($types);
+			foreach ($types as $type) {
+				$child = $this->createChild(RunJobs::class, $file);
+				$child->setOption('type', $type);
+				$child->execute();
+			}
 		}
 	}
 

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -224,11 +224,23 @@ class BuildTranslations extends Maintenance {
 	/** Run every queued job synchronously (the export has no background runner). */
 	private function drainJobs(): void {
 		$group = $this->getServiceContainer()->getJobQueueGroup();
-		$job = $group->pop();
-		while ($job) {
-			$job->run();
-			$group->ack($job);
-			$job = $group->pop();
+		// pop() with no type shuffles the queue types to avoid starvation, and these jobs create the
+		// translated pages, so a shuffled order hands them different page and revision ids on every
+		// bake. Drain one type at a time, in name order, until nothing is left anywhere.
+		while (true) {
+			$types = $group->getQueuesWithJobs();
+			if (!$types) {
+				return;
+			}
+			sort($types);
+			foreach ($types as $type) {
+				$job = $group->pop($type);
+				while ($job) {
+					$job->run();
+					$group->ack($job);
+					$job = $group->pop($type);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
First of a series for #269. On its own it does not make the HTML reproducible; it removes one of the reasons it is not.

## Two random orders in one queue

`JobQueueDB::optimalOrder()` returns `random`, so `doPop()` picks a row with `mt_rand` to spread concurrent runners over the table (`JobQueueDB.php:316-322`). On top of that, `JobQueueGroup::pop()` does `shuffle( $types )` "to avoid starvation" (`JobQueueGroup.php:241`). A build has a single runner and neither problem to solve.

It matters because these jobs create pages. Translate renders `<Page>/<lang>` from a job, so job order decides the page and revision ids those pages get. Dumping the `page` and `revision` tables from two bakes of identical source:

```
630 pages and 664 revisions in both, none missing from either
id 165:  a = Deploying/Page_display_title/ko    b = Deploying/en
```

Same pages, different creation order, therefore different ids. They reach the HTML through `wgArticleId`, `wgRevisionId` and the parser cache comment, which is a large part of why all 171 exported pages differ between bakes.

## The change

Ask the database queue for `fifo`, overriding only that key so the class and TTL core chose stay put. Then drain one type at a time in name order, looping until no queue has anything left, in `buildTranslations::drainJobs()` and in the build's own `runJobs` step (core's `runJobs.php` takes `--type`).

## How far it gets

Measured over two bakes each time:

| | before | after |
| --- | --- | --- |
| page id → title mismatches | 465 | **226** |
| latest-revision mismatches | 60 | **16** |
| pages, revisions | 630, 664 in both | 630, 664 in both |

Better, not solved. `Deploying/en` is still created at a varying point inside the marking loop, so something outside the queue creates it: most likely a deferred update whose flush is timing dependent rather than counted. I did not chase that further, because the ids it shuffles carry no meaning in a static export, where there is no API to ask about a revision. Neutralising them in the output is both simpler and more robust, and is the next change in this series.

Setting `fifo` is still right on its own terms: a build should not shuffle its own queue, and the churn it causes between deploys is real.

## Verification

Two bakes with a clean workdir each, page and revision tables dumped from inside the container. The bake is otherwise unchanged: 631 files, `Getting_Started/ko.html` present, its language bar carrying `lang="ko"`, and the e2e suite passing 13/13 against the served output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
