### PR TITLE
fix: report a vetoed File:/MediaWiki: import as a failure

### DIFF
--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -64,7 +64,16 @@ class ImportWikitext extends Maintenance {
 				$updater = $page->newPageUpdater($user);
 				$updater->setContent(SlotRecord::MAIN, $content);
 				$updater->saveRevision(CommentStoreComment::newUnsavedComment('Import'));
-				$this->output(" done\n");
+				// These are exactly the pages an edit hook may veto -- AbuseFilter or SpamBlacklist on a
+				// File: description, CSS validation on MediaWiki:Common.css.
+				if ($updater->wasSuccessful()) {
+					$this->output(" done\n");
+				} else {
+					$status = $updater->getStatus();
+					$reason = $status ? $status->getWikiText(false, false, 'en') : 'no revision was saved';
+					$this->output(' failed: ' . $reason . "\n");
+					$failed[] = $relative;
+				}
 				continue;
 			}
 


### PR DESCRIPTION
3 of 18 from #288.

The `NS_FILE`/`NS_MEDIAWIKI` branch called `saveRevision()`, discarded the result, printed `" done"` and continued.

The method's own contract is `@return bool Whether every file was imported successfully`, and the comment at the bottom of the loop says failures must be loud because *"a silent partial export is worse than none"*. That guarantee was void for exactly the namespaces most likely to need it — the old-revision branch below was the only one that checked anything.

`saveRevision()` returns `null` and leaves a fatal status when a hook vetoes the edit:

- a `File:` description page rejected by `MultiContentSave` or `EditFilterMergedContent` (AbuseFilter, SpamBlacklist),
- a `MediaWiki:Common.css` failing CSS content validation.

The build then published with the page silently missing while `execute()` returned `true`.

`PageUpdater::wasSuccessful()` and `getStatus()` are already available on the object in hand, so this needs no new service. The status text is included in the failure line so the reason reaches the build log.

Builds that were quietly dropping pages will now fail, which is the point.

Verified with `phpcs` and `php -l`. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_