### PR TITLE
fix: give the per-skin build its own environment and working directory

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -5,9 +5,14 @@
 		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis" />
 		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeClassBrace" />
-		<!-- wikven shells out (passthru) and uses @ for best-effort filesystem ops; allow both. -->
+		<!-- wikven shells out and uses @ for best-effort filesystem ops; allow both. Shell::command() is
+		     not the alternative here: it buffers the child's output, which loses the live progress of a
+		     per-skin build or a slow composer run, and its default restrictions hide LocalSettings.php
+		     from a nested maintenance script. proc_open is the safest of these (an array argv never
+		     reaches a shell), so it is allowed alongside the passthru calls it has not replaced. -->
 		<exclude name="MediaWiki.Usage.ForbiddenFunctions.passthru" />
 		<exclude name="MediaWiki.Usage.ForbiddenFunctions.escapeshellarg" />
+		<exclude name="MediaWiki.Usage.ForbiddenFunctions.proc_open" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
 	</rule>
 	<file>.</file>

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -131,18 +131,26 @@ class Build extends Maintenance {
 			$this->fatalError('Wikven: cannot locate the PHP executable to render skins');
 		}
 
-		// run.php resolves relative to the install root (binary php-cli needs it), so chdir there.
-		chdir($GLOBALS['IP']);
 		$command = array_merge($prefix, ['maintenance/run.php', __FILE__]);
 
-		$previous = getenv('WIKVEN_BUILD_SKIN');
-		putenv("WIKVEN_BUILD_SKIN=$skin");
-		passthru(implode(' ', array_map('escapeshellarg', $command)), $exit);
-		if ($previous === false) {
-			putenv('WIKVEN_BUILD_SKIN');
-		} else {
-			putenv("WIKVEN_BUILD_SKIN=$previous");
+		// The skin and the working directory are passed as arguments, scoped to the child alone, so
+		// this process's own environment and cwd stay untouched while a skin renders. run.php resolves
+		// relative to the install root, which the binary's php-cli requires, hence $GLOBALS['IP'] as
+		// the child's cwd. An array argv also means the arguments never pass through a shell to be
+		// quoted for.
+		$descriptors = [0 => STDIN, 1 => STDOUT, 2 => STDERR];
+		$pipes = [];
+		$process = proc_open(
+			$command,
+			$descriptors,
+			$pipes,
+			$GLOBALS['IP'],
+			['WIKVEN_BUILD_SKIN' => $skin] + getenv()
+		);
+		if ($process === false) {
+			$this->fatalError("Wikven: could not start the build for skin '$skin'");
 		}
+		$exit = proc_close($process);
 
 		if ($exit !== 0) {
 			$this->fatalError("Wikven: build failed for skin '$skin' (exit $exit)");


### PR DESCRIPTION
10 of 18 from #288.

`renderSkinPass()` passed the skin by mutating **this process's** environment with `putenv()` and set the child's working directory with `chdir($IP)`, never restoring it. Both are global side effects standing in for per-child state.

- `includes/WikvenSettings.php:201` reads `WIKVEN_BUILD_SKIN` at settings-load time, so through the loop the orchestrator itself was "in" a skin it was not rendering. Anything in the parent re-reading settings or calling `getenv()` between the `putenv` and its restore saw the wrong one.
- The `chdir` is needed because `run.php` resolves relative to the install root, which the binary's `php-cli` requires — but it was never undone, so every relative path in the parent after the first skin resolved against `$IP`.

`proc_open()` takes a `$cwd` and an `$env` per child and touches neither in the parent. Passing an **array argv** also means the arguments never reach a shell to be quoted for in the first place, so the `implode`/`escapeshellarg` round trip goes away (correct today only because every argument is internally controlled — `readlink('/proc/self/exe')` is not). Descriptor specs `[0 => STDIN, 1 => STDOUT, 2 => STDERR]` keep the live passthrough `passthru()` provided; `proc_close()` returns the exit status.

**Why not Shellbox.** `MediaWiki\Shell\Shell::command()` is core-bundled but wrong here: it buffers output into a `Result`, losing the per-skin progress of a long bake, and its default `RESTRICT_DEFAULT` includes `NO_LOCALSETTINGS`, which would hide `LocalSettings.php` from the nested maintenance script and break the child outright. `.phpcs.xml` records that next to the `proc_open` exclusion, alongside the `passthru` one already there for the calls this does not replace (`fetchExtensions`, `bin/build.php`).

`phpcs` clean across the repo with the updated ruleset. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_