### PR TITLE
test: wait on the condition, not the clock, in two e2e assertions

### DIFF
--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -32,8 +32,9 @@ test("a content page fetches nothing from a live backend", async ({ page }) => {
 		}
 	});
 
-	await page.goto("Installation.html", { waitUntil: "load" });
-	await page.waitForTimeout(1000);
+	// This asserts the absence of a request, so the wait is defined by the traffic itself -- exactly
+	// the property under test here.
+	await page.goto("Installation.html", { waitUntil: "networkidle" });
 
 	expect(backend, backend.join("; ")).toEqual([]);
 });

--- a/tests/e2e/tabber.spec.js
+++ b/tests/e2e/tabber.spec.js
@@ -13,7 +13,10 @@ const SELECTED = '.tabber__tab[aria-selected="true"]';
 const tabbersOf = async (page) => {
 	const tabbers = page.locator(".tabber");
 	await expect(tabbers.first()).toBeVisible();
-	expect(await tabbers.count()).toBeGreaterThan(1);
+	// TabberNeue wires a tabber only while it is on screen -- the very behaviour these tests exercise
+	// -- so the second wrapper can still be arriving when the first is already visible; toHaveCount
+	// retries until it appears.
+	await expect(tabbers).toHaveCount(2);
 	return [tabbers.nth(0), tabbers.nth(1)];
 };
 


### PR DESCRIPTION
16 of 18 from #288.

Both of these hold a suite open on a guess.

**`smoke.spec.js:36`** asserted that a content page issues no backend request, and bounded the observation with `page.waitForTimeout(1000)`.

A fixed window makes a *negative* assertion vacuous: a module that requests `/api.php` 1.2 s after `load` — a deferred Codex mount on a cold CI runner is exactly that shape — passes, and a real regression ships green. `networkidle` is defined by the absence of traffic, which is the property under test, so it extends itself while the page is still fetching and returns sooner when it is not.

(Playwright's docs discourage `networkidle` for *waiting until ready*; this is the opposite case — measuring quiescence is what the flag does.)

**`tabber.spec.js:16`** used `expect(await tabbers.count()).toBeGreaterThan(1)` — the one assertion in the file that does not auto-wait, in the helper every tabber test runs through.

`expect(tabbers.first()).toBeVisible()` above it only proves the *first* `.tabber` exists. TabberNeue wires a tabber only while it is on screen, which is the behaviour the comment at lines 20–23 says these tests exercise, so the second wrapper can still be arriving when the first is visible. `count()` then reads 1 and the whole suite fails with "expected 1 to be greater than 1" instead of retrying. `toHaveCount` retries and names the locator when it does fail.

Pinning the count to 2 matches what the helper already returns (`nth(0)`, `nth(1)`).

`biome ci`, `node --check` and `npx playwright test --list` (13 tests) clean.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_