### PR TITLE
ci: let Playwright own the static server for the e2e run

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -82,19 +82,9 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
 
-      # Serve dist under the site's own /wikven/ path prefix (as GitHub Pages does) so the
-      # Pagefind bundle and results page resolve, then drive it with a headless browser.
+      # The static server and its readiness check live in playwright.config.js (webServer), so the
+      # same command works on a developer's machine too.
       - name: Assert the rendered site in a browser
         env:
           WIKVEN_BASE_URL: http://127.0.0.1:8080/wikven/
-        run: |
-          mkdir -p pw-root
-          ln -sfn "$PWD/dist" pw-root/wikven
-          python3 -m http.server 8080 --directory pw-root &
-          server=$!
-          trap 'kill $server' EXIT
-          for _ in $(seq 1 30); do
-            curl -sf -o /dev/null "${WIKVEN_BASE_URL}index.html" && break
-            sleep 0.5
-          done
-          npm run test:e2e
+        run: npm run test:e2e

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,11 +2,27 @@ const { defineConfig, devices } = require("@playwright/test");
 
 // CI bakes docs/ to dist/, serves it under the site's own path prefix, and passes
 // the resulting base URL in WIKVEN_BASE_URL. The specs use paths relative to it.
+const baseURL = process.env.WIKVEN_BASE_URL ?? "http://127.0.0.1:8080/wikven/";
+
 module.exports = defineConfig({
 	testDir: "./tests/e2e",
 	reporter: "line",
 	use: {
-		baseURL: process.env.WIKVEN_BASE_URL,
+		baseURL,
 		...devices["Desktop Chrome"],
+	},
+	// Polls this exact URL until it answers, aborts the run with the server's own output if it never
+	// does, and tears the process down from the runner even when the job is cancelled. `dist` is
+	// exposed under the site's own /wikven/ path prefix, as GitHub Pages serves it, so the Pagefind
+	// bundle and the results page resolve. This also makes `npm run test:e2e` work as-is outside CI.
+	webServer: {
+		command:
+			'mkdir -p pw-root && ln -sfn "$PWD/dist" pw-root/wikven && ' +
+			"python3 -m http.server 8080 --directory pw-root",
+		url: `${baseURL}index.html`,
+		timeout: 30_000,
+		reuseExistingServer: !process.env.CI,
+		stdout: "pipe",
+		stderr: "pipe",
 	},
 });


### PR DESCRIPTION
15 of 18 from #288. Flagged independently by two of the seven reviewers.

`smoke.yml` started `python3 -m http.server` in the background, saved the PID, installed `trap 'kill $server' EXIT`, and polled with a `for`/`curl`/`sleep` readiness loop.

Four problems, all of them the kind `webServer` exists to remove:

- **The loop falls through.** After ~15 s it stops polling and runs the suite anyway, so a server that failed to bind is reported as N tests failing with `net::ERR_CONNECTION_REFUSED` rather than "server did not start".
- **No output captured.** The server's stdout and stderr went nowhere, so a bind error ("address already in use") left no trace in the log at all.
- **`trap … EXIT` is not reliable.** It signals only the shell's direct child, and does not run if the step is killed by timeout — leaking the port.
- **Duplicated URL.** The readiness URL was a second copy of `WIKVEN_BASE_URL`, free to drift from the one the tests navigate to.

Playwright's `webServer` polls the same URL the tests use, prints the server's output and aborts the run when startup times out, and tears the process down from its own runner. `reuseExistingServer: !process.env.CI` keeps a local `wikven serve` from being fought over while still refusing to reuse a stale listener in CI.

It also makes `npm run test:e2e` work outside CI, which until now required replicating the workflow's shell by hand.

**Verified:** the `webServer` command serves `dist` under the `/wikven/` prefix (HTTP 200 against `pw-root/wikven/index.html`), `npx playwright test --list` still discovers all 13 tests, and `biome ci` is clean.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_