### PR TITLE
refactor: import old revisions through OldRevisionImporter

### DIFF
--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -7,11 +7,11 @@ use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\ContentHandler;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
+use MediaWiki\Import\WikiRevision;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
-use WikiRevision;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 	? getenv('MW_INSTALL_PATH')
@@ -76,7 +76,9 @@ class ImportWikitext extends Maintenance {
 			$revision->setComment('');
 			$revision->setTimestamp(wfTimestamp(TS_UNIX, filemtime($filename)));
 
-			if ($revision->importOldRevision()) {
+			// WikiRevision::importOldRevision() has been a deprecated shim for this service since 1.31.
+			$importer = $this->getServiceContainer()->getWikiRevisionOldRevisionImporter();
+			if ($importer->import($revision)) {
 				$this->output(" done\n");
 			} else {
 				$this->output(" failed\n");


### PR DESCRIPTION
2 of 18 from #288.

Verified against `REL1_46`, the tag the Dockerfile pins: `WikiRevision::importOldRevision()` carries `@deprecated since 1.31. Use OldRevisionImporter::import`, and its body does nothing but resolve that service and call `import($this)`.

1.46 also moved the class to `namespace MediaWiki\Import` and left `class_alias(WikiRevision::class, 'WikiRevision')` marked deprecated since 1.46 — so the `use WikiRevision;` on line 14 was on a deprecated path as of the pinned core too.

Both are pure indirection today, so this is a no-op at runtime. The point is that the file stops reaching a service it can name directly through two separately-deprecated entry points.

The namespaced class name requires 1.46+, which `extension.json` already demands (`"MediaWiki": ">= 1.46.0"`).

Verified with `phpcs` and `php -l`. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally; the deprecation and the shim's body were read from the `REL1_46` source.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_