### PR TITLE
refactor: find image binaries with core's ExecutableFinder

### DIFF
--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -85,9 +85,17 @@ unset($wgFooterIcons['poweredby']);
 
 // Detect image backend at run time; SVG never via ImageMagick (IM7 lacks `convert`).
 $wikvenFindExe = static function (array $names) {
+	// Core's own environment checks locate the very same binaries with this, so the two agree on where
+	// they are: it splits PATH on PATH_SEPARATOR and also searches the standard bin directories a
+	// stripped-down PATH omits (/usr/local/bin, /opt/csw/bin, ...). It reaches nothing but getenv() and
+	// is_executable() at this point, so it is safe this early; guarded anyway, since LocalSettings runs
+	// before the extension can assume anything about the core it was dropped into.
+	if (class_exists(\MediaWiki\Utils\ExecutableFinder::class)) {
+		return \MediaWiki\Utils\ExecutableFinder::findInDefaultPaths($names) ?: null;
+	}
 	$path = getenv('PATH') ?: '/usr/local/bin:/usr/bin:/bin';
 	foreach ($names as $name) {
-		foreach (explode(':', $path) as $dir) {
+		foreach (explode(PATH_SEPARATOR, $path) as $dir) {
 			if ($dir !== '' && is_executable(rtrim($dir, '/') . '/' . $name)) {
 				return rtrim($dir, '/') . '/' . $name;
 			}


### PR DESCRIPTION
12 of 18 from #288.

`$wikvenFindExe` read `getenv('PATH')`, split it on a hardcoded `':'`, and tested `is_executable()` per directory per candidate name.

`MediaWiki\Utils\ExecutableFinder::findInDefaultPaths()` is a near-exact match for the call shape, including the "first of several candidate names" semantics, and is what core's own environment checks use to locate ImageMagick — so the two now agree on which binary is meant. It splits on `PATH_SEPARATOR` rather than `':'`, also searches the standard bin directories a stripped-down `PATH` may omit (`/usr/local/bin`, `/opt/csw/bin`, `/usr/gnu/bin`, `/sw/bin`, …), and handles the Windows suffix.

**Two things worth a reviewer's attention.**

It searches those default directories *before* `PATH`, where the hand-rolled version searched `PATH` first. That is core's ordering, which is the point of adopting it, but it is a behaviour change. On the Docker image ImageMagick is at `/usr/bin/convert` either way.

It runs during `LocalSettings.php`, where the service container does not exist. That is safe here: `findInDefaultPaths` reaches nothing but `getenv()` and `is_executable()`, and its one gate — `Shell::isDisabled()` — only checks `function_exists('proc_open')`. Both were read from the `REL1_46` source. It is still guarded with `class_exists` and the previous loop kept as a fallback, since this file runs before the extension can assume anything about the core it was dropped into.

The `PATH_SEPARATOR` fix is carried into that fallback too.

Note the class is `MediaWiki\Utils\`, not `MediaWiki\Installer\`, and the method is `findInDefaultPaths()`, not `findExecutableInDefaultPaths()` — both corrected against the real source.

Verified with `phpcs` and `php -l`. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_