### PR TITLE
fix: build the search index once, at the end

### DIFF
--- a/includes/Search.php
+++ b/includes/Search.php
@@ -6,6 +6,15 @@ use MediaWiki\Registration\ExtensionRegistry;
 
 /** Whether SifterSearch provides a working static search box: loaded and indexing into a bundle. */
 class Search {
+	/**
+	 * SifterSearch's index rebuild, which the build defers to the end.
+	 *
+	 * It is queued for every revision inserted and rebuilds the whole bundle each time it runs, so
+	 * anything that drains the queue mid-import pays for a full Pagefind pass over the content so
+	 * far, and leaves another generation of hashed index files behind in the output.
+	 */
+	public const INDEX_JOB = 'sifterSearchBuildIndex';
+
 	public static function isActive(): bool {
 		return (
 			ExtensionRegistry::getInstance()->isLoaded('SifterSearch')

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -62,21 +62,36 @@ class Build extends Maintenance {
 		}
 	}
 
-	/** Run the queue one type at a time, in name order: the runner otherwise shuffles the types. */
+	/**
+	 * Run the queue one type at a time, in name order: the runner otherwise shuffles the types.
+	 *
+	 * The search index is held back to the end. SifterSearch enqueues a rebuild for every revision
+	 * inserted, and although a pending one absorbs the rest, each pass of the queue picks up
+	 * whichever has arrived since. A bake was running Pagefind 21 times and leaving 20 dead
+	 * generations of hashed index files in the output, since Pagefind writes into a directory rather
+	 * than replacing it. Held back, it runs once, over the finished content.
+	 */
 	private function runJobs(string $file): void {
 		$group = $this->getServiceContainer()->getJobQueueGroup();
 		while (true) {
-			$types = $group->getQueuesWithJobs();
+			$types = array_diff($group->getQueuesWithJobs(), [Search::INDEX_JOB]);
 			if (!$types) {
-				return;
+				break;
 			}
 			sort($types);
 			foreach ($types as $type) {
-				$child = $this->createChild(RunJobs::class, $file);
-				$child->setOption('type', $type);
-				$child->execute();
+				$this->runJobsOfType($file, $type);
 			}
 		}
+		if (in_array(Search::INDEX_JOB, $group->getQueuesWithJobs(), true)) {
+			$this->runJobsOfType($file, Search::INDEX_JOB);
+		}
+	}
+
+	private function runJobsOfType(string $file, string $type): void {
+		$child = $this->createChild(RunJobs::class, $file);
+		$child->setOption('type', $type);
+		$child->execute();
 	}
 
 	/** Freeze page_touched once content is final; wiki-page modules fold it into their version hash. */

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -228,7 +228,8 @@ class BuildTranslations extends Maintenance {
 		// translated pages, so a shuffled order hands them different page and revision ids on every
 		// bake. Drain one type at a time, in name order, until nothing is left anywhere.
 		while (true) {
-			$types = $group->getQueuesWithJobs();
+			// The search index is left for the end of the build; see Search::INDEX_JOB.
+			$types = array_diff($group->getQueuesWithJobs(), [Search::INDEX_JOB]);
 			if (!$types) {
 				return;
 			}


### PR DESCRIPTION
Closes #269. With this, two bakes of the same source produce byte-identical trees.

## A bake ran Pagefind 23 times

SifterSearch queues an index rebuild on `RevisionRecordInserted`, and each run re-indexes the whole wiki. So anything that drains the queue mid-import pays for a full Pagefind pass over the content so far. `buildTranslations::drainJobs()` is called after marking *each* translatable page, to materialise its units before loading translations, which alone accounted for one pass per page.

Confirmed rather than inferred, by replacing the binary in the image with a wrapper that logs its calls:

```
PAGEFIND 23:51:44 args=--site /workspace/.cache/mw/sifter-search --output-path /workspace/dist/pagefind
PAGEFIND 23:51:46 args=...
… 23 invocations, spread over 70 seconds
```

That also corrected my first guess. I had assumed the repeats came from the build's own `runJobs` loop and moved the job to the end there, which made it *worse* (21 meta files became 24), because the real source was the drain inside `buildTranslations`.

## The cost was not only time

Pagefind writes into its output directory rather than replacing it, so each pass left another generation of hashed index files behind. A bake shipped 21 `pagefind.en_*.pf_meta` files, of which `pagefind-entry.json` referenced exactly one. The other 20 were dead weight in every deploy, and being snapshots of a half-imported wiki, they differed between bakes, which is what kept `dist/` from being reproducible after the HTML was settled in #282.

## The change

Hold that one job type back in both drains, and run it once over the finished content. The type name lives on `Search` next to `isActive()`, since two callers need it.

| | before | after |
| --- | --- | --- |
| Pagefind invocations | 23 | **1** |
| `pagefind.en_*.pf_meta` | 21 | **1** |
| `index/` | 40 | **2** |
| `fragment/` | 68 | **52**, one per exported page |
| files in `dist/` | 628 | **554** |

## Reproducibility, end to end

Two bakes of `docs/`, clean workdir each time:

```
554 files, 0 differences
```

Where this work started, 350 of 649 files differed. The series: #270 and #271 (module version hashes, #260), #276 (thumbnail timestamps), #281 (job order), #282 (HTML), and this.

The e2e suite passes 13/13, including the two tests that drive the search box and the results page, so the single index is a working one.

## Verification

Real bakes throughout; `diff -rq` over the trees; the invocation count measured with a wrapped binary in a derived image; Playwright against the served output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
