### PR TITLE
ci: compute image tags and labels with docker/metadata-action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,25 +41,31 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # On a release (tag input set) publish the immutable version tags plus latest, else just latest.
-      - name: Compute image tags
-        id: tags
-        env:
-          TAG: ${{ inputs.tag }}
-        run: |
-          img=ghcr.io/chaotic-ground/wikven
-          if [ -n "$TAG" ]; then
-            v=${TAG#v}
-            printf 'tags=%s\n' "$img:$v,$img:${v%.*},$img:${v%%.*},$img:latest" >> "$GITHUB_OUTPUT"
-          else
-            printf 'tags=%s\n' "$img:latest" >> "$GITHUB_OUTPUT"
-          fi
+      # metadata-action computes proper semver tags (a prerelease is not tagged :latest or a bare
+      # major/minor) and emits the org.opencontainers.image.* labels, without which GHCR does not link
+      # the published package back to this repository.
+      - name: Compute image tags and labels
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
+        with:
+          images: ghcr.io/chaotic-ground/wikven
+          # latest is handled explicitly below; the default "auto" keys off a tag push, and releases
+          # reach this workflow through workflow_call with the tag as an input instead.
+          flavor: latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=semver,pattern={{major}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=raw,value=latest,enable=${{ inputs.tag == '' || !contains(inputs.tag, '-') }}
 
       - name: Build and push the image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           push: ${{ github.repository_owner == 'chaotic-ground' && github.ref == 'refs/heads/main' }}
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           # Layer cache shared with the other image builds, so a PR reuses main's cached layers.
           cache-from: type=gha,scope=wikven-image
           cache-to: type=gha,mode=max,scope=wikven-image


### PR DESCRIPTION
18 of 18 from #288.

The tag list was derived with shell parameter expansion (`v=${TAG#v}`, then `${v%.*}` and `${v%%.*}`) and joined into `$GITHUB_OUTPUT` by hand. Two gaps:

**No OCI labels at all.** The image is published without `org.opencontainers.image.source`, `.revision`, `.created` or `.version`. Without `image.source`, GHCR does not link `ghcr.io/chaotic-ground/wikven` back to this repository, so the package page carries no README and no provenance. `metadata-action` emits all of them and `build-push-action` applies them.

**`${v%.*}` is string chopping, not semver.** The day a `v1.2.0-rc.1` tag is cut — release-please supports it, the config just does not use it today — it would publish `:1.2.0-rc`, `:1` **and `:latest`**, all pointing at a prerelease. `metadata-action`'s semver types skip major/minor for prereleases by design.

`latest` is gated explicitly (`inputs.tag == '' || !contains(inputs.tag, '-')`) rather than left to `flavor: latest=auto`, because releases reach this workflow through `workflow_call` with the tag as an *input*, not as a tag push — so `auto` would never fire. The push-to-main path keeps `latest` as its only tag, as before.

Same vendor as the `setup-buildx-action` and `build-push-action` already pinned in this workflow, so it adds no new supply-chain surface, and it is SHA-pinned with a version comment like the rest.

`yamllint` and a YAML parse check are clean; the tag logic itself is only exercised on a real release, so this one wants a reviewer's eye on the `enable=` expressions.

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_