### PR TITLE
fix: split translation units only on adjacent newlines, as Translate does

### DIFF
--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -81,7 +81,11 @@ class StalenessComputer {
 				if (self::insideVerbatim($block[0][1], $verbatim)) {
 					return $block[0][0];
 				}
-				$units = preg_split('/(\n[ \t]*\n)/', $block[2][0], -1, PREG_SPLIT_DELIM_CAPTURE);
+				// The two newlines must be adjacent, matching Translate's own sectioniser
+				// ('~(^\s*|\s*\n\n\s*|\s*$)~'): a line of spaces or tabs between them is still the same
+				// unit to Translate, and marking it as two would put a <!--T:n--> mid-unit, which
+				// Translate rejects (pt-shake-position).
+				$units = preg_split('/(\n\n)/', $block[2][0], -1, PREG_SPLIT_DELIM_CAPTURE);
 				$marked = '';
 				foreach ($units as $index => $segment) {
 					// Odd indices are the blank-line separators between units; keep them verbatim.

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -24,6 +24,14 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 		);
 	}
 
+	public function testMarkDoesNotSplitOnALineThatOnlyLooksBlank() {
+		// Translate's sectioniser needs the two newlines adjacent, so it reads this as one unit.
+		$this->assertSame(
+			"<translate>\n<!--T:1-->\nFirst.\n \nSecond.\n</translate>",
+			StalenessComputer::mark("<translate>\nFirst.\n \nSecond.\n</translate>")
+		);
+	}
+
 	public function testMarkKeepsExistingNumbersAndContinuesFromTheHighest() {
 		$this->assertSame(
 			"<translate>\n<!--T:5-->\nOld.\n\n<!--T:6-->\nNew.\n</translate>",


### PR DESCRIPTION
7 of 18 from #288.

`mark()` separated units on `/(\n[ \t]*\n)/`, so a "blank" line carrying a space or a tab ended a unit.

Translate's own sectioniser needs the two newlines **adjacent** — verified against `REL1_46`, `TranslatablePageParser.php:128`:

```php
$parts = preg_split( '~(^\s*|\s*\n\n\s*|\s*$)~', $text, -1, $flags );
```

The two have to agree, because `buildTranslations.php` feeds wikven-marked wikitext straight into Translate's real marker (`getMarkOperation()`) and then writes translated units keyed by wikven's ids.

Failing input — note the single space on the middle line:

```
<translate>
First paragraph.
 
Second paragraph.
</translate>
```

wikven wrote `<!--T:1-->` and `<!--T:2-->` where Translate sees one unit. Translate then rejects the page for carrying a marker mid-unit (`pt-shake-position`), `getUnitValidationStatus()->isOK()` is false, and `buildTranslations` prints "has invalid translation units; skipping" — so an invisible trailing space in a docs file silently dropped the page from the translated build.

Adopting Translate's `TranslatablePageParser` wholesale is the larger version of this and is recorded in #288 (group B): its `parse()` is pure string work, but it armours only `<nowiki>` — not `<syntaxhighlight>`/`<pre>`/`<source>` — and appends markers to the end of a heading line rather than on their own line above. Both are pinned by the existing tests.

**Verification.** `StalenessComputer` has no MediaWiki dependencies, so it was run standalone against every assertion copied out of `StalenessComputerTest`: all pass unchanged, and the new regression case yields exactly one marker. `phpcs` clean.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_