### PR TITLE
feat: carry ULS webfonts in the export, opt in

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -99,6 +99,10 @@
 			"value": "",
 			"description": "URL template for the per-page \"View source\" tab, linking to the page's source file in the repository. $1 is replaced with the page's percent-encoded source file name, as for WikvenEditUrl. Empty disables the tab."
 		},
+		"WikvenULSWebfonts": {
+			"value": false,
+			"description": "Carry UniversalLanguageSelector's webfonts in the export, so a script with no font on the reader's system renders as text rather than boxes. Off by default because it adds payload: only languages ULS has no system font for are shipped, typically 2 KiB to a few hundred KiB each, and the site then redistributes those fonts under their own licenses, which are copied alongside them."
+		},
 		"WikvenLogos": {
 			"value": [],
 			"description": "Header logos, mirroring $wgLogos but keyed to image file names in the source directory (each inlined as a data URI)."

--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -46,10 +46,20 @@ class RelativeUrl {
 			},
 			$html
 		);
-		return preg_replace_callback(
+		$html = preg_replace_callback(
 			'#\burl\((["\']?)(\.\.?)/#',
 			static function (array $m) use ($rebase): string {
 				return 'url(' . $m[1] . $rebase($m[2]);
+			},
+			$html
+		);
+		// ULS reads its webfont directory from a config value, which rewriteScripts sets next to the
+		// bundle. It is not an attribute or a url(), so none of the patterns above reach it, and the
+		// browser resolves it against the document like any other relative URL.
+		return preg_replace_callback(
+			'#("wgULSFontRepositoryBasePath":")(\.\.?)/#',
+			static function (array $m) use ($rebase): string {
+				return $m[1] . $rebase($m[2]);
 			},
 			$html
 		);

--- a/includes/Webfonts.php
+++ b/includes/Webfonts.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * Picks which UniversalLanguageSelector webfonts a site needs, so the export can carry them.
+ *
+ * ULS keeps its fonts as woff2 files in the extension tree and describes them in a generated file,
+ * data compiled from data/fontrepo rather than anything a server computes. That makes the choice a
+ * pure function of the site's languages, which is what this class is.
+ */
+class Webfonts {
+	/** The module carrying the repository data, which ULS loads on demand rather than per page. */
+	public const REPOSITORY_MODULE = 'ext.uls.webfonts.repository';
+
+	/** Where the generated repository description sits, relative to the ULS extension directory. */
+	public const REPOSITORY_FILE = 'resources/js/ext.uls.webfonts.repository.js';
+
+	/** Where the woff2 files sit, relative to the ULS extension directory. */
+	public const FONTS_DIR = 'data/fontrepo/fonts';
+
+	/** Where the license texts a font.ini names sit, relative to the ULS extension directory. */
+	public const LICENSES_DIR = 'data/fontrepo/licenses';
+
+	/** Where the fonts land under the output directory, and what the base path points at. */
+	public const OUTPUT_DIR = 'fonts/uls';
+
+	/**
+	 * Read the repository description as data.
+	 *
+	 * The file is JavaScript, but the object it assigns is JSON: quoted keys, no trailing commas, no
+	 * expressions. Taking it as JSON keeps the build from executing anything ULS ships.
+	 *
+	 * @param string $contents The file's contents.
+	 * @return array{languages: array<string, string[]>, fonts: array<string, array>}|null
+	 *   Null if the file is not the shape this expects, so the caller can say so rather than guess.
+	 */
+	public static function repository(string $contents): ?array {
+		if (!preg_match('/\$\.webfonts\.repository\s*=\s*(\{.*?\});/s', $contents, $matches)) {
+			return null;
+		}
+		$data = json_decode($matches[1], true);
+		if (!is_array($data) || !isset($data['languages']) || !isset($data['fonts'])) {
+			return null;
+		}
+		return ['languages' => $data['languages'], 'fonts' => $data['fonts']];
+	}
+
+	/**
+	 * The font families to ship for the given languages.
+	 *
+	 * A language whose list starts with "system" has a font already: the entries after it are reader
+	 * preferences (a dyslexia-friendly face, a historical-kana face) that ULS only applies when
+	 * someone picks one, so shipping them would cost a site hundreds of kilobytes to no effect. What
+	 * is left is the case this feature exists for, a script with no system font, where the first
+	 * entry is the font that stops the page rendering as tofu.
+	 *
+	 * @param array $repository As returned by repository().
+	 * @param string[] $languages Language codes the site exports.
+	 * @return string[] Family names, sorted, including the variants a shipped family declares.
+	 */
+	public static function familiesFor(array $repository, array $languages): array {
+		$families = [];
+		foreach ($languages as $language) {
+			$listed = $repository['languages'][$language] ?? [];
+			if (!$listed || $listed[0] === 'system') {
+				continue;
+			}
+			foreach ($listed as $family) {
+				if ($family !== 'system') {
+					$families[$family] = true;
+				}
+			}
+		}
+
+		// A family names its bold and italic faces as separate entries; a page that renders bold
+		// text in the script needs them too.
+		$queue = array_keys($families);
+		while ($queue) {
+			$family = array_pop($queue);
+			foreach ($repository['fonts'][$family]['variants'] ?? [] as $variant) {
+				if (!isset($families[$variant])) {
+					$families[$variant] = true;
+					$queue[] = $variant;
+				}
+			}
+		}
+
+		$names = array_keys($families);
+		sort($names);
+		return $names;
+	}
+
+	/**
+	 * The woff2 file each family is served from, relative to the font directory.
+	 *
+	 * The repository appends a cache-busting query to every path ("Alef/Alef-Regular.woff2?a2499").
+	 * It belongs in the URL the browser asks for, not in the name of the file on disk.
+	 *
+	 * @param array $repository As returned by repository().
+	 * @param string[] $families As returned by familiesFor().
+	 * @return array<string, string> Family name => relative path, without the query.
+	 */
+	public static function filesFor(array $repository, array $families): array {
+		$files = [];
+		foreach ($families as $family) {
+			$path = $repository['fonts'][$family]['woff2'] ?? null;
+			if (is_string($path) && $path !== '') {
+				$files[$family] = strtok($path, '?');
+			}
+		}
+		return $files;
+	}
+
+	/**
+	 * The license file a family's font.ini names, if it names one.
+	 *
+	 * Whoever turns this on publishes the fonts from their own site, so the license text travels
+	 * with them. font.ini records it per family ("licensefile=OFL.txt").
+	 *
+	 * @param string $ini Contents of a family's font.ini.
+	 * @return string|null The file name, or null when the family declares none.
+	 */
+	public static function licenseFile(string $ini): ?string {
+		$parsed = parse_ini_string($ini, true, INI_SCANNER_RAW);
+		if (!is_array($parsed)) {
+			return null;
+		}
+		foreach ($parsed as $section) {
+			if (is_array($section) && isset($section['licensefile']) && is_string($section['licensefile'])) {
+				$name = trim($section['licensefile']);
+				// Only a bare file name: the value names a file in the repository's licenses dir.
+				if ($name !== '' && !str_contains($name, '/') && !str_contains($name, '..')) {
+					return $name;
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -222,10 +222,17 @@ foreach ($config['extensions'] ?? [] as $extension) {
 }
 
 // UniversalLanguageSelector (enabled for content i18n) would have the browser pull its webfont
-// module and font files from load.php, which a static export cannot serve. Turn webfonts off;
-// bundling them into the static site instead is tracked as a separate enhancement.
+// module and font files from load.php, which a static export cannot serve. Off unless the site asks
+// for them, in which case storeWebfonts.php copies the ones its languages need next to the HTML and
+// the repository base path below points the browser at that copy instead of at load.php.
 if (in_array('UniversalLanguageSelector', $config['extensions'], true)) {
-	$GLOBALS['wgULSWebfontsEnabled'] = false;
+	$wikvenWebfonts = (bool)( $GLOBALS['wgWikvenULSWebfonts'] ?? false );
+	$GLOBALS['wgULSWebfontsEnabled'] = $wikvenWebfonts;
+	if ($wikvenWebfonts) {
+		// Relative to the page, so it works under any base path; RelativeUrl reparents it per depth.
+		require_once "$IP/extensions/Wikven/includes/Webfonts.php";
+		$GLOBALS['wgULSFontRepositoryBasePath'] = './' . MediaWiki\Extension\Wikven\Webfonts::OUTPUT_DIR . '/';
+	}
 }
 
 // SifterSearch ships built in; default its Pagefind index into the build's dist dir, unless the

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -169,6 +169,7 @@ class Build extends Maintenance {
 		$this->step(BuildScripts::class, "$own/buildScripts.php");
 		$this->step(RewriteScripts::class, "$own/rewriteScripts.php");
 		$this->step(StoreImages::class, "$own/storeImages.php");
+		$this->step(StoreWebfonts::class, "$own/storeWebfonts.php");
 		$this->step(Rename::class, "$own/rename.php");
 		// Rename has expanded translation pages into "<Page>/<lang>.html"; resolve MyLanguage links now.
 		$this->step(ResolveTranslationLinks::class, "$own/resolveTranslationLinks.php");

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -55,6 +55,11 @@ class BuildScripts extends Maintenance {
 				$seeds[] = $searchModule;
 			}
 		}
+		// Seed the webfont repository: ULS loads it with mw.loader.using() the first time it applies a
+		// font, so it is in no page's queue, and without it the export asks load.php for it.
+		if (( $GLOBALS['wgULSWebfontsEnabled'] ?? false ) && $rl->isModuleRegistered(Webfonts::REPOSITORY_MODULE)) {
+			$seeds[] = Webfonts::REPOSITORY_MODULE;
+		}
 		// 2. Expand to the full dependency closure, plus the implicit base modules.
 		$closure = $this->resolveClosure($rl, $seeds, $wgLanguageCode, $wgDefaultSkin);
 

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -74,6 +74,7 @@ class RewriteScripts extends Maintenance {
 				. '<script src="'
 				. $prefix
 				. '/modules-static.js"></script>'
+				. $this->webfontBase($prefix)
 				. '<script>mw.loader.load('
 				. json_encode($trigger)
 				. ');</script>';
@@ -201,6 +202,27 @@ class RewriteScripts extends Maintenance {
 			}
 		}
 		return -1;
+	}
+
+	/**
+	 * Point ULS's webfont base at this page's copy of the fonts.
+	 *
+	 * The base path is a ResourceLoader config var, so it is set once in the shared bundle and cannot
+	 * be relative to a page: every page at depth would resolve "./fonts/uls/" inside its own
+	 * directory. This runs after the bundle, with the same depth-correct prefix used for the script
+	 * tags above, so the last writer is the one that knows where the page sits.
+	 */
+	private function webfontBase(string $prefix): string {
+		if (!( $GLOBALS['wgULSWebfontsEnabled'] ?? false )) {
+			return '';
+		}
+		$base = $prefix . '/' . Webfonts::OUTPUT_DIR . '/';
+		// Unescaped slashes so RelativeUrl::reparent can see the path when rename moves the page down.
+		return (
+			'<script>mw.config.set('
+			. json_encode(['wgULSFontRepositoryBasePath' => $base], JSON_UNESCAPED_SLASHES)
+			. ');</script>'
+		);
 	}
 }
 

--- a/maintenance/storeWebfonts.php
+++ b/maintenance/storeWebfonts.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use Maintenance;
+use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
+use MediaWiki\Registration\ExtensionRegistry;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/** Copy the UniversalLanguageSelector webfonts the exported languages need next to the HTML. */
+class StoreWebfonts extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription('Make the ULS webfonts for the site\'s languages local to the export.');
+	}
+
+	/**
+	 * @return bool Whether every font that was asked for is now in the output directory.
+	 */
+	public function execute() {
+		$loaded = ExtensionRegistry::getInstance()->isLoaded('UniversalLanguageSelector');
+		if (!$loaded || !( $GLOBALS['wgULSWebfontsEnabled'] ?? false )) {
+			return true;
+		}
+		$uls = $this->getServiceContainer()->getMainConfig()->get('ExtensionDirectory') . '/UniversalLanguageSelector';
+		$dir = rtrim((string)$GLOBALS['wgWikvenHtmlDirectory'], '/');
+		if ($dir === '' || !is_dir($uls)) {
+			return true;
+		}
+
+		$repositoryFile = "$uls/" . Webfonts::REPOSITORY_FILE;
+		$repository = is_file($repositoryFile)
+			? Webfonts::repository((string)file_get_contents($repositoryFile))
+			: null;
+		if ($repository === null) {
+			$this->output("Wikven: cannot read the ULS font repository; shipping no webfonts\n");
+			return false;
+		}
+
+		$languages = $this->languages();
+		$families = Webfonts::familiesFor($repository, $languages);
+		if (!$families) {
+			$this->output(
+				'Wikven: no webfont needed for ' . implode(', ', $languages) . "; the system fonts cover them\n"
+			);
+			return true;
+		}
+
+		$target = "$dir/" . Webfonts::OUTPUT_DIR;
+		$ok = true;
+		$bytes = 0;
+		foreach (Webfonts::filesFor($repository, $families) as $family => $relative) {
+			$source = "$uls/" . Webfonts::FONTS_DIR . "/$relative";
+			if (!is_file($source)) {
+				$this->output("Wikven: missing webfont for $family ($relative)\n");
+				$ok = false;
+				continue;
+			}
+			$destination = "$target/$relative";
+			if (!wfMkdirParents(dirname($destination))) {
+				$this->output("Wikven: could not create $destination\n");
+				$ok = false;
+				continue;
+			}
+			copy($source, $destination);
+			$bytes += (int)filesize($source);
+			$this->copyLicense($uls, dirname($source), dirname($destination));
+		}
+
+		$this->output(sprintf(
+			"Stored %d webfont(s) for %s (%.0f KiB)\n",
+			count($families),
+			implode(', ', $languages),
+			$bytes / 1024
+		));
+		return $ok;
+	}
+
+	/**
+	 * The languages the export contains: the content language plus every translation in the source.
+	 *
+	 * @return string[]
+	 */
+	private function languages(): array {
+		$languages = [(string)$GLOBALS['wgLanguageCode']];
+		$source = rtrim((string)( $GLOBALS['wgWikvenSourceDirectory'] ?? '' ), '/');
+		if ($source !== '' && is_dir($source)) {
+			$isKnown = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
+			foreach (TranslationSource::baseFiles($source) as $baseFile) {
+				$languages = array_merge($languages, TranslationSource::translationLanguages($baseFile, $isKnown));
+			}
+		}
+		$languages = array_values(array_unique($languages));
+		sort($languages);
+		return $languages;
+	}
+
+	/** Copy the license text a family's font.ini names, so the fonts do not travel without it. */
+	private function copyLicense(string $uls, string $familyDir, string $destinationDir): void {
+		$ini = "$familyDir/font.ini";
+		if (!is_file($ini)) {
+			return;
+		}
+		$name = Webfonts::licenseFile((string)file_get_contents($ini));
+		if ($name === null) {
+			return;
+		}
+		// A family may keep its own copy; otherwise the text is one of the repository's shared ones.
+		$source = is_file("$familyDir/$name") ? "$familyDir/$name" : "$uls/" . Webfonts::LICENSES_DIR . "/$name";
+		if (is_file($source)) {
+			copy($source, "$destinationDir/$name");
+		}
+	}
+}
+
+$maintClass = StoreWebfonts::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/tests/phpunit/unit/RelativeUrlTest.php
+++ b/tests/phpunit/unit/RelativeUrlTest.php
@@ -109,4 +109,24 @@ class RelativeUrlTest extends MediaWikiUnitTestCase {
 			return true;
 		}));
 	}
+
+	/**
+	 * ULS reads its webfont directory from a config value that rewriteScripts writes next to the
+	 * bundle, so it is neither an attribute nor a url(), and a moved page still has to find it.
+	 */
+	public function testTheWebfontBasePathIsReparented() {
+		$this->assertSame(
+			'mw.config.set({"wgULSFontRepositoryBasePath":"../fonts/uls/"});',
+			RelativeUrl::reparent('mw.config.set({"wgULSFontRepositoryBasePath":"./fonts/uls/"});', 1)
+		);
+		$this->assertSame(
+			'mw.config.set({"wgULSFontRepositoryBasePath":"../../fonts/uls/"});',
+			RelativeUrl::reparent('mw.config.set({"wgULSFontRepositoryBasePath":"./fonts/uls/"});', 2)
+		);
+	}
+
+	public function testAnAbsoluteWebfontBasePathIsLeftAlone() {
+		$html = 'mw.config.set({"wgULSFontRepositoryBasePath":"/fonts/uls/"});';
+		$this->assertSame($html, RelativeUrl::reparent($html, 2));
+	}
 }

--- a/tests/phpunit/unit/WebfontsTest.php
+++ b/tests/phpunit/unit/WebfontsTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\Webfonts;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Webfonts
+ */
+class WebfontsTest extends MediaWikiUnitTestCase {
+	/**
+	 * The repository file as ULS generates it, cut down to the entries these tests need but keeping
+	 * its shape: the JS wrapper, the cache-busting query on every path, and the two kinds of language
+	 * entry, one with a system font in front and one without.
+	 */
+	private function repositoryFile(): string {
+		return <<<'JS'
+			// Do not edit! This file is generated from data/fontrepo by scripts/compile-font-repo.php
+			( function () {
+				$.webfonts = $.webfonts || {};
+				$.webfonts.repository = {
+				"base": "../data/fontrepo/fonts/",
+				"languages": {
+					"bug": [
+						"Saweri"
+					],
+					"en": [
+						"system",
+						"ComicNeue",
+						"OpenDyslexic"
+					],
+					"he": [
+						"system",
+						"Alef"
+					],
+					"hbo": [
+						"Alef"
+					]
+				},
+				"fonts": {
+					"Saweri": {
+						"woff2": "saweri/saweri.woff2?fe482"
+					},
+					"Alef": {
+						"woff2": "Alef/Alef-Regular.woff2?a2499",
+						"variants": {
+							"bold": "Alef Bold"
+						}
+					},
+					"Alef Bold": {
+						"fontweight": "bold",
+						"woff2": "Alef/Alef-Bold.woff2?7c873"
+					},
+					"ComicNeue": {
+						"woff2": "ComicNeue/ComicNeue-Regular.woff2?11111"
+					},
+					"OpenDyslexic": {
+						"woff2": "OpenDyslexic/OpenDyslexic-Regular.woff2?22222"
+					}
+				}
+				};
+			}() );
+			JS;
+	}
+
+	private function repository(): array {
+		return Webfonts::repository($this->repositoryFile());
+	}
+
+	public function testTheGeneratedFileIsReadAsData() {
+		$repository = $this->repository();
+		$this->assertIsArray($repository);
+		$this->assertSame(['Saweri'], $repository['languages']['bug']);
+		$this->assertSame('saweri/saweri.woff2?fe482', $repository['fonts']['Saweri']['woff2']);
+	}
+
+	/** Anything that is not the generated shape is refused, rather than half-read. */
+	public function testSomethingElseIsRefused() {
+		$this->assertNull(Webfonts::repository(''));
+		$this->assertNull(Webfonts::repository('$.webfonts.repository = notAnObject;'));
+		$this->assertNull(Webfonts::repository('$.webfonts.repository = {"languages": {}};'));
+	}
+
+	/** A language with no system font gets its font: this is the case the feature exists for. */
+	public function testALanguageWithoutASystemFontIsShipped() {
+		$this->assertSame(['Saweri'], Webfonts::familiesFor($this->repository(), ['bug']));
+	}
+
+	/**
+	 * A language whose list starts with "system" is left alone. Its remaining entries are reader
+	 * preferences, so shipping them would cost payload for a font nobody has asked to see.
+	 */
+	public function testASystemFirstLanguageShipsNothing() {
+		$this->assertSame([], Webfonts::familiesFor($this->repository(), ['en', 'he']));
+	}
+
+	public function testAnUnlistedLanguageShipsNothing() {
+		$this->assertSame([], Webfonts::familiesFor($this->repository(), ['ko', 'zh']));
+	}
+
+	/** Bold and italic faces are separate entries, and text in the script may well be bold. */
+	public function testVariantsComeAlong() {
+		$this->assertSame(['Alef', 'Alef Bold'], Webfonts::familiesFor($this->repository(), ['hbo']));
+	}
+
+	public function testEachLanguageIsCountedOnce() {
+		$families = Webfonts::familiesFor($this->repository(), ['bug', 'bug', 'hbo']);
+		$this->assertSame(['Alef', 'Alef Bold', 'Saweri'], $families);
+	}
+
+	/** The cache-busting query belongs in the URL the browser asks for, not in the file's name. */
+	public function testFilePathsLoseTheQuery() {
+		$files = Webfonts::filesFor($this->repository(), ['Saweri', 'Alef', 'Alef Bold']);
+		$this->assertSame(
+			[
+				'Saweri' => 'saweri/saweri.woff2',
+				'Alef' => 'Alef/Alef-Regular.woff2',
+				'Alef Bold' => 'Alef/Alef-Bold.woff2'
+			],
+			$files
+		);
+	}
+
+	public function testAFamilyWithNoFileIsSkipped() {
+		$this->assertSame([], Webfonts::filesFor($this->repository(), ['NoSuchFamily']));
+	}
+
+	/** font.ini names the license text that has to travel with the font. */
+	public function testTheLicenseFileIsReadFromFontIni() {
+		$ini = "[Saweri]\nlanguages=bug*\nversion=2\nlicense=GPL-3.0-only\nlicensefile=gpl-3.0.txt\n";
+		$this->assertSame('gpl-3.0.txt', Webfonts::licenseFile($ini));
+	}
+
+	public function testAFamilyThatNamesNoLicenseFileGivesNull() {
+		$this->assertNull(Webfonts::licenseFile("[Akkadian]\nlanguages=akk*\nversion=1\n"));
+		$this->assertNull(Webfonts::licenseFile(''));
+	}
+
+	/** The value names a file in the repository's licenses directory, so a path is not one. */
+	public function testAPathIsRefusedAsALicenseFile() {
+		$this->assertNull(Webfonts::licenseFile("[X]\nlicensefile=../../../etc/passwd\n"));
+		$this->assertNull(Webfonts::licenseFile("[X]\nlicensefile=sub/dir/OFL.txt\n"));
+	}
+}


### PR DESCRIPTION
Implements the design on #219. Draft, because the one thing it lacks is a permanent test, and that needs a page in a language I cannot write. Details at the end.

## What it does

`WikvenULSWebfonts`, off by default:

```yaml
config:
  WikvenULSWebfonts: true
```

turns ULS's webfonts back on, copies the fonts the site's languages need into `dist/fonts/uls/`, and points the browser at that copy instead of at `load.php`.

## Only the languages that need one

The repository's `languages` map holds two different things:

```
"am":  ["AbyssinicaSIL"]                        ← no system font: this is the tofu fix
"en":  ["system", "ComicNeue", "OpenDyslexic"]  ← system font first, the rest are preferences
```

A language whose list starts with `system` is skipped, so an English site does not pay 508 KiB for two fonts that only appear if a reader opens ULS display settings. What is left costs 2 KiB (`bug`) to 378 KiB (`bn`) per language, and each family's `font.ini` names a license text, which is copied alongside.

## Three things only a bake in a browser revealed

Each of these looked settled on paper and was not.

**The base path is a bundle-wide value, not a per-page one.** `wgULSFontRepositoryBasePath` comes from `onResourceLoaderGetConfigVars`, so it is written once into `modules-static.js`, which every page loads. A relative value is then wrong for every page below the root: `Licenses/en.html` would look in `Licenses/fonts/uls/`. `rewriteScripts` now writes the value per page, after the bundle so the last writer wins, using the same depth-correct prefix it already computes for the script tags. It runs while pages are still flat, so `RelativeUrl::reparent` carries the value when `rename` moves a page into a directory. My first attempt put the rewrite only in `RelativeUrl` and it never matched anything, because the value is not in per-page `RLCONF` at all.

**`json_encode` escapes slashes.** The injected value arrived as `".\/.\/fonts\/uls\/"`, which the reparent pattern could not see. `JSON_UNESCAPED_SLASHES` fixes it, and the unit test pins the shape.

**The repository module never reached the bundle.** ULS loads it with `mw.loader.using()` the first time it applies a font, so it is in no page's module queue. The export asked `load.php` for it:

```
repoState: "error"
request:   load.php?modules=ext.uls.webfonts.repository → 404
```

`buildScripts` now seeds it, right next to the search module that is seeded for exactly the same reason ("loaded on focus, never in page queue").

## Verified end to end

Baked with the flag on and a Buginese page present, then driven in a browser:

```
repoState "ready"   base ".././fonts/uls/"   200 saweri.woff2?fe482   load.php requests: 0
computed font-family on the body: "Saweri, sans-serif"
```

So the font is fetched from the export, at the right path from a page one directory down, with nothing reaching for a server. `dist/fonts/uls/saweri/` holds `saweri.woff2` and `gpl-3.0.txt`, once per skin, as images already are.

With the flag off: no `fonts/` directory, no config value in the HTML, and the existing e2e suite passes 13/13.

Unit tests cover the selection rules (`WebfontsTest`: the two kinds of language entry, variants, the query on font paths, and refusing a `licensefile` that is a path) and the depth rewrite (`RelativeUrlTest`).

## Why this is a draft: the fixture

The design called for a `bug` page in `docs/` so CI could cover this. I used one locally to verify, with placeholder text, and I have not committed it, because **I cannot write Buginese**. Producing a page of it would be inventing text in a language neither of us can check, published on the project's own site, where a Buginese reader would be the one to discover it was nonsense. That is not a thing I will commit.

Three ways forward, your call:

1. **You or a speaker writes it.** The cheapest real fixture in the whole repository: `bug` needs one 2 KiB font file. `docs/Licenses/bug.wikitext` following the shape of `ko.wikitext` is all it takes, and `build-and-check` can then assert the woff2 lands and no `load.php` request is made.
2. **A quotation instead of prose.** For `hbo` (Biblical Hebrew, 97 KiB) a short attributed verse is verifiable rather than invented. It is honest, though a page of scripture in the licenses docs is odd.
3. **Ship without the CI test**, on the unit tests plus the manual verification above, and leave the browser-level check to whoever next enables the flag.

I would take 1 if you can, else 3, and I would not do 2.

## Not done, deliberately

The repository data is not pruned to the shipped families. It does not need to be for correctness, because `$.webfonts` applies a language's *first* font and a `system`-first language therefore requests nothing. The one loose end is that ULS's display settings still offer fonts the site did not ship, and picking one 404s. Worth a follow-up if anyone uses that menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
