### PR TITLE
ci: surface PR previews as a native deployment, not a comment

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -23,7 +23,7 @@ on:
 
 permissions:
   contents: write  # push the preview to the gh-pages branch
-  pull-requests: write  # post and update the sticky preview comment
+  deployments: write  # record the preview as a native GitHub deployment (shown on the PR)
 
 # One preview build per PR; a new push supersedes an in-flight one.
 concurrency:
@@ -65,9 +65,65 @@ jobs:
           cache: false  # the image was just built locally; nothing to cache or pull
 
       # Deploy dist/ to pr-preview/pr-<N>/ on gh-pages on open/sync, and remove it on close.
+      # comment: false - the preview surfaces as a native GitHub deployment (below), not a comment.
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1.8.1
         with:
           source-dir: dist
           preview-branch: gh-pages
           umbrella-dir: pr-preview
+          comment: false
+
+      # Surface the preview as a native GitHub deployment, so the PR shows a "View deployment"
+      # button and an environment badge instead of a comment. The URL matches the umbrella path
+      # the action deploys to. auto-inactive is off so each open PR's preview stays active
+      # independently (one shared "preview" environment, one deployment per PR head).
+      - name: Record preview deployment
+        if: success() && github.event.action != 'closed'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const number = context.payload.number;
+            const url = `https://${context.repo.owner}.github.io/`
+              + `${context.repo.repo}/pr-preview/pr-${number}/`;
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              environment: 'preview',
+              transient_environment: true,
+              auto_merge: false,
+              required_contexts: [],
+              description: `Preview for PR #${number}`,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment_url: url,
+              auto_inactive: false,
+              description: 'Preview is live',
+            });
+
+      # On close, mark this PR's preview deployment inactive, matching the torn-down files.
+      - name: Deactivate preview deployment
+        if: always() && github.event.action == 'closed'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: 'preview',
+              ref: context.payload.pull_request.head.sha,
+            });
+            for (const deployment of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: 'inactive',
+                description: 'Preview removed',
+              });
+            }


### PR DESCRIPTION
Replaces the docs-PR "preview is ready" sticky comment with a native GitHub **deployment**, so a PR shows a **"View deployment"** button and an environment badge — the affordance most preview tooling (Vercel/Netlify/…) uses.

## Why a github-script step

`rossjrw/pr-preview-action` exposes a `comment` input (so the sticky comment is just `comment: false`), but it only pushes files to `gh-pages` — it never touches GitHub's Deployments API. So a small `actions/github-script` step creates the deployment itself:

- **On open/sync:** create a deployment on the PR head, environment `preview`, and a `success` status whose `environment_url` points at the umbrella path (`…/pr-preview/pr-<N>/`, the same URL the comment used).
- **`auto_inactive: false`** so each open PR's preview stays active independently under the one shared `preview` environment (otherwise a new PR's deployment would inactivate the others').
- **On close:** mark that PR's deployment `inactive`, matching the files the action tears down.

## Cost

Free. The Deployments API, the "View deployment" UI, and the Environments tab are available on all plans for public repos; only environment *protection rules* are ever gated, and this doesn't use them.

## Permissions

- Adds `deployments: write`.
- Drops `pull-requests: write` — no longer needed once the action stops commenting.

## Verification

- YAML parses; all lines ≤120, no trailing whitespace, ASCII-only (matches the repo's yamllint/typos config).
- `actions/github-script` pinned to the v7.0.1 commit, consistent with the repo's SHA-pinning convention.
- The preview build/deploy path itself is unchanged; only the surfacing (comment → deployment) differs. End-to-end deployment UI is exercised when this workflow runs on a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A44TcRUYBgT5edbEe1r4Cz)_