### PR TITLE
fix: propagate the child's exit code from wikven build and serve

### DIFF
--- a/caddy/wikven.go
+++ b/caddy/wikven.go
@@ -2,6 +2,7 @@
 package wikvencaddy
 
 import (
+	"errors"
 	"flag"
 	"os"
 	"os/exec"
@@ -55,6 +56,16 @@ func reexec(args ...string) (int, error) {
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
 	if err := cmd.Run(); err != nil {
+		// Propagate the child's own exit code so a caller scripting on `wikven build` can tell one
+		// failure from another, and return a nil error so Caddy does not also print "exit status N"
+		// on top of the diagnostic the child already wrote. A signalled child reports -1; call that 1.
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
+			if code := exit.ExitCode(); code > 0 {
+				return code, nil
+			}
+			return 1, nil
+		}
 		return 1, err
 	}
 	return 0, nil


### PR DESCRIPTION
14 of 18 from #288.

```go
if err := cmd.Run(); err != nil {
    return 1, err
}
```

`reexec` collapsed every failure of the re-executed `php-cli build.php` or `file-server` to exit code 1, and handed Caddy the raw `*exec.ExitError`, which it printed as "exit status N" on top of the diagnostic the child had already written.

`wikven build` is meant for CI and Dockerfiles, so `build.php` distinguishing one failure from another (import failed vs. render failed) was invisible to anything scripting on the exit code, and stderr carried a doubled message.

`caddycmd.Command.Func` returns `(int, error)` precisely so the int can carry the process exit status. `errors.As` plus `ExitCode()` is the stdlib idiom for a wrapper binary; returning a `nil` error alongside the code suppresses Caddy's redundant line. A signalled child reports `-1`, which becomes 1.

This is a behaviour change for anything currently keying on `1`.

`gofmt` and `go vet` clean.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_