### PR TITLE
fix: stop the RLPAGEMODULES rewrite from editing article prose

### DIFF
--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -68,8 +68,10 @@ class RewriteScripts extends Maintenance {
 			$trigger = array_merge($trigger, $this->defaultGadgetModules());
 			$trigger = array_values(array_unique($trigger));
 
-			// Stop the startup module from auto-loading anything over the network.
-			$html = preg_replace('/RLPAGEMODULES=\[[^\]]*\]/', 'RLPAGEMODULES=[]', $html);
+			// Stop the startup module from auto-loading anything over the network. Only the first match:
+			// the assignment lives in the RLQ script near the top of the page, and the same string can
+			// legitimately recur in the article body, e.g. a page documenting this pattern.
+			$html = preg_replace('/RLPAGEMODULES=\[[^\]]*\]/', 'RLPAGEMODULES=[]', $html, 1);
 
 			// Swap the async load.php startup tag for the local bundle + trigger.
 			$tags =


### PR DESCRIPTION
8 of 18 from #288.

```php
$html = preg_replace('/RLPAGEMODULES=\[[^\]]*\]/', 'RLPAGEMODULES=[]', $html);
```

No `$limit`, so it rewrote every occurrence in the page — not just the assignment in the RLQ script near the top.

A page whose visible content mentions the string is rendered as `RLPAGEMODULES=[&quot;foo&quot;]`, which `\[[^\]]*\]` matches, so the published site silently lost that text. The `docs/` tree is this project's own demo site, so the page most likely to say it is one we ship.

Bounding the replacement to one match removes the corruption.

Two things recorded in #288 rather than fixed here:

- Scoping the edit to the RLQ `<script>` element with `Wikimedia\RemexHtml\Tokenizer` is the principled version — it removes the class of bug rather than the instance — but it is real work for a small payoff next to a one-argument fix.
- `[^\]]*` cannot span a `]`, which is a legal ResourceLoader module-name character (`isValidModuleName` only rejects `!`, `,`, `|`), so such a name makes `json_decode` return null a few lines above and drops the page's whole module queue. Same regex, different defect, left for the tokenizer change.

Verified with `phpcs` and `php -l`. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_