### PR TITLE
fix: make storeImages downloads status-aware and stream to disk

### DIFF
--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -96,12 +96,30 @@ class StoreImages extends Maintenance {
 			'timeout' => 30,
 			'userAgent' => 'wikven static-site builder (https://github.com/chaotic-ground/wikven)'
 		];
-		// Retry with backoff: Commons may 4xx/5xx while generating an uncached thumbnail.
+		$tmp = "$dest.tmp";
+		// Retry with backoff: Commons may 5xx while generating an uncached thumbnail. A 4xx (e.g. a
+		// dead File: link) won't change on retry, so stop as soon as one comes back.
 		for ($attempt = 1; $attempt <= 3; $attempt++) {
-			$bytes = $http->get($url, $options, __METHOD__);
-			if ($bytes !== null && $bytes !== '') {
-				file_put_contents($dest, $bytes, LOCK_EX);
+			$req = $http->create($url, $options, __METHOD__);
+			$fh = fopen($tmp, 'wb');
+			if ($fh === false) {
+				break;
+			}
+			$req->setCallback(static function ($resource, $buffer) use ($fh) {
+				return fwrite($fh, $buffer);
+			});
+			$status = $req->execute();
+			fclose($fh);
+
+			$httpStatus = $req->getStatus();
+			if ($status->isOK() && $httpStatus >= 200 && $httpStatus < 300 && filesize($tmp) > 0) {
+				rename($tmp, $dest);
 				return "./$name";
+			}
+
+			unlink($tmp);
+			if ($httpStatus >= 400 && $httpStatus < 500) {
+				break;
 			}
 			if ($attempt < 3) {
 				sleep($attempt);


### PR DESCRIPTION
`storeImages.php`'s `store()` used `HttpRequestFactory::get()` in a blind 3-attempt retry loop: it couldn't tell a 4xx (a dead `File:` link, which retrying can't fix) from a 5xx (Commons still generating an uncached thumbnail, worth retrying), and it buffered the whole image body in memory before writing it out.

This switches to `HttpRequestFactory::create()` + `MWHttpRequest::setCallback()`, MediaWiki core's documented streaming-download API: the response body is written to a temp file as it arrives instead of being held in memory, and the HTTP status is inspected before deciding to retry. A 4xx now fails immediately; a 5xx still retries with backoff, same as before. The temp file is only renamed into place once a full 2xx response with a non-empty body has landed, so a partial download never becomes the final file.

9 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_