### PR TITLE
fix: take the DISPLAYTITLE spellings from the magic word registry

### DIFF
--- a/includes/PageTranslation/TranslationSource.php
+++ b/includes/PageTranslation/TranslationSource.php
@@ -4,9 +4,11 @@ namespace MediaWiki\Extension\Wikven\PageTranslation;
 
 use FilesystemIterator;
 use MediaWiki\Extension\Wikven\SourceFile;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Throwable;
 
 /**
  * Locates translatable source pages and their translations by wikven's naming convention.
@@ -58,7 +60,41 @@ class TranslationSource {
 		// documenting page translation -- is an example, not a magic word the parser ever runs.
 		$matches = [];
 		$stripped = Parser::extractTagsAndParams(['syntaxhighlight', 'source', 'nowiki', 'pre'], $text, $matches);
-		return preg_match('/\{\{\s*DISPLAYTITLE\s*:/i', $stripped) === 1;
+		// DISPLAYTITLE is a localized magic word: on a de-content wiki the working spelling is
+		// {{ANZEIGETITEL:}}. Checking every synonym in the content language covers that, or such a page
+		// is handed a title unit its own magic word then overrides.
+		foreach (self::displayTitleSynonyms() as $synonym) {
+			if (preg_match('/\{\{\s*' . preg_quote($synonym, '/') . '\s*:/i', $stripped) === 1) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Every spelling of the DISPLAYTITLE magic word in the content language, English always included.
+	 *
+	 * @return string[]
+	 */
+	private static function displayTitleSynonyms(): array {
+		try {
+			$synonyms = MediaWikiServices::getInstance()
+				->getMagicWordFactory()
+				->get('displaytitle')
+				->getSynonyms();
+		} catch (Throwable) {
+			// Callers include maintenance scripts that run before the container is usable; the English
+			// spelling works on the wikis wikven itself ships, so a missing registry is not fatal.
+			$synonyms = [];
+		}
+		$synonyms[] = 'DISPLAYTITLE';
+		$unique = [];
+		foreach ($synonyms as $synonym) {
+			if ($synonym !== '' && !in_array($synonym, $unique, true)) {
+				$unique[] = $synonym;
+			}
+		}
+		return $unique;
 	}
 
 	/** The translation file for a base file in the given language ("Foo.wikitext" -> "Foo/ko.wikitext"). */


### PR DESCRIPTION
5 of 18 from #288.

`hasFixedDisplayTitle()` matched `/\{\{\s*DISPLAYTITLE\s*:/i` — the English spelling of a localized magic word.

On a `$wgLanguageCode = 'de'` site the working form is `{{ANZEIGETITEL:Wikven}}`. The check returned false for it, so `translatableTitle()` handed back a title unit, `scaffold` asked translators for a translated title, `buildTranslations` wrote it into Translate's Page-display-title unit — and the page's own DISPLAYTITLE then overrode it in every language.

That is precisely the outcome the doc comment above says the exclusion exists to prevent: *"asking for a translation Translate could not apply would only invite one that silently does nothing."*

`MagicWordFactory->get('displaytitle')->getSynonyms()` returns the content language's spellings. English is kept in the list unconditionally, so nothing regresses on an en wiki, and synonyms are `preg_quote`d before going into the pattern.

The lookup is wrapped because `markTranslations` and `scaffoldTranslations` do not check that they are running against a usable service container; on a failure it falls back to the English spelling, which is what the code did before.

`TranslationSourceTest` is already an integration test, since `extractTagsAndParams` needs the parser, so there is no test-tier change.

Verified with `phpcs` and `php -l`. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_