### PR TITLE
fix: probe openssl's own compiled-in CA bundle location first

### DIFF
--- a/bin/build.php
+++ b/bin/build.php
@@ -23,17 +23,28 @@ putenv("WIKVEN_WORKDIR=$work");
 $_ENV['WIKVEN_WORKDIR'] = $work;
 
 // Static binaries ship no CA certs; point openssl at the host bundle for HTTPS unless already set.
-if (getenv('SSL_CERT_FILE') === false) {
-	foreach ([
+if (getenv('SSL_CERT_FILE') === false && getenv('SSL_CERT_DIR') === false) {
+	// openssl reports the exact bundle path/dir it was compiled to look for, ahead of the guessed
+	// distro paths below, which cover systems where that compiled-in default isn't actually there.
+	$locations = function_exists('openssl_get_cert_locations') ? openssl_get_cert_locations() : [];
+	$candidates = array_filter([
+		$locations['default_cert_file'] ?? null,
 		'/etc/ssl/certs/ca-certificates.crt',
 		'/etc/pki/tls/certs/ca-bundle.crt',
 		'/etc/ssl/cert.pem'
-	] as $ca) {
+	]);
+	foreach ($candidates as $ca) {
 		if (is_file($ca)) {
 			putenv("SSL_CERT_FILE=$ca");
 			$_ENV['SSL_CERT_FILE'] = $ca;
 			break;
 		}
+	}
+	// No single bundle file found; fall back to openssl's compiled-in certs directory, if present.
+	$certDir = $locations['default_cert_dir'] ?? '';
+	if (getenv('SSL_CERT_FILE') === false && $certDir !== '' && is_dir($certDir)) {
+		putenv("SSL_CERT_DIR=$certDir");
+		$_ENV['SSL_CERT_DIR'] = $certDir;
 	}
 }
 


### PR DESCRIPTION
`bin/build.php`'s CA-bundle search only tried a fixed list of common distro paths (`/etc/ssl/certs/ca-certificates.crt`, etc.), guessed rather than derived from the running system.

`openssl_get_cert_locations()` (no new dependency, it's a core PHP `ext-openssl` function) reports the exact file — and, failing that, directory — the running openssl build was actually compiled to look for. Probing that first covers systems where the compiled-in default doesn't match any of the guessed distro paths, which stay as a fallback for systems where `openssl_get_cert_locations()` isn't usable or its reported file isn't present. The check also now honors an already-set `SSL_CERT_DIR`, not just `SSL_CERT_FILE`, when deciding whether the caller already configured a CA source.

11 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_