### PR TITLE
fix: replace fetchExtensions' curl subprocess with core's HTTP client

### DIFF
--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Wikven;
 
 use Maintenance;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Settings\Source\Format\JsonFormat;
 use MediaWiki\Settings\Source\Format\YamlFormat;
 
@@ -176,7 +177,7 @@ class FetchExtensions extends Maintenance {
 	private function fetchTarball(string $url, string $dest, string $name, string $kind, ?string $sha256 = null): void {
 		$this->output("Wikven: downloading $kind '$name' from $url\n");
 		$tmp = tempnam(sys_get_temp_dir(), 'wikven');
-		$this->run(['curl', '-sSL', '-f', '-o', $tmp, '--', $url], "download $kind '$name'");
+		$this->download($url, $tmp, "download $kind '$name'");
 		if ($sha256 !== null) {
 			$actual = hash_file('sha256', $tmp);
 			if (!hash_equals($sha256, (string)$actual)) {
@@ -245,6 +246,28 @@ class FetchExtensions extends Maintenance {
 			['composer', 'update', '--no-dev', '--no-interaction', '--working-dir=' . $IP],
 			'composer update'
 		);
+	}
+
+	/** Download $url to $dest, streaming the body to disk instead of buffering it in memory. */
+	private function download(string $url, string $dest, string $what): void {
+		$http = MediaWikiServices::getInstance()->getHttpRequestFactory();
+		$req = $http->create($url, ['followRedirects' => true], __METHOD__);
+
+		$fh = fopen($dest, 'wb');
+		if ($fh === false) {
+			$this->fatalError("Wikven: could not open '$dest' for writing.");
+		}
+		$req->setCallback(static function ($resource, $buffer) use ($fh) {
+			return fwrite($fh, $buffer);
+		});
+		$status = $req->execute();
+		fclose($fh);
+
+		$httpStatus = $req->getStatus();
+		if (!$status->isOK() || $httpStatus < 200 || $httpStatus >= 300) {
+			unlink($dest);
+			$this->fatalError("Wikven: failed to $what (HTTP $httpStatus).");
+		}
 	}
 
 	/**


### PR DESCRIPTION
`fetchTarball()` shelled out to `curl -sSL -f` to download extension/skin tarballs. That means the download runs under curl's own unbounded default timeout rather than MediaWiki's configured HTTP timeouts, and makes curl an implicit runtime dependency for this one path even though the maintenance script already boots the full MediaWiki service container.

This adds a `download()` helper that uses `HttpRequestFactory::create()` + `MWHttpRequest::setCallback()` (the same streaming-to-disk approach as #307's `storeImages.php` fix) instead, and fails loudly with the HTTP status on anything outside 2xx.

10 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_