### PR TITLE
fix: drop the history directory without shelling out, and check the result

### DIFF
--- a/bin/build.php
+++ b/bin/build.php
@@ -83,10 +83,28 @@ $run(["$ip/extensions/Wikven/maintenance/fetchExtensions.php"]);
 $run(['update', '--quick']);
 $run(["$ip/extensions/Wikven/maintenance/build.php"]);
 
-// Drop the per-page history the file cache emits, as the Docker run does.
+// Drop the per-page history the file cache emits, as the Docker run does. Done without a shell: this
+// is the entry point that has to work on a host with no distro toolchain -- it hunts for its own
+// executable and a CA bundle above for the same reason -- and each removal's result is checked so a
+// failure here is reported instead of leaving dist/history/ published under a misleading "done".
 $history = "$work/dist/history";
 if (is_dir($history)) {
-	passthru('rm -rf ' . escapeshellarg($history));
+	$entries = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($history, FilesystemIterator::SKIP_DOTS),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ($entries as $entry) {
+		// isDir() follows symlinks and rmdir() would then fail on the link itself; unlink handles both.
+		$ok = ( $entry->isDir() && !$entry->isLink() ) ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+		if (!$ok) {
+			fwrite(STDERR, 'wikven: could not remove ' . $entry->getPathname() . "\n");
+			exit(1);
+		}
+	}
+	if (!rmdir($history)) {
+		fwrite(STDERR, "wikven: could not remove $history\n");
+		exit(1);
+	}
 }
 
 fwrite(STDERR, "wikven: done -> $work/dist\n");


### PR DESCRIPTION
11 of 18 from #288.

```php
passthru('rm -rf ' . escapeshellarg($history));
```

This re-introduced `/bin/sh` and coreutils in the one entry point whose whole premise is a host with no distro toolchain — it resolves its own executable through `/proc/self/exe` and hunts for a CA bundle a few lines above for exactly that reason.

Its exit code was also the only one in the file left unchecked, unlike the `$run` closure directly above it. So on a host without `rm`, the build still printed `wikven: done -> …/dist` with `dist/history/` published — the opposite of what the preceding comment says the step is for.

SPL does this natively: `RecursiveIteratorIterator` over `RecursiveDirectoryIterator` with `CHILD_FIRST`, then `unlink`/`rmdir` with the result checked.

`wfRecursiveRemoveDir()` is core's version but is not available here — this process never boots MediaWiki, it only spawns it. (It would also be the wrong choice: it dispatches on `filetype()`, which stats *through* a symlink and returns `"dir"`, so it recurses into a symlinked directory and deletes the link target's contents. `isDir() && !isLink()` here means links are unlinked instead.)

Verified with `php -l`; this file is outside the `phpcs`/mago source paths. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_