### PR TITLE
fix: drain translation jobs with JobRunner instead of a manual loop

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -223,7 +223,9 @@ class BuildTranslations extends Maintenance {
 
 	/** Run every queued job synchronously (the export has no background runner). */
 	private function drainJobs(): void {
-		$group = $this->getServiceContainer()->getJobQueueGroup();
+		$services = $this->getServiceContainer();
+		$group = $services->getJobQueueGroup();
+		$runner = $services->getJobRunner();
 		// pop() with no type shuffles the queue types to avoid starvation, and these jobs create the
 		// translated pages, so a shuffled order hands them different page and revision ids on every
 		// bake. Drain one type at a time, in name order, until nothing is left anywhere.
@@ -235,12 +237,8 @@ class BuildTranslations extends Maintenance {
 			}
 			sort($types);
 			foreach ($types as $type) {
-				$job = $group->pop($type);
-				while ($job) {
-					$job->run();
-					$group->ack($job);
-					$job = $group->pop($type);
-				}
+				// Runs every job of this type, popping and acking, until the queue is empty.
+				$runner->run(['type' => $type]);
 			}
 		}
 	}


### PR DESCRIPTION
`drainJobs()` popped, ran, and acked each job by hand, one type at a time. `JobRunner::run(['type' => $type])` does that same pop/run/ack cycle for one type, plus what the manual loop skipped: it runs each job's `DeferredUpdates` before popping the next one, respects the configured job backoff list, and aborts early on read-only mode or replica lag.

The per-type, name-sorted draining order that keeps page/revision ids stable across rebuilds is unchanged — `array_diff($group->getQueuesWithJobs(), [Search::INDEX_JOB])`, `sort()`, then one `JobRunner::run()` call per type, looping until every queue (other than the search index, still deferred to the end of the build) is empty.

13 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_