### PR TITLE
fix: make verbatimRanges() comment-aware

### DIFF
--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -280,15 +280,43 @@ class StalenessComputer {
 	 *
 	 * An unclosed verbatim tag runs to the end of the page, matching how MediaWiki renders it. That
 	 * is the safer reading: the alternative -- treating the span as absent -- would hand the rest of
-	 * the page back to the marker scan, turning example text into counted units.
+	 * the page back to the marker scan, turning example text into counted units. But an HTML comment
+	 * is inert to MediaWiki's parser, so a tag name it merely mentions -- e.g. "<!-- don't wrap this
+	 * in <nowiki> -->" -- must not seed a span in the first place: read as a real opener, that "runs
+	 * to the end of the page" rule would swallow every marker after it. Scanning match by match,
+	 * instead of in one preg_match_all pass, lets a match like that be skipped in place, so a genuine
+	 * span later in the page is still found.
 	 *
 	 * @return list<array{int,int}>
 	 */
 	private static function verbatimRanges(string $text): array {
+		$comments = self::commentRanges($text);
 		// The attribute run is lazy so a self-closing tag closes on its own "/>" instead of the
 		// attributes swallowing the slash and leaving the tag to match as unclosed.
 		$pattern = '#<(' . self::VERBATIM_TAGS . ')(?:\s[^>]*?)?(?:/\s*>|>.*?</\1\s*>|>.*)#is';
-		if (!preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE)) {
+
+		$ranges = [];
+		$offset = 0;
+		$length = strlen($text);
+		while ($offset < $length && preg_match($pattern, $text, $match, PREG_OFFSET_CAPTURE, $offset)) {
+			$start = $match[0][1];
+			$comment = self::containingRange($start, $comments);
+			if ($comment !== null) {
+				// A false opener inside a comment; resume right after it instead of accepting a
+				// match that would otherwise run to the end of the page.
+				$offset = $comment[1];
+				continue;
+			}
+			$end = $start + strlen($match[0][0]);
+			$ranges[] = [$start, $end];
+			$offset = $end;
+		}
+		return $ranges;
+	}
+
+	/** Byte ranges of the HTML comments in a page, each as [start, endExclusive]. */
+	private static function commentRanges(string $text): array {
+		if (!preg_match_all('/<!--.*?-->/s', $text, $matches, PREG_OFFSET_CAPTURE)) {
 			return [];
 		}
 		$ranges = [];
@@ -303,12 +331,21 @@ class StalenessComputer {
 	 * @param list<array{int,int}> $ranges
 	 */
 	private static function insideVerbatim(int $offset, array $ranges): bool {
-		foreach ($ranges as [$start, $end]) {
-			if ($offset >= $start && $offset < $end) {
-				return true;
+		return self::containingRange($offset, $ranges) !== null;
+	}
+
+	/**
+	 * @param int $offset
+	 * @param list<array{int,int}> $ranges
+	 * @return ?array{int,int} The range in $ranges containing $offset, or null.
+	 */
+	private static function containingRange(int $offset, array $ranges): ?array {
+		foreach ($ranges as $range) {
+			if ($offset >= $range[0] && $offset < $range[1]) {
+				return $range;
 			}
 		}
-		return false;
+		return null;
 	}
 
 	/** Strip <translate> wrapper tags and surrounding whitespace so the hash tracks unit content only. */

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -299,6 +299,17 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 		];
 	}
 
+	public function testACommentMerelyMentioningAVerbatimTagDoesNotSwallowLaterUnits() {
+		// An HTML comment is inert to MediaWiki's parser, so a tag name it merely mentions -- as a
+		// reviewer note might -- must not read as a real, unclosed opener; that would otherwise run
+		// to the end of the page and hide the second <translate> block entirely.
+		$text =
+			"<translate>\n<!--T:1-->\nOne.\n</translate>\n"
+			. "<!-- reviewer: do not wrap this in <nowiki> -->\n"
+			. "<translate>\n<!--T:2-->\nTwo.\n</translate>";
+		$this->assertSame([1, 2], array_keys(StalenessComputer::splitUnits($text)));
+	}
+
 	public function testMarkIgnoresATranslatePairAfterAnUnclosedVerbatimTag() {
 		// The same rule applies to marking: nothing after the unclosed tag is numbered.
 		$text = "<translate>\nReal.\n</translate>\n<pre>\n<translate>\nExample.\n</translate>";


### PR DESCRIPTION
`verbatimRanges()` located `<syntaxhighlight|source|nowiki|pre>` spans with a single `preg_match_all` pass and no HTML-comment handling. A comment merely mentioning one of those tag names — e.g. `<!-- don't wrap this in <nowiki> -->` — has no real closer anywhere after it, so it read as a genuinely unclosed tag and, by the deliberate "runs to the end of the page" rule for those, swallowed every marker after it: `analyze()` then reported every later unit as untranslated or orphaned, and `restamp()` left their stamps untouched.

The finding recommended `Parser::extractTagsAndParams()`, MediaWiki core's own tag extractor, which is comment-aware for exactly this reason. I didn't take that route: it strips content to variable-length `UNIQ` markers rather than reserializing, which would need every downstream byte offset this class returns remapped back onto the original text, plus separately restoring `<!--T:n-->` markers that get stripped as comments along the way before they can be rescanned — real complexity the finding itself flagged. It would also cost this class its explicit design goal, stated in its own doc comment, of staying pure string work usable outside a MediaWiki bootstrap.

Instead, the scan now runs match by match instead of in one `preg_match_all` pass, against a first pass of the page's HTML comment ranges. A match whose opening tag starts inside a comment is skipped and scanning resumes right after that comment, so a genuine span later in the page is still found — same offsets on the original text as before, no `UNIQ`-marker remapping, no MediaWiki bootstrap dependency. Verified standalone against the full existing case matrix (every verbatim tag form, multiple regions, unclosed-tag-runs-to-end-of-page, closed spans not swallowing later units) plus the new regression case, before and after, to confirm the fix and rule out regressions.

14 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_