### PR TITLE
fix: create directories with wfMkdirParents

### DIFF
--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -170,8 +170,10 @@ class Main implements
 			$path = rtrim($path, '/');
 		}
 		$path .= '/' . $this->styleDirectory;
-		if (!is_dir($path)) {
-			mkdir($path, 0777, true);
+		// Honours $wgDirectoryMode, tolerates a concurrent create (build.php renders one process per
+		// skin) and logs a real failure instead of printing a warning into the page.
+		if (!wfMkdirParents($path, null, __METHOD__)) {
+			return;
 		}
 		if (!file_exists("$path/$name.css")) {
 			touch("$path/$name.css");

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -66,7 +66,9 @@ if ($wikvenWorkEnv !== false && $wikvenWorkEnv !== '') {
 	$wgCacheDirectory = "$wikvenCache/mw";
 	$wgTmpDirectory = "$wikvenCache/tmp";
 	foreach ([$wgUploadDirectory, $wgCacheDirectory, $wgTmpDirectory] as $wikvenDir) {
-		if (!is_dir($wikvenDir) && !mkdir($wikvenDir, 0777, true) && !is_dir($wikvenDir)) {
+		// Honours $wgDirectoryMode and re-checks is_dir() itself after a losing race, which the
+		// standalone binary can hit when two builds share one workdir.
+		if (!wfMkdirParents($wikvenDir, null, __FILE__)) {
 			throw new \RuntimeException("Wikven: could not create directory $wikvenDir");
 		}
 	}

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -33,8 +33,8 @@ class BuildScripts extends Maintenance {
 
 		$htmlDir = rtrim($wgWikvenHtmlDirectory, '/');
 		$outDir = $htmlDir . '/' . rtrim($wgWikvenScriptDirectory, '/');
-		if (!is_dir($outDir)) {
-			mkdir($outDir, 0777, true);
+		if (!wfMkdirParents($outDir, null, __METHOD__)) {
+			$this->fatalError("Could not create script directory $outDir");
 		}
 
 		$rl = MediaWikiServices::getInstance()->getResourceLoader();


### PR DESCRIPTION
1 of 18 from #288. This PR was originally the whole of group A; it has been reduced to a single finding and the rest split out, one PR per finding — see the index in #288.

Three sites hand-rolled `if (!is_dir($d)) mkdir($d, 0777, true)` while five others in the same tree already used core's helper: `build.php:157`, `bakeWebfonts.php:83` and `:166`, `rename.php:65`, `scaffoldTranslations.php:78`.

`wfMkdirParents()` honours `$wgDirectoryMode` instead of hardcoding `0777`, re-checks `is_dir()` after a failed `mkdir` so a lost race is not an error, and reports a genuine failure instead of letting PHP print a bare warning into whatever stream happens to be open. The race is real here: `build.php` spawns a process per skin, and the standalone binary can have two builds sharing one workdir.

All three failures were silent:

- **`includes/Hooks/Main.php:174`** — an unwritable style directory means the CSS stubs are never created, `buildStyles.php` globs an empty directory, and pages ship `<link>` tags (already emitted at `Main.php:139`) pointing at stylesheets that do not exist.
- **`maintenance/buildScripts.php:36`** — the failed `mkdir` is swallowed, `file_put_contents()` at line 64 then fails, the export has no JS bundle, and line 82 reports success anyway. Now a `fatalError`.
- **`includes/WikvenSettings.php:68`** — already threw on failure, so only the mode and race handling change here.

Verified with `phpcs` (clean across the repo) and `php -l`. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally; `wfMkdirParents`' signature and race handling were read from `REL1_46`, the tag the Dockerfile pins.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp