### PR TITLE
fix: list directories with FilesystemIterator, not glob

### DIFF
--- a/includes/PageTranslation/TranslationSource.php
+++ b/includes/PageTranslation/TranslationSource.php
@@ -97,8 +97,14 @@ class TranslationSource {
 			return [];
 		}
 		$languages = [];
-		foreach (glob("$directory/*.wikitext") ?: [] as $file) {
-			$lang = basename($file, '.wikitext');
+		// The directory name comes from a page title, and *, ? and [ are legal there; a glob pattern
+		// built from it would expand them in every path component, so "C*-algebra" would also match the
+		// translations of "Clifford-algebra" and import their units into the wrong page.
+		foreach (new FilesystemIterator($directory, FilesystemIterator::SKIP_DOTS) as $file) {
+			if (!$file->isFile() || $file->getExtension() !== 'wikitext') {
+				continue;
+			}
+			$lang = $file->getBasename('.wikitext');
 			if ($isKnownLanguage($lang)) {
 				$languages[] = $lang;
 			}

--- a/maintenance/stripBuildStamps.php
+++ b/maintenance/stripBuildStamps.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven;
 
+use FilesystemIterator;
 use Maintenance;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
@@ -25,8 +26,13 @@ class StripBuildStamps extends Maintenance {
 		}
 
 		$changed = 0;
-		foreach (glob("$dir/*.html") as $file) {
-			$html = (string)file_get_contents($file);
+		// A configured directory containing a glob metacharacter would make a glob pattern built from it
+		// match nothing, silently leaving a per-build request id in every page.
+		foreach (new FilesystemIterator($dir, FilesystemIterator::SKIP_DOTS) as $file) {
+			if (!$file->isFile() || $file->getExtension() !== 'html') {
+				continue;
+			}
+			$html = (string)file_get_contents($file->getPathname());
 			$stripped = BuildStamps::strip($html);
 			if ($stripped !== $html) {
 				file_put_contents($file, $stripped, LOCK_EX);


### PR DESCRIPTION
6 of 18 from #288.

Two places used `glob()` as a directory lister with the directory name interpolated into the pattern:

- `TranslationSource::translationLanguages()` built `"$directory/*.wikitext"` from a path derived from a **page title**
- `stripBuildStamps` built `"$dir/*.html"` from a configured path

`*`, `?` and `[` are legal in MediaWiki page titles and in filenames, and `glob()` expands them in *every* path component.

A page `docs/C*-algebra.wikitext` with its translations in `docs/C*-algebra/` produces the pattern `docs/C*-algebra/*.wikitext`, which also matches `docs/Clifford-algebra/ko.wikitext`. `translationLanguages()` then reports `ko` for a page that has no Korean translation, `checkTranslations` compares that file against the wrong source, and `buildTranslations` imports its units into the wrong page.

A `[` in the configured HTML directory makes `stripBuildStamps` match nothing and silently leave a per-build request id in every page — which defeats the reproducible output the class exists for.

`FilesystemIterator` lists a directory by name and never reinterprets it as a pattern. `baseFiles()` and `resolveTranslationLinks` already use the SPL iterators, so this is the idiom the rest of the tree uses. It returns entries unsorted, so the existing `sort()` stays.

`stripBuildStamps` also lacked the `?: []` guard its counterpart had, so a `glob()` failure was a PHP 8 `TypeError` rather than a no-op; that goes away with the call.

Verified with `phpcs` and `php -l`. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_