### PR TITLE
test: mock HTTP with core's MockHttpTrait

### DIFF
--- a/tests/phpunit/integration/RetryingForeignRepoTest.php
+++ b/tests/phpunit/integration/RetryingForeignRepoTest.php
@@ -3,10 +3,8 @@
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
 use MediaWiki\Extension\Wikven\RetryingForeignRepo;
-use MediaWiki\Http\HttpRequestFactory;
-use MediaWiki\Http\MWHttpRequest;
-use MediaWiki\Status\Status;
 use MediaWikiIntegrationTestCase;
+use MockHttpTrait;
 use RuntimeException;
 use Wikimedia\FileBackend\FSFileBackend;
 use Wikimedia\ObjectCache\WANObjectCache;
@@ -17,6 +15,8 @@ use Wikimedia\ObjectCache\WANObjectCache;
  * @covers \MediaWiki\Extension\Wikven\RetryingForeignRepo
  */
 class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
+	use MockHttpTrait;
+
 	/** A repository with its own empty cache, so one test's lookups cannot answer another's. */
 	private function newRepo(): RetryingForeignRepo {
 		return new RetryingForeignRepo([
@@ -43,23 +43,19 @@ class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
 	 */
 	private function answerWith(array $responses, &$made): void {
 		$made = 0;
-		$factory = $this->createMock(HttpRequestFactory::class);
-		$factory->method('create')
-			->willReturnCallback(
-				function () use ($responses, &$made): MWHttpRequest {
-					$response = $responses[min($made, count($responses) - 1)];
-					$made++;
-					$request = $this->createMock(MWHttpRequest::class);
-					$request->method('execute')
-						->willReturn(
-							isset($response['body']) ? Status::newGood() : Status::newFatal('http-timed-out')
-						);
-					$request->method('getContent')->willReturn($response['body'] ?? '');
-					$request->method('getResponseHeader')->willReturn($response['lastModified'] ?? null);
-					return $request;
-				}
-			);
-		$this->setService('HttpRequestFactory', $factory);
+		// installMockHttp builds a real HttpRequestFactory and fails the test by name on any request
+		// path this mock does not answer.
+		$this->installMockHttp(function () use ($responses, &$made) {
+			$response = $responses[min($made, count($responses) - 1)];
+			$made++;
+			if (!isset($response['body'])) {
+				return $this->makeFakeTimeoutRequest();
+			}
+			$headers = isset($response['lastModified'])
+				? ['Last-Modified' => $response['lastModified']]
+				: [];
+			return $this->makeFakeHttpRequest($response['body'], 200, $headers);
+		});
 	}
 
 	/** An imageinfo response body, with a thumbnail URL unless $thumbUrl is null. */


### PR DESCRIPTION
17 of 18 from #288.

`answerWith()` built its own stack: `createMock(HttpRequestFactory::class)` wired to hand-made `createMock(MWHttpRequest::class)` stubs, with a bespoke `['fail']` vs `['body' => …]` protocol.

`createMock` stubs **every** method to return null in silence — including `createMultiClient()`, `createGuzzleClient()`, `request()` and `get()`. The day core's `ForeignAPIRepo` path reaches one of those, the test dies with "call to a member function on null" from inside core rather than pointing at the mock. Same for the response object: `setHeader()`/`setCallback()` answer with nulls.

`MockHttpTrait` (`@stable to use in extensions` since 1.36) builds a **real** `HttpRequestFactory` with `onlyMethods([...])` and `TestCase::fail()`s on any request path it does not serve; `makeFakeHttpRequest` uses `createNoOpMock` with an allow-list, so an unexpected call is loud. It also removes the bespoke array protocol and the `&$made` out-parameter shape stays available because `installMockHttp` accepts a callable.

**Verified against `REL1_46`:** `ForeignAPIRepo::httpGet()` calls only `setHeader`, `execute`, `getResponseHeader` and `getContent` — all inside `makeFakeHttpRequest`'s allow-list — so this is a drop-in. `installMockHttp`'s callable form maps straight onto `create`'s `willReturnCallback`, so the per-attempt cursor the retry tests need is kept.

`makeFakeTimeoutRequest()` returns 504 with an `http-timed-out` fatal rather than a bare `newFatal`, which no assertion depends on.

`phpcs` clean. MediaWiki core is not on disk in this environment, so PHPUnit was not run locally — CI is the real check for this one.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_