### PR TITLE
fix: match &lt;translate&gt; with its attributes, as Translate does

### DIFF
--- a/includes/PageTranslation/TranslationSource.php
+++ b/includes/PageTranslation/TranslationSource.php
@@ -17,6 +17,13 @@ use RecursiveIteratorIterator;
  * buildTranslations (materialize) so both agree on what is a base and what is a translation.
  */
 class TranslationSource {
+	/**
+	 * An opening <translate> tag, attributes and all. Translate accepts <translate nowrap>, and
+	 * StalenessComputer::mark() matches the same shape, so both halves of the pipeline agree on
+	 * what counts as a translatable page.
+	 */
+	private const TRANSLATE_TAG = '#<translate(?:\s[^>]*)?>#';
+
 	/** Whether a page's wikitext marks it as translatable (a real <translate>, not one shown as an example). */
 	public static function isTranslatable(string $text): bool {
 		// A <translate> inside a verbatim span -- <syntaxhighlight>, <nowiki>, <pre>, <source> -- is an
@@ -25,7 +32,10 @@ class TranslationSource {
 		// looking for a real tag, rather than trusting a hand-rolled regex.
 		$matches = [];
 		$stripped = Parser::extractTagsAndParams(['syntaxhighlight', 'source', 'nowiki', 'pre'], $text, $matches);
-		return str_contains($stripped, '<translate>');
+		// Match the tag the way Translate itself does, attributes included: <translate nowrap> is a real
+		// translatable page, and StalenessComputer::mark() accepts the same shape, so the two agree on
+		// what marks a page for CI checks and the translated build.
+		return preg_match(self::TRANSLATE_TAG, $stripped) === 1;
 	}
 
 	/**

--- a/tests/phpunit/integration/TranslationSourceTest.php
+++ b/tests/phpunit/integration/TranslationSourceTest.php
@@ -21,6 +21,12 @@ class TranslationSourceTest extends MediaWikiIntegrationTestCase {
 	public static function provideIsTranslatable(): array {
 		return [
 			'a real translate block' => ["<languages/>\n<translate>\n<!--T:1-->\nHi.\n</translate>", true],
+			// Translate accepts attributes on the tag.
+			'a translate block with an attribute' => [
+				"<languages/>\n<translate nowrap>\n<!--T:1-->\nHi.\n</translate>",
+				true
+			],
+			'a tag that merely starts the same way' => ['<translatex>Hi.</translatex>', false],
 			'plain text' => ['Just prose, no markup.', false],
 			// The page documenting page translation shows <translate> as an example; it is not a source.
 			'translate inside syntaxhighlight' => [


### PR DESCRIPTION
4 of 18 from #288.

`isTranslatable()` decided translatability with `str_contains($stripped, '<translate>')`, which misses `<translate nowrap>`.

That is ordinary Translate markup, so a page beginning

```
<languages/>
<translate nowrap>
<!--T:1-->
…
```

was not translatable as far as wikven was concerned: it never appeared in `baseFiles()`, so it was never marked, never checked by CI, never built with translations, and `translate scaffold` reported it as "not translatable, skipped".

The inconsistency is visible inside the same directory — `StalenessComputer::mark()` already matches `<translate(?:\s[^>]*)?>`, so the two halves of one pipeline disagreed about what a `<translate>` tag is. The shape is now a named constant here, matching `mark()`'s.

The `Parser::extractTagsAndParams` pre-pass stays, so a `<translate>` shown as an example inside `<syntaxhighlight>`/`<nowiki>`/`<pre>`/`<source>` is still not a source page. That is why Translate's own `TranslatablePageParser::containsMarkup()` is not used directly: it has no notion of those verbatim spans, which `TranslationSourceTest::provideIsTranslatable` pins.

Two provider cases added: `<translate nowrap>` is translatable, and `<translatex>` is not.

Verified with `phpcs` and `php -l`, plus a standalone check of the pattern against both. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_