### PR TITLE
fix: read Vector feature classes through classList

### DIFF
--- a/resources/pinnable-state.js
+++ b/resources/pinnable-state.js
@@ -30,10 +30,16 @@
 
 	// A feature Vector already persists client-side carries a
 	// "vector-feature-<name>-clientpref-*" html class; leave those to Vector.
-	const isClientPreference = (feature) =>
-		new RegExp(`(?:^| )${FEATURE_PREFIX}${feature}-clientpref-`).test(
-			html.className,
+	// The class attribute is split on any ASCII whitespace, so a pretty-printed
+	// page whose classes are separated by a newline still has to match here,
+	// and a feature name is a data attribute we do not control, so it must not
+	// be interpolated into a regex where a metacharacter could change the match.
+	const isClientPreference = (feature) => {
+		const prefix = `${FEATURE_PREFIX}${feature}-clientpref-`;
+		return Array.prototype.some.call(html.classList, (name) =>
+			name.startsWith(prefix),
 		);
+	};
 
 	const setFeatureClass = (feature, pinned) => {
 		html.classList.remove(`${FEATURE_PREFIX}${feature}-enabled`);


### PR DESCRIPTION
13 of 18 from #288.

```js
new RegExp(`(?:^| )${FEATURE_PREFIX}${feature}-clientpref-`).test(html.className)
```

This hand-implements class-token separation as "start of string or a single space", against a DOM attribute value, with an interpolated data attribute in the pattern. Two defects:

**Whitespace.** The HTML `class` attribute is split on any ASCII whitespace — space, tab, LF, CR, FF. A page whose classes are separated by a newline (ordinary in templates, and in anything that pretty-prints the export) makes `isClientPreference` return false for a feature Vector *does* own client-side. This module then writes a competing `-enabled`/`-disabled` class and moves the element — which is the double-management the file's own comment at lines 14–16 says it must avoid.

**Metacharacters.** `feature` comes from `data-feature-name`, an attribute we do not control, and went into the regex unescaped. The file advertises (lines 11–13) that it covers "any element following the same contract", so a third-party feature name containing `.`, `+` or `(` silently changes the match. `startsWith` has no such surface.

`classList` does the whitespace splitting per spec. The file already uses `classList.add/remove/toggle` at lines 39–44 and 75–76, so this is the idiom the rest of the module uses; it also stops compiling a fresh `RegExp` per header per call.

`biome ci` and `node --check` clean.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_