### PR TITLE
fix: decode JS-bundle URL escapes with json_decode in AssetLocalizer

### DIFF
--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -34,14 +34,13 @@ class AssetLocalizer {
 
 			// (1) ResourceLoader image endpoint.
 			$text = preg_replace_callback(
-				'~url\(\s*[\'"]?([^)\'"]*load\.php\?[^)\'"]*image=[^)\'"]*?)[\'"]?\s*\)~',
+				// The delimiter is a literal quote in a plain stylesheet, but inside a JS bundle it is the
+				// escaped " / ' CSSMin emits whenever a url() has to be quoted.
+				'~url\(\s*(?:\\\\u002[27]|[\'"])?([^)\'"]*load\.php\?[^)\'"]*image=[^)\'"]*?)'
+				. '(?:\\\\u002[27]|[\'"])?\s*\)~',
 				static function ($m) use (&$map, $rl, $dir, $lang, $skin, $inline) {
 					// Decode the JSON-string escapes used inside JS bundles.
-					$url = str_replace(
-						['\\/', '\\u0026', '\\u003d', '\\u003D'],
-						['/', '&', '=', '='],
-						$m[1]
-					);
+					$url = self::decodeJsonString($m[1]);
 					if (!array_key_exists($url, $map)) {
 						$map[$url] = self::dumpRlImage($rl, $url, $dir, $lang, $skin, $inline);
 					}
@@ -56,7 +55,7 @@ class AssetLocalizer {
 					'~url\(\s*[\'"]?(\\\\?/(?:skins|resources|extensions)/[^)\'"?]+'
 					. '\.(?:svg|png|gif|jpe?g))(?:\?[^)\'"]*)?[\'"]?\s*\)~',
 					static function ($m) use (&$map, $mwRoot, $dir, $inline) {
-						$path = str_replace('\\/', '/', $m[1]);
+						$path = self::decodeJsonString($m[1]);
 						if (!array_key_exists($path, $map)) {
 							$map[$path] = self::copyAsset($mwRoot, $path, $dir, $inline);
 						}
@@ -68,6 +67,19 @@ class AssetLocalizer {
 
 			file_put_contents($file, $text, LOCK_EX);
 		}
+	}
+
+	/**
+	 * Undo the escaping a URL picked up from being embedded in a JS bundle's JSON string literal.
+	 *
+	 * ResourceLoader escapes those with JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT, so
+	 * json_decode is the exact inverse and covers every escape those flags produce. Text that is not a
+	 * JSON string body -- a plain CSS file, where nothing was escaped in the first place -- passes
+	 * through unchanged.
+	 */
+	private static function decodeJsonString(string $text): string {
+		$decoded = json_decode('"' . $text . '"');
+		return is_string($decoded) ? $decoded : $text;
 	}
 
 	/** Encode raw image bytes as a data: URI usable unquoted inside url(). */


### PR DESCRIPTION
9 of 18 from #288.

A `url()` lifted out of a combined-mode JS bundle was un-escaped with a four-entry table:

```php
str_replace(['\\/', '\\u0026', '\\u003d', '\\u003D'], ['/', '&', '=', '='], $m[1])
```

ResourceLoader escapes those strings with `JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT` — the `&` in the table is itself the evidence that `JSON_HEX_AMP` is on, so the quote flags are too. `json_decode` is the exact inverse, so the file stops having to track core's encoder.

**The regex needed widening with it.** `CSSMin::buildUrlValue()` quotes any URL containing a character outside `[\w\d:@/~.%+;,?&=-]`, such as a multi-module `modules=a|b` image URL, and inside a bundle that quote arrives as `"`. The old `['\"]?` matched only a literal quote, so the escape was captured *as part of the URL*, `parse_str` yielded `image=foo"`, `dumpRlImage()` returned null, and the asset was left pointing at `load.php` — a 404 on a static host, which is the one thing this class exists to prevent.

**Verification.** The pattern was exercised against both forms:

| input | before | after |
|---|---|---|
| `url(/load.php?…&image=foo)` | ✅ | ✅ unchanged |
| `url("…")`, `url('…')` | ✅ | ✅ unchanged |
| `url(\/load.php?…&image=foo)` | ✅ | ✅ unchanged |
| `url("\/load.php?modules=a\|b&image=foo")` | ❌ `"/load.php?…"` | ✅ `/load.php?modules=a\|b&image=foo` |
| `url('…')` | ❌ | ✅ |

Non-JSON input (a plain CSS file, where nothing was escaped) falls back to the raw capture unchanged.

`CSSMin::encodeStringAsDataURI` for the data: URIs is the other half of this area and is left for a follow-up in #288 — it changes the encoding of every inlined icon, which `AssetLocalizerTest` pins.

`phpcs` clean. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_