### PR TITLE
fix: use CSSMin's data: URI encoder in AssetLocalizer

### DIFF
--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Wikven;
 use MediaWiki\Request\FauxRequest;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
+use Wikimedia\Minify\CSSMin;
 
 /** Rewrites image url()s in dumped CSS/JS to local copies, avoiding load.php references. */
 class AssetLocalizer {
@@ -82,9 +83,14 @@ class AssetLocalizer {
 		return is_string($decoded) ? $decoded : $text;
 	}
 
-	/** Encode raw image bytes as a data: URI usable unquoted inside url(). */
+	/**
+	 * Encode raw image bytes as a data: URI usable unquoted inside url().
+	 *
+	 * CSSMin percent-encodes printable text (an SVG, typically) instead of base64-encoding it, which
+	 * is what ResourceLoader itself does for the same images when it inlines them into a CSS bundle.
+	 */
 	private static function dataUri(string $bytes, string $mime): string {
-		return 'data:' . $mime . ';base64,' . base64_encode($bytes);
+		return CSSMin::encodeStringAsDataURI($bytes, $mime);
 	}
 
 	/**

--- a/tests/phpunit/integration/AssetLocalizerTest.php
+++ b/tests/phpunit/integration/AssetLocalizerTest.php
@@ -77,7 +77,8 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 		AssetLocalizer::localizeImages($rl, $dir, [$js], 'en', 'vector', true);
 
 		$out = file_get_contents($js);
-		$expected = 'url(data:image/svg+xml;base64,' . base64_encode('<svg>arrow</svg>') . ')';
+		// CSSMin percent-encodes printable content like this SVG rather than base64-encoding it.
+		$expected = 'url(data:image/svg+xml,%3Csvg%3Earrow%3C/svg%3E)';
 		$this->assertStringContainsString($expected, $out, 'asset inlined as a data: URI');
 		$this->assertStringNotContainsString('url(./img-', $out, 'no relative file reference emitted');
 		$this->assertCount(0, glob("$dir/img-*.svg"), 'no image file written in inline mode');


### PR DESCRIPTION
`AssetLocalizer::dataUri()` always base64-encoded inlined images. `Wikimedia\Minify\CSSMin::encodeStringAsDataURI()` — already a MediaWiki core dependency reached through `ResourceLoader`, so no new dependency here — picks percent-encoding for printable content (an SVG) and falls back to base64 for binary content (a PNG), which is the same choice ResourceLoader itself makes when it inlines these same images into a CSS bundle. Percent-encoded SVGs are typically shorter and compress better than their base64 equivalent.

12 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_