### PR TITLE
fix: make the exported HTML the same in every bake

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -22,6 +22,14 @@ inputs:
       Cache the pulled image between runs, keyed on the image ref. Set to
       "false" to always pull fresh.
     default: "true"
+  date-epoch:
+    description: >-
+      Unix time the built site should claim its content was last written, as
+      SOURCE_DATE_EPOCH (https://reproducible-builds.org/docs/source-date-epoch/).
+      Defaults to the commit date of HEAD, which makes the "last edited" dates
+      true of the commit and identical for every bake of it. Left unset if the
+      checkout has no git history, and the bake then uses a fixed date.
+    default: ""
 
 runs:
   using: composite
@@ -38,6 +46,7 @@ runs:
         OUTPUT: ${{ inputs.output }}
         IMAGE: ${{ inputs.image }}
         CACHE: ${{ inputs.cache }}
+        DATE_EPOCH: ${{ inputs.date-epoch }}
       run: |
         tar="$HOME/.cache/wikven/image.tar"
         if [ "$CACHE" = "true" ] && [ -f "$tar" ]; then
@@ -51,7 +60,17 @@ runs:
           fi
         fi
         mkdir -p "$OUTPUT"
+        # Unset unless resolved: the bake falls back to a fixed date rather than the build clock.
+        if [ -z "$DATE_EPOCH" ]; then
+          DATE_EPOCH=$(git log -1 --format=%ct 2>/dev/null || true)
+        fi
+        epoch=()
+        case "$DATE_EPOCH" in
+          '' | *[!0-9]*) ;;
+          *) epoch=(-e "SOURCE_DATE_EPOCH=$DATE_EPOCH") ;;
+        esac
         docker run --rm \
           -v "$PWD/$SOURCE:/workspace/src" \
           -v "$PWD/$OUTPUT:/workspace/dist" \
+          "${epoch[@]}" \
           "$IMAGE"

--- a/includes/BuildStamps.php
+++ b/includes/BuildStamps.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/** Removes the per-build stamps MediaWiki leaves in a rendered page. */
+class BuildStamps {
+	/**
+	 * What a page records about the request that rendered it, rather than about the page.
+	 *
+	 * Each entry is a pattern and its replacement. The ids are blanked rather than deleted, because
+	 * mw.config.get() on a missing key returns null where scripts expect a number; nothing in an
+	 * export can act on them anyway, since there is no api.php to ask about a revision. The
+	 * comments are dropped whole: they are debugging output for a live wiki, addressed to someone
+	 * reading view-source on a server they operate.
+	 */
+	private const STAMPS = [
+		// A fresh id per request, and how long that request took.
+		'/"wgRequestId":"[0-9a-f]+"/' => '"wgRequestId":""',
+		'/"wgBackendResponseTime":\d+/' => '"wgBackendResponseTime":0',
+		// Page and revision ids: stable within a bake, but not across bakes (see #269).
+		'/"wgArticleId":\d+/' => '"wgArticleId":0',
+		'/"wgRelevantArticleId":\d+/' => '"wgRelevantArticleId":0',
+		'/"wgCurRevisionId":\d+/' => '"wgCurRevisionId":0',
+		'/"wgRevisionId":\d+/' => '"wgRevisionId":0',
+		// OutputTransform\Stages\RenderDebugInfo: a uuid per render, and the parser cache's own note.
+		'/\n?<!-- Render ID [0-9a-f-]+ -->\n?/' => "\n",
+		'/\n?<!-- Saved in parser cache with key .*?-->\n?/s' => "\n",
+		// HTMLFileCache::saveToFileCache stamps the moment it wrote the file.
+		'/\n?<!-- Cached(?:\/compressed)? \d+ -->\n?/' => "\n"
+	];
+
+	/**
+	 * @param string $html A rendered page.
+	 * @return string The page with the stamps removed or blanked.
+	 */
+	public static function strip(string $html): string {
+		foreach (self::STAMPS as $pattern => $replacement) {
+			$html = preg_replace($pattern, $replacement, $html);
+		}
+		return $html;
+	}
+}

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -29,6 +29,23 @@ $wgInvalidateCacheOnLocalSettingsChange = false;
 // Only the order is overridden, so the class and claimTTL core picked stay as they are.
 $GLOBALS['wgJobTypeConf']['default']['order'] = 'fifo';
 
+// The NewPP limit report is a wall-clock measurement of the parse, so it differs between bakes.
+// It is addressed to someone debugging a live wiki, and nothing in an export can act on it.
+$wgEnableParserLimitReporting = false;
+
+// Run the whole build as of one instant. Every revision and upload is created while the build runs,
+// so with a live clock the pages report themselves as edited seconds ago, differently in each bake:
+// "last edited" lines, File: history, {{CURRENTTIMESTAMP}}, page_touched, cache stamps. Freezing the
+// clock settles all of them at the source, which is what SOURCE_DATE_EPOCH means
+// (https://reproducible-builds.org/docs/source-date-epoch/); wikven's GitHub action passes the
+// commit being built, so the dates are true of it. Without it a fixed date is used, a wrong-but-
+// fixed one being easier to live with than a wrong-and-moving one.
+$wikvenEpoch = getenv('SOURCE_DATE_EPOCH');
+$wikvenEpoch = is_string($wikvenEpoch) && preg_match('/^\d+$/', trim($wikvenEpoch))
+	? (int)trim($wikvenEpoch)
+	: 946684800;
+Wikimedia\Timestamp\ConvertibleTimestamp::setFakeTime($wikvenEpoch);
+
 // A build parses every page many times over (the import, the job queue, the translated pages, one
 // pass per skin), and each parse of a page embedding a Wikimedia Commons image asks
 // commons.wikimedia.org for that image's thumbnail URL again. MediaWiki caches those lookups in

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -23,8 +23,8 @@ require_once "$IP/maintenance/Maintenance.php";
 
 /** Build the static site: populate the wiki, then render each enabled skin in a fresh boot. */
 class Build extends Maintenance {
-	/** The page_touched every page is frozen to, chosen only for being a constant. */
-	private const FROZEN_TOUCHED = '20000101000000';
+	/** Fallback for the frozen timestamps when the caller names none; chosen only for being fixed. */
+	private const FROZEN_TIMESTAMP = '20000101000000';
 
 	public function __construct() {
 		parent::__construct();
@@ -84,7 +84,7 @@ class Build extends Maintenance {
 		$dbw = $this->getPrimaryDB();
 		$dbw->newUpdateQueryBuilder()
 			->update('page')
-			->set(['page_touched' => $dbw->timestamp(self::FROZEN_TOUCHED)])
+			->set(['page_touched' => $dbw->timestamp(self::FROZEN_TIMESTAMP)])
 			->where(ISQLPlatform::ALL_ROWS)
 			->caller(__METHOD__)
 			->execute();
@@ -146,7 +146,9 @@ class Build extends Maintenance {
 		$this->step(RebuildFileCache::class, "$ip/maintenance/rebuildFileCache.php", ['overwrite' => true]);
 		// RebuildFileCache renders in the content language; re-render translations in their own.
 		$this->step(RetranslateChrome::class, "$own/retranslateChrome.php");
-		// Every page is rendered by now, so freezing costs no staleness; the asset dumps below read it.
+		// Every page is rendered by now: drop what each one recorded about the request that made it.
+		$this->step(StripBuildStamps::class, "$own/stripBuildStamps.php");
+		// Nothing is rendered after this, so freezing costs no staleness; the asset dumps below read it.
 		$this->freezePageTouched();
 		$this->step(BuildStyles::class, "$own/buildStyles.php");
 		$this->step(BuildScripts::class, "$own/buildScripts.php");
@@ -221,6 +223,9 @@ class Build extends Maintenance {
 
 	/** Point the wiki's main page at $wgWikvenMainPage (imported later; see assertMainPageExists). */
 	private function setMainPage(): void {
+		// Whatever the installer made the main page, before the message below repoints it.
+		$installed = Title::newMainPage();
+
 		$title = Title::newFromText('MediaWiki:Mainpage');
 		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
 		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
@@ -229,6 +234,32 @@ class Build extends Maintenance {
 		$content = ContentHandler::makeContent($GLOBALS['wgWikvenMainPage'], $title);
 		$updater->setContent(SlotRecord::MAIN, $content);
 		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Set the main page'));
+
+		$this->dropInstalledMainPage($installed, $user);
+	}
+
+	/**
+	 * Delete the page the installer wrote, unless the source provides one by that name.
+	 *
+	 * It holds MediaWiki's "MediaWiki has been installed" boilerplate, which every bake was
+	 * exporting as a page of the site. It is also the one page created before wikven's settings
+	 * load, so its revision keeps the real clock and made the export differ between bakes.
+	 */
+	private function dropInstalledMainPage(Title $installed, User $user): void {
+		if (!$installed->canExist() || !$installed->exists()) {
+			return;
+		}
+		if (SourceFile::exists($installed->getPrefixedText())) {
+			return;
+		}
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($installed);
+		$status = $this->getServiceContainer()
+			->getDeletePageFactory()
+			->newDeletePage($page, $user)
+			->deleteUnsafe('Wikven: installer page, not part of the source');
+		if (!$status->isOK()) {
+			$this->output("Wikven: could not delete the installer's main page {$installed->getPrefixedText()}\n");
+		}
 	}
 
 	/** Hide about/privacy/disclaimer footer links with no imported target (blank label to "-"). */

--- a/maintenance/stripBuildStamps.php
+++ b/maintenance/stripBuildStamps.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use Maintenance;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/** Drop the request ids, render ids and timestamps MediaWiki stamps into every rendered page. */
+class StripBuildStamps extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription('Remove per-build metadata from the rendered pages.');
+	}
+
+	public function execute() {
+		global $wgWikvenHtmlDirectory;
+		$dir = rtrim((string)$wgWikvenHtmlDirectory, '/');
+		if ($dir === '' || !is_dir($dir)) {
+			return;
+		}
+
+		$changed = 0;
+		foreach (glob("$dir/*.html") as $file) {
+			$html = (string)file_get_contents($file);
+			$stripped = BuildStamps::strip($html);
+			if ($stripped !== $html) {
+				file_put_contents($file, $stripped, LOCK_EX);
+				$changed++;
+			}
+		}
+		$this->output("Stripped build stamps from $changed page(s)\n");
+	}
+}
+
+$maintClass = StripBuildStamps::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/tests/phpunit/unit/BuildStampsTest.php
+++ b/tests/phpunit/unit/BuildStampsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\BuildStamps;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\BuildStamps
+ */
+class BuildStampsTest extends MediaWikiUnitTestCase {
+	/** A page as the file cache wrote it, with every stamp a real bake produced. */
+	private function page(string $request, string $render, string $stamp, int $id, int $ms): string {
+		return (
+			"<!DOCTYPE html>\n<html><head><script>RLCONF={\"wgRequestId\":\"$request\","
+			. "\"wgPageName\":\"index\",\"wgCurRevisionId\":$id,\"wgRevisionId\":$id,"
+			. "\"wgArticleId\":75,\"wgRelevantArticleId\":75,\"wgIsArticle\":true};</script></head><body>\n"
+			. "<p>The page itself.</p>\n"
+			. "<ul id=\"footer-info\">\n\t<li id=\"footer-info-copyright\">CC BY-SA</li>\n</ul>\n"
+			. "<!-- Render ID $render -->\n"
+			. '<!-- Saved in parser cache with key my_wiki:pcache:75:|#|:idhash:canonical and '
+			. "timestamp $stamp and revision id $id. Rendering was triggered because: page_view\n -->\n"
+			. '<script>(RLQ=window.RLQ||[]).push(function(){mw.config.set('
+			. "{\"wgBackendResponseTime\":$ms,\"wgHostname\":\"runner\"});});</script>\n"
+			. "<!-- Cached $stamp -->\n</html>\n"
+		);
+	}
+
+	/** One bake's stamps, as they really came out of two runs. */
+	private function first(): string {
+		return $this->page(
+			'1f7c4e3d5fdc9ddb1edf5acc',
+			'9f9a68fb-95a6-11f1-abf7-999c0f47f1e8',
+			'20260811170350',
+			629,
+			34
+		);
+	}
+
+	private function second(): string {
+		return $this->page(
+			'4d0af69e26d7d90bc2bc9c2a',
+			'e18ba777-9404-11f1-b2fd-015fcea9a1a3',
+			'20260809151331',
+			631,
+			28
+		);
+	}
+
+	/** The property that matters: two bakes of one page come out as the same bytes. */
+	public function testTwoBakesOfOnePageBecomeIdentical() {
+		$first = $this->first();
+		$second = $this->second();
+		$this->assertNotSame($first, $second, 'the inputs differ to begin with');
+
+		$this->assertSame(BuildStamps::strip($first), BuildStamps::strip($second));
+	}
+
+	public function testTheStampsAreGone() {
+		$stripped = BuildStamps::strip($this->first());
+		$this->assertStringNotContainsString('1f7c4e3d5fdc9ddb1edf5acc', $stripped);
+		$this->assertStringNotContainsString('9f9a68fb', $stripped);
+		$this->assertStringNotContainsString('20260811170350', $stripped);
+		$this->assertStringNotContainsString('Render ID', $stripped);
+		$this->assertStringNotContainsString('Saved in parser cache', $stripped);
+		$this->assertStringNotContainsString('<!-- Cached', $stripped);
+		$this->assertStringNotContainsString(':629', $stripped);
+	}
+
+	/** The page keeps its content, its structure and the config keys scripts read. */
+	public function testThePageSurvives() {
+		$stripped = BuildStamps::strip($this->first());
+		$this->assertStringContainsString('<p>The page itself.</p>', $stripped);
+		$this->assertStringContainsString('"wgPageName":"index"', $stripped);
+		$this->assertStringContainsString('"wgIsArticle":true', $stripped);
+		$this->assertStringContainsString('"wgHostname":"runner"', $stripped);
+		$this->assertStringEndsWith("</html>\n", $stripped);
+		// Blanked, not deleted: mw.config.get() would return null for a key that is not there.
+		$this->assertStringContainsString('"wgArticleId":0', $stripped);
+		$this->assertStringContainsString('"wgCurRevisionId":0', $stripped);
+		$this->assertStringContainsString('"wgRevisionId":0', $stripped);
+		$this->assertStringContainsString('"wgRequestId":""', $stripped);
+		$this->assertStringContainsString('"wgBackendResponseTime":0', $stripped);
+		$this->assertStringContainsString('"wgRelevantArticleId":0', $stripped);
+		// The footer is not this class's business; the dates in it are frozen in the database.
+		$this->assertStringContainsString('footer-info-copyright', $stripped);
+	}
+
+	public function testStrippingIsIdempotent() {
+		$once = BuildStamps::strip($this->first());
+		$this->assertSame($once, BuildStamps::strip($once));
+	}
+
+	/** A page carrying none of them is left exactly as it was. */
+	public function testAPageWithoutStampsIsUnchanged() {
+		$html = "<!DOCTYPE html>\n<html><body><p>Nothing to strip.</p></body></html>\n";
+		$this->assertSame($html, BuildStamps::strip($html));
+	}
+
+	/** The compressed variant of the file cache comment is worded differently. */
+	public function testTheCompressedFileCacheCommentIsAlsoDropped() {
+		$html = "<html><body>x</body>\n<!-- Cached/compressed 20260811170350 -->\n</html>";
+		$this->assertStringNotContainsString('Cached/compressed', BuildStamps::strip($html));
+	}
+}


### PR DESCRIPTION
Continues #281 for #269. After this, no HTML page differs between two bakes of the same source.

## Where it stood

All 171 exported pages differed. Normalising every cause #269 lists still left all 171 differing, so the issue's list was incomplete. Four causes, each fixed where it belongs.

## 1. One instant for the whole build

Every revision and upload is created while the build runs, so with a live clock each page claims it was edited seconds ago, differently in each bake: the "last edited" line, the `File:` history table, `{{CURRENTTIMESTAMP}}`, `page_touched`, cache stamps.

`SOURCE_DATE_EPOCH` is [the convention](https://reproducible-builds.org/docs/source-date-epoch/) for telling a reproducible build which date to claim. The build now runs as of it, and the GitHub action passes the commit date of `HEAD`, so those dates become true of the commit rather than of the machine that built it. Without it, a fixed fallback date.

Verified both ways: with `SOURCE_DATE_EPOCH=1780000000` pages read "28 May 2026, at 20:26"; without, "1 January 2000, at 00:00".

**Freezing the clock rather than rewriting rows afterwards is the part worth knowing.** My first attempt updated `revision.rev_timestamp` after the import and changed nothing in the output, because `RevisionStore::getKnownLatestRevision()` caches revision rows in the object cache for a week (`RevisionStore.php:2922`), which in a bake is the database and therefore outlives the process. Same shape as the `LinkCache` trap in #271.

## 2. No parse measurements

`$wgEnableParserLimitReporting = false`. The NewPP limit report is a wall-clock measurement addressed to whoever is debugging a live wiki, and it also carried the transclusion timing table into `wgPageParseReport`.

## 3. Strip what a page records about its own request

`includes/BuildStamps` drops the request id, the render uuid, the parser cache and file cache notes, the backend response time, and blanks the page and revision ids.

Those ids deserve a note: they are stable within a bake but not across bakes, because jobs still create the translated pages in a varying order even after #281 made the queue fifo. Rather than keep chasing that through Translate's deferred updates, the ids are blanked, since nothing in an export can act on them: there is no `api.php` to ask about a revision. They are blanked rather than removed, because `mw.config.get()` returns null for an absent key where a script may expect a number.

## 4. Stop exporting the installer's page

`Main_Page.html` is MediaWiki's own boilerplate:

> **MediaWiki has been installed.** Consult the User's Guide for information on using the wiki software.

Every wikven site has been shipping it. It is also the only page created before wikven's settings load, so its revision kept the real clock whatever else was frozen. It is deleted during the build, only when the source provides no page by that name, and identified before `MediaWiki:Mainpage` is repointed so it works whatever language the wiki was installed in.

## Result

Two bakes of `docs/`, clean workdir each time:

| | before this stack | now |
| --- | --- | --- |
| files differing | 350 of 649 | **71 of 628** |
| HTML pages | 171 | **0** |
| JS, CSS, thumbnails | differ | identical (#270, #271, #276) |
| pagefind | 170 | 71 |

628 rather than 649 files because the installer page and its index entries are gone.

## What is left

Only pagefind's index. 66 of its 68 fragments are byte-identical between bakes; two fragments and the index files are not, and the HTML those are built from now is. That is inside a tool wikven only invokes, so I have recorded it on #269 with the measurements rather than chase it here. Also worth a look eventually: a single bake writes 21 `pagefind.en_*.pf_meta` files, which does not look intended.

## Verification

Real bakes throughout, with a clean workdir each time; `diff -rq` over the trees; `BuildStamps` covered by unit tests, whose fixtures are the stamps two real bakes produced; the e2e suite run against the served output, 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
