### PR TITLE
feat: bake ULS webfonts into the static export (opt-in)

### DIFF
--- a/docs/Translating.wikitext
+++ b/docs/Translating.wikitext
@@ -20,7 +20,7 @@ extensions:
 
 <translate>
 <!--T:4-->
-A static export cannot serve UniversalLanguageSelector's runtime webfonts (they load from a live endpoint), so {{SITENAME}} turns them off; readers see each script in their own system fonts.
+A static export cannot serve UniversalLanguageSelector's runtime webfonts (they load from a live endpoint), so by default {{SITENAME}} turns them off and readers see each script in their own system fonts. Set <code>WikvenBundleWebfonts</code> to bake the fonts into the site instead, so a reader whose system lacks a font for a script still sees the intended typeface.
 
 <!--T:5-->
 You do not list the languages you translate into: as with Translate itself, a language exists as soon as a translation for it does. The language you write your pages in stays the source language.

--- a/extension.json
+++ b/extension.json
@@ -106,6 +106,10 @@
 		"WikvenRepositories": {
 			"value": [],
 			"description": "Sources for third-party extensions and skins listed in extensions/skins. A map of component name to a tarball/repository/package source, fetched by maintenance/fetchExtensions.php before MediaWiki loads them."
+		},
+		"WikvenBundleWebfonts": {
+			"value": false,
+			"description": "When true and UniversalLanguageSelector is installed, bake its webfonts for the export's languages into a static stylesheet, so readers of a script their system lacks a font for see the intended typeface instead of tofu. Off by default because it adds font payload to the output."
 		}
 	},
 	"MessagesDirs": {

--- a/includes/Webfonts/FontRepository.php
+++ b/includes/Webfonts/FontRepository.php
@@ -146,10 +146,15 @@ class FontRepository {
 		$style = isset($config['fontstyle']) && is_string($config['fontstyle']) ? $config['fontstyle'] : 'normal';
 		$name = $this->escape($family);
 
-		return "@font-face{font-family:'$name';"
+		return (
+			"@font-face{font-family:'$name';"
 			. "font-weight:$weight;font-style:$style;font-display:swap;"
 			. "src:local('$name'),"
-			. "url('" . $prefix . $path . "') format('woff2');}\n";
+			. "url('"
+			. $prefix
+			. $path
+			. "') format('woff2');}\n"
+		);
 	}
 
 	/**
@@ -160,8 +165,16 @@ class FontRepository {
 	 * @return string
 	 */
 	private function applyRule(string $lang, string $family): string {
-		return ':lang(' . $lang . '),[lang="' . $lang . '"]'
-			. "{font-family:'" . $this->escape($family) . "',sans-serif;}\n";
+		return (
+			':lang('
+			. $lang
+			. '),[lang="'
+			. $lang
+			. '"]'
+			. "{font-family:'"
+			. $this->escape($family)
+			. "',sans-serif;}\n"
+		);
 	}
 
 	/**

--- a/includes/Webfonts/FontRepository.php
+++ b/includes/Webfonts/FontRepository.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Webfonts;
+
+/**
+ * Turn UniversalLanguageSelector's font-repository data into a static @font-face
+ * stylesheet, so an export can ship webfonts without ULS's runtime JavaScript.
+ *
+ * ULS applies, with no reader interaction, the first font listed for a language,
+ * unless that first entry is "system" (the OS font, i.e. no webfont). This class
+ * reproduces exactly that default: for each language whose default is a real
+ * font, it emits an @font-face for the font and its bold/italic variants, and a
+ * :lang() rule that applies it. The alternative fonts a reader could pick from
+ * the ULS menu are dropped, since a static page carries no menu.
+ *
+ * The font url()s are written relative to a caller-supplied base, meant to be the
+ * path from the stylesheet's own location to the copied woff2 files. Because the
+ * URLs in an external stylesheet resolve against the stylesheet, not the page
+ * linking it, they render correctly from any page depth or host subdirectory.
+ */
+class FontRepository {
+	/** @var array<string,string[]> Language code => font family names, in preference order. */
+	private array $languages;
+
+	/** @var array<string,array> Family name => font config (woff2 path, variants, weight, style). */
+	private array $fonts;
+
+	/**
+	 * @param array $repository The decoded $.webfonts.repository object (its languages/fonts maps).
+	 */
+	public function __construct(array $repository) {
+		$this->languages = is_array($repository['languages'] ?? null) ? $repository['languages'] : [];
+		$this->fonts = is_array($repository['fonts'] ?? null) ? $repository['fonts'] : [];
+	}
+
+	/**
+	 * The family ULS applies to $language by default, or null when that default is the
+	 * system font (the language's list starts with "system") or the language has no fonts.
+	 *
+	 * @param string $language
+	 * @return string|null
+	 */
+	public function defaultFamily(string $language): ?string {
+		$list = $this->languages[$language] ?? null;
+		if (!is_array($list) || $list === []) {
+			return null;
+		}
+		$first = $list[0];
+		if (!is_string($first) || $first === 'system') {
+			return null;
+		}
+		return isset($this->fonts[$first]) ? $first : null;
+	}
+
+	/**
+	 * Build the stylesheet for a set of languages.
+	 *
+	 * @param string[] $languages Language codes present in the export.
+	 * @param string $basePath Path prefix, relative to the stylesheet's own location, under
+	 *   which the woff2 files are copied (e.g. "fonts/uls/").
+	 * @return array{css: string, files: string[]} The stylesheet text, and the base-relative
+	 *   woff2 paths (no "?query") it references, deduped. Both are deterministically ordered.
+	 */
+	public function build(array $languages, string $basePath): array {
+		$prefix = rtrim($basePath, '/') . '/';
+
+		// A unique, sorted language list keeps a rebake byte-identical whatever order pages came in.
+		$languages = array_values(array_unique($languages));
+		sort($languages);
+
+		$files = [];
+		// Family => @font-face block(s), deduped so a font shared by two languages is defined once.
+		$faces = [];
+		// Language => family, in language order, for the :lang() application rules.
+		$apply = [];
+
+		foreach ($languages as $lang) {
+			$family = $this->defaultFamily($lang);
+			if ($family === null) {
+				continue;
+			}
+			$apply[$lang] = $family;
+			if (!isset($faces[$family])) {
+				$faces[$family] = $this->faceRules($family, $prefix, $files);
+			}
+		}
+
+		ksort($faces);
+		$css = '';
+		foreach ($faces as $block) {
+			$css .= $block;
+		}
+		foreach ($apply as $lang => $family) {
+			$css .= $this->applyRule($lang, $family);
+		}
+
+		$files = array_values(array_unique($files));
+		sort($files);
+		return ['css' => $css, 'files' => $files];
+	}
+
+	/**
+	 * The @font-face rules for $family and its variants, appending each woff2 path to $files.
+	 *
+	 * @param string $family
+	 * @param string $prefix
+	 * @param string[] &$files
+	 * @return string
+	 */
+	private function faceRules(string $family, string $prefix, array &$files): string {
+		$config = $this->fonts[$family] ?? null;
+		if (!is_array($config)) {
+			return '';
+		}
+		$css = $this->face($family, $config, $prefix, $files);
+		$variants = is_array($config['variants'] ?? null) ? $config['variants'] : [];
+		foreach ($variants as $variantFamily) {
+			// A variant is defined under its own family entry (e.g. "Alef Bold") but shares the base
+			// family name, so the browser picks it up for bold/italic text of that family.
+			if (is_string($variantFamily) && isset($this->fonts[$variantFamily])) {
+				$css .= $this->face($family, $this->fonts[$variantFamily], $prefix, $files);
+			}
+		}
+		return $css;
+	}
+
+	/**
+	 * One @font-face rule declaring $family from a font config entry.
+	 *
+	 * @param string $family
+	 * @param array $config
+	 * @param string $prefix
+	 * @param string[] &$files
+	 * @return string
+	 */
+	private function face(string $family, array $config, string $prefix, array &$files): string {
+		$woff2 = $config['woff2'] ?? null;
+		if (!is_string($woff2) || $woff2 === '') {
+			return '';
+		}
+		// The repository appends a "?hash" cache-buster; the file on disk carries none.
+		$path = explode('?', $woff2, 2)[0];
+		$files[] = $path;
+
+		$weight = isset($config['fontweight']) && is_string($config['fontweight']) ? $config['fontweight'] : 'normal';
+		$style = isset($config['fontstyle']) && is_string($config['fontstyle']) ? $config['fontstyle'] : 'normal';
+		$name = $this->escape($family);
+
+		return "@font-face{font-family:'$name';"
+			. "font-weight:$weight;font-style:$style;font-display:swap;"
+			. "src:local('$name'),"
+			. "url('" . $prefix . $path . "') format('woff2');}\n";
+	}
+
+	/**
+	 * The :lang() rule applying $family to text in $lang, with a generic fallback.
+	 *
+	 * @param string $lang
+	 * @param string $family
+	 * @return string
+	 */
+	private function applyRule(string $lang, string $family): string {
+		return ':lang(' . $lang . '),[lang="' . $lang . '"]'
+			. "{font-family:'" . $this->escape($family) . "',sans-serif;}\n";
+	}
+
+	/**
+	 * Escape a font-family name for a single-quoted CSS string.
+	 *
+	 * @param string $name
+	 * @return string
+	 */
+	private function escape(string $name): string {
+		return str_replace(['\\', "'"], ['\\\\', "\\'"], $name);
+	}
+}

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -222,8 +222,9 @@ foreach ($config['extensions'] ?? [] as $extension) {
 }
 
 // UniversalLanguageSelector (enabled for content i18n) would have the browser pull its webfont
-// module and font files from load.php, which a static export cannot serve. Turn webfonts off;
-// bundling them into the static site instead is tracked as a separate enhancement.
+// module and font files from load.php, which a static export cannot serve. Turn its runtime
+// webfonts off; when $wgWikvenBundleWebfonts is set, maintenance/bakeWebfonts.php instead bakes
+// the same fonts into a static stylesheet (see includes/Webfonts/FontRepository.php).
 if (in_array('UniversalLanguageSelector', $config['extensions'], true)) {
 	$GLOBALS['wgULSWebfontsEnabled'] = false;
 }

--- a/maintenance/bakeWebfonts.php
+++ b/maintenance/bakeWebfonts.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use Maintenance;
+use MediaWiki\Extension\Wikven\Webfonts\FontRepository;
+use MediaWiki\Registration\ExtensionRegistry;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/**
+ * Bake UniversalLanguageSelector webfonts into the export as a plain stylesheet:
+ * @font-face plus :lang() rules for the languages the pages use, with the woff2
+ * files copied alongside. It reproduces the font ULS would apply by default,
+ * without shipping ULS's runtime JavaScript (which pulls fonts from load.php,
+ * an endpoint a static host cannot serve).
+ *
+ * Opt-in via $wgWikvenBundleWebfonts, since it adds font payload; a no-op when
+ * off or when ULS is not installed. The stylesheet is linked like site.styles.css
+ * (rewriteScripts wires it in, rename's reparenting keeps the <link> correct at
+ * any subpage depth), and its font url()s resolve against the stylesheet itself,
+ * so they hold from every page regardless of depth or host subdirectory.
+ */
+class BakeWebfonts extends Maintenance {
+	/** Output subdirectory (under the dist root) the woff2 files are copied into. */
+	private const FONTS_SUBDIR = 'fonts/uls';
+
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription('Bake ULS webfonts for the export languages into a static stylesheet.');
+	}
+
+	public function execute() {
+		global $wgWikvenHtmlDirectory, $wgWikvenStyleDirectory, $wgLanguageCode;
+
+		if (!$this->getConfig()->get('WikvenBundleWebfonts')) {
+			return;
+		}
+		if (!ExtensionRegistry::getInstance()->isLoaded('UniversalLanguageSelector')) {
+			$this->output("Wikven: UniversalLanguageSelector not installed; skipping webfont bundling.\n");
+			return;
+		}
+
+		$ulsDir = $this->ulsDirectory();
+		if ($ulsDir === null) {
+			$this->output("Wikven: could not locate UniversalLanguageSelector; skipping webfont bundling.\n");
+			return;
+		}
+		$repository = $this->readRepository($ulsDir);
+		if ($repository === null) {
+			$this->output("Wikven: could not read the ULS font repository; skipping webfont bundling.\n");
+			return;
+		}
+
+		$htmlDir = rtrim($wgWikvenHtmlDirectory, '/');
+		$styleDir = trim(rtrim($wgWikvenStyleDirectory, '/'), '/');
+		$atRoot = $styleDir === '' || $styleDir === '.';
+		$cssDir = $atRoot ? $htmlDir : "$htmlDir/$styleDir";
+
+		$languages = $this->discoverLanguages($htmlDir, $wgLanguageCode);
+
+		// The woff2 live at <htmlDir>/fonts/uls/...; the stylesheet sits in $cssDir, so its url()s
+		// step up out of any style subdirectory to reach them.
+		$depth = $atRoot ? 0 : substr_count($styleDir, '/') + 1;
+		$basePath = str_repeat('../', $depth) . self::FONTS_SUBDIR . '/';
+
+		$built = ( new FontRepository($repository) )->build($languages, $basePath);
+		if (trim($built['css']) === '' || $built['files'] === []) {
+			$this->output("Wikven: no bundled webfonts apply to the export's languages.\n");
+			return;
+		}
+
+		$copied = $this->copyFonts($ulsDir, "$htmlDir/" . self::FONTS_SUBDIR, $built['files']);
+		if ($copied === 0) {
+			$this->error('Wikven: none of the required webfont files could be copied.');
+			return;
+		}
+
+		if (!is_dir($cssDir) && !wfMkdirParents($cssDir)) {
+			$this->fatalError("Wikven: could not create style directory $cssDir");
+		}
+		file_put_contents("$cssDir/webfonts.css", $built['css'], LOCK_EX);
+		$this->output("Wrote webfonts.css ($copied font file(s))\n");
+	}
+
+	/**
+	 * The install directory of the UniversalLanguageSelector extension, or null if not found.
+	 *
+	 * @return string|null
+	 */
+	private function ulsDirectory(): ?string {
+		$things = ExtensionRegistry::getInstance()->getAllThings();
+		$path = $things['UniversalLanguageSelector']['path'] ?? null;
+		if (!is_string($path) || !is_file($path)) {
+			return null;
+		}
+		return dirname($path);
+	}
+
+	/**
+	 * Read ULS's generated font-repository module, whose object literal is valid JSON.
+	 *
+	 * @param string $ulsDir
+	 * @return array|null The decoded repository (languages/fonts maps), or null on any failure.
+	 */
+	private function readRepository(string $ulsDir): ?array {
+		$file = "$ulsDir/resources/js/ext.uls.webfonts.repository.js";
+		if (!is_file($file)) {
+			return null;
+		}
+		$js = file_get_contents($file);
+		if ($js === false) {
+			return null;
+		}
+		// The file assigns `$.webfonts.repository = { ... };`; capture that object literal.
+		if (!preg_match('/\.repository\s*=\s*(\{.*\})\s*;/s', $js, $m)) {
+			return null;
+		}
+		$data = json_decode($m[1], true);
+		return is_array($data) ? $data : null;
+	}
+
+	/**
+	 * The set of languages the export renders in: the content language plus the lang of every
+	 * rendered page (translated pages carry their own). Read from the <html lang="..."> tag.
+	 *
+	 * @param string $htmlDir
+	 * @param string $contentLang
+	 * @return string[]
+	 */
+	private function discoverLanguages(string $htmlDir, string $contentLang): array {
+		$languages = [$contentLang];
+		foreach (glob("$htmlDir/*.html") as $file) {
+			// The <html> tag is at the top; a small read avoids loading whole pages.
+			$head = file_get_contents($file, false, null, 0, 2048);
+			if ($head !== false && preg_match('/<html[^>]*\blang="([^"]+)"/', $head, $m)) {
+				$languages[] = $m[1];
+			}
+		}
+		return $languages;
+	}
+
+	/**
+	 * Copy each base-relative woff2 path from ULS's font repo into the output.
+	 *
+	 * @param string $ulsDir
+	 * @param string $destBase Output directory the woff2 tree is copied under.
+	 * @param string[] $files Base-relative woff2 paths (e.g. "AbyssinicaSIL/AbyssinicaSIL-R.woff2").
+	 * @return int The number of files copied.
+	 */
+	private function copyFonts(string $ulsDir, string $destBase, array $files): int {
+		$srcBase = "$ulsDir/data/fontrepo/fonts";
+		$copied = 0;
+		foreach ($files as $relative) {
+			$src = "$srcBase/$relative";
+			if (!is_file($src)) {
+				$this->output("  missing font: $relative\n");
+				continue;
+			}
+			$dest = "$destBase/$relative";
+			$dir = dirname($dest);
+			if (!is_dir($dir) && !wfMkdirParents($dir)) {
+				$this->error("Wikven: could not create font directory $dir");
+				continue;
+			}
+			if (copy($src, $dest)) {
+				$copied++;
+			}
+		}
+		return $copied;
+	}
+}
+
+$maintClass = BakeWebfonts::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -166,6 +166,8 @@ class Build extends Maintenance {
 		// Nothing is rendered after this, so freezing costs no staleness; the asset dumps below read it.
 		$this->freezePageTouched();
 		$this->step(BuildStyles::class, "$own/buildStyles.php");
+		// Opt-in: bake ULS webfonts into a static stylesheet rewriteScripts links below.
+		$this->step(BakeWebfonts::class, "$own/bakeWebfonts.php");
 		$this->step(BuildScripts::class, "$own/buildScripts.php");
 		$this->step(RewriteScripts::class, "$own/rewriteScripts.php");
 		$this->step(StoreImages::class, "$own/storeImages.php");

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -32,6 +32,11 @@ class RewriteScripts extends Maintenance {
 		$siteStylesHref = './' . rtrim($wgWikvenStyleDirectory, '/') . '/site.styles.css';
 		$hasSiteStyles = is_file("$htmlDir/site.styles.css") && filesize("$htmlDir/site.styles.css") > 0;
 
+		// Bundled webfonts (opt-in; bakeWebfonts wrote it): link ahead of site styles so a site can
+		// still override the font-family, and let rename's reparenting fix the href on subpages.
+		$webfontsHref = './' . rtrim($wgWikvenStyleDirectory, '/') . '/webfonts.css';
+		$hasWebfonts = is_file("$htmlDir/webfonts.css") && filesize("$htmlDir/webfonts.css") > 0;
+
 		$rl = MediaWikiServices::getInstance()->getResourceLoader();
 
 		// With SifterSearch the static Pagefind bundle keeps the native search box working, so keep it.
@@ -91,6 +96,15 @@ class RewriteScripts extends Maintenance {
 				'',
 				$html
 			);
+
+			// Link the bundled webfonts, before the site styles injected below.
+			if ($hasWebfonts) {
+				$html = str_replace(
+					'</head>',
+					'<link rel="stylesheet" href="' . $webfontsHref . '"></head>',
+					$html
+				);
+			}
 
 			// Re-link the site styles last (their own file) so they win the cascade over the skin defaults.
 			if ($hasSiteStyles) {

--- a/tests/phpunit/unit/Webfonts/FontRepositoryTest.php
+++ b/tests/phpunit/unit/Webfonts/FontRepositoryTest.php
@@ -18,14 +18,14 @@ class FontRepositoryTest extends MediaWikiUnitTestCase {
 				'ti' => ['AbyssinicaSIL'],
 				'he' => ['Alef'],
 				'af' => ['system', 'OpenDyslexic'],
-				'xx' => ['MissingFont'],
+				'xx' => ['MissingFont']
 			],
 			'fonts' => [
 				'AbyssinicaSIL' => ['woff2' => 'AbyssinicaSIL/AbyssinicaSIL-R.woff2?2942e'],
 				'Alef' => ['woff2' => 'Alef/Alef-Regular.woff2?a2499', 'variants' => ['bold' => 'Alef Bold']],
 				'Alef Bold' => ['fontweight' => 'bold', 'woff2' => 'Alef/Alef-Bold.woff2?7c873'],
-				'OpenDyslexic' => ['woff2' => 'OpenDyslexic/OpenDyslexic.woff2?9f0e1'],
-			],
+				'OpenDyslexic' => ['woff2' => 'OpenDyslexic/OpenDyslexic.woff2?9f0e1']
+			]
 		];
 	}
 
@@ -46,8 +46,7 @@ class FontRepositoryTest extends MediaWikiUnitTestCase {
 	}
 
 	public function testBuildEmitsFacesApplyRulesAndFileList() {
-		$built = ( new FontRepository($this->repository() ) )
-			->build(['am', 'he', 'af', 'xx', 'ti'], 'fonts/uls/');
+		$built = ( new FontRepository($this->repository()) )->build(['am', 'he', 'af', 'xx', 'ti'], 'fonts/uls/');
 
 		$css = $built['css'];
 
@@ -72,24 +71,24 @@ class FontRepositoryTest extends MediaWikiUnitTestCase {
 			[
 				'AbyssinicaSIL/AbyssinicaSIL-R.woff2',
 				'Alef/Alef-Bold.woff2',
-				'Alef/Alef-Regular.woff2',
+				'Alef/Alef-Regular.woff2'
 			],
 			$built['files']
 		);
 	}
 
 	public function testSystemDefaultLanguagesContributeNothing() {
-		$built = ( new FontRepository($this->repository() ) )->build(['af', 'xx'], 'fonts/uls/');
+		$built = ( new FontRepository($this->repository()) )->build(['af', 'xx'], 'fonts/uls/');
 		$this->assertSame('', $built['css']);
 		$this->assertSame([], $built['files']);
 	}
 
 	public function testAFontSharedByTwoLanguagesIsDefinedOnce() {
 		// Both "am" and "ti" default to AbyssinicaSIL.
-		$built = ( new FontRepository($this->repository() ) )->build(['am', 'ti'], 'fonts/uls/');
+		$built = ( new FontRepository($this->repository()) )->build(['am', 'ti'], 'fonts/uls/');
 		$this->assertSame(1, substr_count($built['css'], "@font-face{font-family:'AbyssinicaSIL';"));
-		$this->assertStringContainsString(":lang(am),[lang=\"am\"]", $built['css']);
-		$this->assertStringContainsString(":lang(ti),[lang=\"ti\"]", $built['css']);
+		$this->assertStringContainsString(':lang(am),[lang="am"]', $built['css']);
+		$this->assertStringContainsString(':lang(ti),[lang="ti"]', $built['css']);
 	}
 
 	public function testBuildIsDeterministicRegardlessOfLanguageOrder() {
@@ -101,7 +100,7 @@ class FontRepositoryTest extends MediaWikiUnitTestCase {
 	}
 
 	public function testBasePathIsNormalisedWithASingleTrailingSlash() {
-		$built = ( new FontRepository($this->repository() ) )->build(['am'], '../fonts/uls');
+		$built = ( new FontRepository($this->repository()) )->build(['am'], '../fonts/uls');
 		$this->assertStringContainsString("url('../fonts/uls/AbyssinicaSIL/AbyssinicaSIL-R.woff2')", $built['css']);
 	}
 }

--- a/tests/phpunit/unit/Webfonts/FontRepositoryTest.php
+++ b/tests/phpunit/unit/Webfonts/FontRepositoryTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit\Webfonts;
+
+use MediaWiki\Extension\Wikven\Webfonts\FontRepository;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Webfonts\FontRepository
+ */
+class FontRepositoryTest extends MediaWikiUnitTestCase {
+	/** A trimmed-down repository shaped like ULS's generated ext.uls.webfonts.repository. */
+	private function repository(): array {
+		return [
+			'base' => '../data/fontrepo/fonts/',
+			'languages' => [
+				'am' => ['AbyssinicaSIL'],
+				'ti' => ['AbyssinicaSIL'],
+				'he' => ['Alef'],
+				'af' => ['system', 'OpenDyslexic'],
+				'xx' => ['MissingFont'],
+			],
+			'fonts' => [
+				'AbyssinicaSIL' => ['woff2' => 'AbyssinicaSIL/AbyssinicaSIL-R.woff2?2942e'],
+				'Alef' => ['woff2' => 'Alef/Alef-Regular.woff2?a2499', 'variants' => ['bold' => 'Alef Bold']],
+				'Alef Bold' => ['fontweight' => 'bold', 'woff2' => 'Alef/Alef-Bold.woff2?7c873'],
+				'OpenDyslexic' => ['woff2' => 'OpenDyslexic/OpenDyslexic.woff2?9f0e1'],
+			],
+		];
+	}
+
+	public function testDefaultFamilyPicksTheFirstRealFont() {
+		$repo = new FontRepository($this->repository());
+		$this->assertSame('AbyssinicaSIL', $repo->defaultFamily('am'));
+		$this->assertSame('Alef', $repo->defaultFamily('he'));
+	}
+
+	public function testDefaultFamilyIsNullWhenSystemFontLeadsOrFontIsUnknown() {
+		$repo = new FontRepository($this->repository());
+		// "af" defaults to the system font, so ULS applies no webfont.
+		$this->assertNull($repo->defaultFamily('af'));
+		// The listed family is not in the fonts map.
+		$this->assertNull($repo->defaultFamily('xx'));
+		// No entry for the language at all.
+		$this->assertNull($repo->defaultFamily('zz'));
+	}
+
+	public function testBuildEmitsFacesApplyRulesAndFileList() {
+		$built = ( new FontRepository($this->repository() ) )
+			->build(['am', 'he', 'af', 'xx', 'ti'], 'fonts/uls/');
+
+		$css = $built['css'];
+
+		// @font-face for the applied fonts, with a base-relative, query-stripped url().
+		$this->assertStringContainsString(
+			"@font-face{font-family:'AbyssinicaSIL';font-weight:normal;font-style:normal;font-display:swap;"
+			. "src:local('AbyssinicaSIL'),url('fonts/uls/AbyssinicaSIL/AbyssinicaSIL-R.woff2') format('woff2');}",
+			$css
+		);
+		// The bold variant is declared under the same family name.
+		$this->assertStringContainsString(
+			"@font-face{font-family:'Alef';font-weight:bold;font-style:normal;font-display:swap;"
+			. "src:local('Alef'),url('fonts/uls/Alef/Alef-Bold.woff2') format('woff2');}",
+			$css
+		);
+		// :lang() application rules for the languages whose default is a real font.
+		$this->assertStringContainsString(":lang(am),[lang=\"am\"]{font-family:'AbyssinicaSIL',sans-serif;}", $css);
+		$this->assertStringContainsString(":lang(he),[lang=\"he\"]{font-family:'Alef',sans-serif;}", $css);
+
+		// The woff2 files to copy: deduped, query-stripped, sorted; OpenDyslexic excluded (af is system).
+		$this->assertSame(
+			[
+				'AbyssinicaSIL/AbyssinicaSIL-R.woff2',
+				'Alef/Alef-Bold.woff2',
+				'Alef/Alef-Regular.woff2',
+			],
+			$built['files']
+		);
+	}
+
+	public function testSystemDefaultLanguagesContributeNothing() {
+		$built = ( new FontRepository($this->repository() ) )->build(['af', 'xx'], 'fonts/uls/');
+		$this->assertSame('', $built['css']);
+		$this->assertSame([], $built['files']);
+	}
+
+	public function testAFontSharedByTwoLanguagesIsDefinedOnce() {
+		// Both "am" and "ti" default to AbyssinicaSIL.
+		$built = ( new FontRepository($this->repository() ) )->build(['am', 'ti'], 'fonts/uls/');
+		$this->assertSame(1, substr_count($built['css'], "@font-face{font-family:'AbyssinicaSIL';"));
+		$this->assertStringContainsString(":lang(am),[lang=\"am\"]", $built['css']);
+		$this->assertStringContainsString(":lang(ti),[lang=\"ti\"]", $built['css']);
+	}
+
+	public function testBuildIsDeterministicRegardlessOfLanguageOrder() {
+		$repo = new FontRepository($this->repository());
+		$this->assertSame(
+			$repo->build(['am', 'he', 'ti'], 'fonts/uls/'),
+			$repo->build(['ti', 'he', 'am', 'am'], 'fonts/uls/')
+		);
+	}
+
+	public function testBasePathIsNormalisedWithASingleTrailingSlash() {
+		$built = ( new FontRepository($this->repository() ) )->build(['am'], '../fonts/uls');
+		$this->assertStringContainsString("url('../fonts/uls/AbyssinicaSIL/AbyssinicaSIL-R.woff2')", $built['css']);
+	}
+}


### PR DESCRIPTION
Closes #219.

When Translate/UniversalLanguageSelector is enabled, wikven disables ULS's runtime webfonts (they load from `load.php`, which a static host cannot serve), so a reader whose system lacks a font for a script sees tofu instead of text. This bakes those fonts into the output instead, behind a new opt-in `$wgWikvenBundleWebfonts` (off by default, since it adds font payload).

## How it works

A new build step, `maintenance/bakeWebfonts.php`, runs after `buildStyles` when the opt-in is set and ULS is installed. It:

- reads ULS's generated `ext.uls.webfonts.repository.js` (its object literal is valid JSON) for the `languages → families` and `family → woff2` maps;
- discovers the export's languages from each page's `<html lang="…">`;
- for each language whose ULS default is a real font (not `"system"`), emits an `@font-face` for the font and its bold/italic variants, plus a `:lang()` rule that applies it — exactly the font ULS would auto-apply, with **no runtime JS**;
- copies just those woff2 files into `dist/fonts/uls/` and writes `webfonts.css`.

The stylesheet is linked like `site.styles.css`: `rewriteScripts` wires in the `<link>`, and `rename`'s reparenting keeps it correct at any subpage depth.

## Why baked CSS, not ULS's JS + a base path

The issue sketched reusing ULS's runtime JS with `$wgULSFontRepositoryBasePath` set to `/fonts/uls/`. Reading ULS's `jquery.webfonts.js`, that JS injects `@font-face { src: url(<base> + <file>) }` **into the page context**, so the URL must be absolute to survive a subpage like `Foo/ko.html` — and an absolute `/fonts/uls/` **404s on GitHub Pages project sites** (`user.github.io/repo/`), a primary target.

Baking a plain stylesheet avoids this entirely: URLs in an **external** stylesheet resolve against the stylesheet's own location, not the linking page, so the font `url()`s hold from every page regardless of depth or host subdirectory — no absolute path, no ULS runtime.

## Structure

- `includes/Webfonts/FontRepository.php` — pure font-selection/CSS-generation logic (no I/O), unit-tested.
- `maintenance/bakeWebfonts.php` — the build step; does only the I/O around `FontRepository`.
- `maintenance/build.php` — runs the step after `BuildStyles`.
- `maintenance/rewriteScripts.php` — links `webfonts.css` (mirrors `site.styles.css`).
- `includes/WikvenSettings.php` — comment now points at the opt-in.
- `extension.json` — declares `WikvenBundleWebfonts` (default `false`).
- `docs/Translating.wikitext` — documents the opt-in.

Enable with:

```yaml
config:
  WikvenBundleWebfonts: true
```

## Verification

- `FontRepositoryTest` covers default-font selection (real vs `"system"` vs unknown), `@font-face` + `:lang()` emission, bold/italic variants, dedup of shared fonts, the file list, base-path normalisation, and byte-for-byte determinism regardless of language order.
- Validated the parser and selection against the **real** upstream ULS data (112 languages, 95 fonts): the repository JS parses as JSON, and the resolved woff2 files exist on disk (e.g. `am → AbyssinicaSIL`, `bn → Siyam Rupali`; `ar`/`he`/`en` correctly get none, matching ULS's system-default behavior).
- Not exercised locally: the full MediaWiki bake, since ULS isn't part of this checkout (it's fetched into the image at build time). The end-to-end path runs in CI / a real build.

## Notes for review

- Fonts are applied broadly via `:lang(xx)` (matching ULS's own default-font application). Inline foreign-language spans are covered only when that language also has a rendered page (discovery reads `<html lang>`, not inline spans) — fine for the per-language-page case #219 targets.
- Per-skin passes copy the fonts under each skin's output dir; correct, with minor byte duplication across skins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A44TcRUYBgT5edbEe1r4Cz)_