### PR TITLE
fix: require real tag context before rewriting a relative reference

### DIFF
--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -12,6 +12,12 @@ class RelativeUrl {
 	 * is exported into a real "Manual/" directory; its references then need a "../" per level so links
 	 * and files agree on a static host. Absolute, protocol-relative and data: URLs carry no leading
 	 * "./" and are left alone. Covers href/src/srcset attributes and CSS url().
+	 *
+	 * Each candidate is required to sit inside a real "<tag ...>" span (or, for url(), inside a
+	 * <style> block too): MediaWiki escapes preformatted text with htmlspecialchars(..., ENT_NOQUOTES),
+	 * which turns a documentation example's own "<a href=\"./intro\">" into "&lt;a href=\"./intro\"&gt;"
+	 * -- the quotes survive, but neither escaped angle bracket is a real "<" or ">", so nothing there
+	 * reads as a tag span and the example's href is correctly left alone.
 	 */
 	public static function reparent(string $html, int $depth): string {
 		if ($depth < 1) {
@@ -22,37 +28,92 @@ class RelativeUrl {
 			return $dots === '..' ? $up . '../' : $up;
 		};
 
+		$tags = self::tagRanges($html);
 		$html = preg_replace_callback(
-			'#\b(href|src)="(\.\.?)/#',
-			static function (array $m) use ($rebase): string {
-				return $m[1] . '="' . $rebase($m[2]);
+			'#(\s)(href|src)="(\.\.?)/#',
+			static function (array $m) use ($rebase, $tags): string {
+				if (!self::insideAny($m[0][1], $tags)) {
+					return $m[0][0];
+				}
+				return $m[1][0] . $m[2][0] . '="' . $rebase($m[3][0]);
 			},
-			$html
+			$html,
+			-1,
+			$count,
+			PREG_OFFSET_CAPTURE
 		);
+
+		$tags = self::tagRanges($html);
 		$html = preg_replace_callback(
-			'#\bsrcset="([^"]*)"#',
-			static function (array $m) use ($rebase): string {
+			'#(\s)srcset="([^"]*)"#',
+			static function (array $m) use ($rebase, $tags): string {
+				if (!self::insideAny($m[0][1], $tags)) {
+					return $m[0][0];
+				}
 				return (
-					'srcset="'
+					$m[1][0] . 'srcset="'
 					. preg_replace_callback(
 						'#(^|,\s*)(\.\.?)/#',
 						static function (array $u) use ($rebase): string {
 							return $u[1] . $rebase($u[2]);
 						},
-						$m[1]
+						$m[2][0]
 					)
 					. '"'
 				);
 			},
-			$html
+			$html,
+			-1,
+			$count,
+			PREG_OFFSET_CAPTURE
 		);
+
+		$styleContexts = array_merge(self::tagRanges($html), self::ranges($html, '#<style\b[^>]*>.*?</style>#is'));
 		return preg_replace_callback(
-			'#\burl\((["\']?)(\.\.?)/#',
-			static function (array $m) use ($rebase): string {
-				return 'url(' . $m[1] . $rebase($m[2]);
+			'#url\((["\']?)(\.\.?)/#',
+			static function (array $m) use ($rebase, $styleContexts): string {
+				if (!self::insideAny($m[0][1], $styleContexts)) {
+					return $m[0][0];
+				}
+				return 'url(' . $m[1][0] . $rebase($m[2][0]);
 			},
-			$html
+			$html,
+			-1,
+			$count,
+			PREG_OFFSET_CAPTURE
 		);
+	}
+
+	/** Byte ranges of the raw "<tag ...>" spans in $html, each as [start, endExclusive]. */
+	private static function tagRanges(string $html): array {
+		return self::ranges($html, '#<[a-zA-Z][^<>]*>#s');
+	}
+
+	/**
+	 * @return list<array{int,int}>
+	 */
+	private static function ranges(string $text, string $pattern): array {
+		if (!preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE)) {
+			return [];
+		}
+		$ranges = [];
+		foreach ($matches[0] as $match) {
+			$ranges[] = [$match[1], $match[1] + strlen($match[0])];
+		}
+		return $ranges;
+	}
+
+	/**
+	 * @param int $offset
+	 * @param list<array{int,int}> $ranges
+	 */
+	private static function insideAny(int $offset, array $ranges): bool {
+		foreach ($ranges as [$start, $end]) {
+			if ($offset >= $start && $offset < $end) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -51,7 +51,8 @@ class RelativeUrl {
 					return $m[0][0];
 				}
 				return (
-					$m[1][0] . 'srcset="'
+					$m[1][0]
+					. 'srcset="'
 					. preg_replace_callback(
 						'#(^|,\s*)(\.\.?)/#',
 						static function (array $u) use ($rebase): string {

--- a/tests/phpunit/unit/RelativeUrlTest.php
+++ b/tests/phpunit/unit/RelativeUrlTest.php
@@ -10,47 +10,89 @@ use MediaWikiUnitTestCase;
  */
 class RelativeUrlTest extends MediaWikiUnitTestCase {
 	public function testDepthZeroLeavesTheHtmlUntouched() {
-		$html = 'href="./index.html" src="././modules-static.js"';
+		$html = '<a href="./index.html"><script src="././modules-static.js"></script></a>';
 		$this->assertSame($html, RelativeUrl::reparent($html, 0));
 	}
 
 	public function testRootRelativeLinksGainOneLevelPerDepth() {
-		$this->assertSame('href="../index.html"', RelativeUrl::reparent('href="./index.html"', 1));
-		$this->assertSame('href="../../index.html"', RelativeUrl::reparent('href="./index.html"', 2));
+		$this->assertSame(
+			'<a href="../index.html">',
+			RelativeUrl::reparent('<a href="./index.html">', 1)
+		);
+		$this->assertSame(
+			'<a href="../../index.html">',
+			RelativeUrl::reparent('<a href="./index.html">', 2)
+		);
 	}
 
 	public function testParentRelativeCanonicalGainsAFurtherLevel() {
-		$this->assertSame('href="../../Intro.html"', RelativeUrl::reparent('href="../Intro.html"', 1));
+		$this->assertSame(
+			'<link href="../../Intro.html">',
+			RelativeUrl::reparent('<link href="../Intro.html">', 1)
+		);
 	}
 
 	public function testScriptAndStyleReferencesAreRebased() {
-		$this->assertSame('src=".././modules-static.js"', RelativeUrl::reparent('src="././modules-static.js"', 1));
 		$this->assertSame(
-			'href=".././skins.vector.styles.css"',
-			RelativeUrl::reparent('href="././skins.vector.styles.css"', 1)
+			'<script src=".././modules-static.js">',
+			RelativeUrl::reparent('<script src="././modules-static.js">', 1)
+		);
+		$this->assertSame(
+			'<link href=".././skins.vector.styles.css">',
+			RelativeUrl::reparent('<link href="././skins.vector.styles.css">', 1)
 		);
 	}
 
 	public function testEachSrcsetCandidateIsRebased() {
 		$this->assertSame(
-			'srcset="../img-a.png 1.5x, ../img-b.png 2x"',
-			RelativeUrl::reparent('srcset="./img-a.png 1.5x, ./img-b.png 2x"', 1)
+			'<img srcset="../img-a.png 1.5x, ../img-b.png 2x">',
+			RelativeUrl::reparent('<img srcset="./img-a.png 1.5x, ./img-b.png 2x">', 1)
 		);
 	}
 
-	public function testCssUrlIsRebased() {
-		$this->assertSame('url(../logo.png)', RelativeUrl::reparent('url(./logo.png)', 1));
+	public function testCssUrlIsRebasedInAStyleBlock() {
+		$this->assertSame(
+			'<style>.a{background:url(../logo.png)}</style>',
+			RelativeUrl::reparent('<style>.a{background:url(./logo.png)}</style>', 1)
+		);
+	}
+
+	public function testCssUrlIsRebasedInAStyleAttribute() {
+		$this->assertSame(
+			'<div style="background:url(../logo.png)">',
+			RelativeUrl::reparent('<div style="background:url(./logo.png)">', 1)
+		);
 	}
 
 	public function testAbsoluteProtocolRelativeAnchorAndDataUrlsAreLeftAlone() {
 		$html =
-			'href="https://example.org/x" href="//cdn/x" href="/images/logo.png" '
-			. 'href="#top" src="data:image/svg+xml,%3Csvg/%3E"';
+			'<a href="https://example.org/x"><a href="//cdn/x"><a href="/images/logo.png">'
+			. '<a href="#top"><img src="data:image/svg+xml,%3Csvg/%3E">';
 		$this->assertSame($html, RelativeUrl::reparent($html, 2));
 	}
 
 	public function testNonAttributeDotSlashInScriptIsNotRewritten() {
 		$html = '<script>var x = {"path": "./y"};</script>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
+	public function testAnEscapedAttributeShownAsACodeExampleIsNotRewritten() {
+		// htmlspecialchars(..., ENT_NOQUOTES), which MediaWiki uses for preformatted text, escapes the
+		// angle brackets but not the quotes: the example reads like a real href="./intro" but sits in
+		// no real "<...>" tag span, so it must be left exactly as written.
+		$html = '<pre>&lt;a href="./intro"&gt;Intro&lt;/a&gt;</pre>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
+	public function testCssUrlShownAsACodeExampleIsNotRewritten() {
+		$html = '<pre>.a{background:url(./bg.png)}</pre>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
+	public function testDataHrefAndXlinkHrefAreNotRewritten() {
+		// \b before "href" also matches inside "data-href" and "xlink:href", neither of which is the
+		// href attribute; only a real, whitespace-preceded href/src is a rewrite target.
+		$html = '<div data-href="./x"><svg><use xlink:href="./y"></use></svg></div>';
 		$this->assertSame($html, RelativeUrl::reparent($html, 1));
 	}
 


### PR DESCRIPTION
`reparent()`'s href/src/srcset/url() regexes had no notion of "this is an attribute", only "these bytes look like one," so they fired anywhere in the page: text nodes, `<pre>`/`<code>` blocks, script string literals. MediaWiki escapes preformatted text with `htmlspecialchars(..., ENT_NOQUOTES)`, which escapes `<`/`>` but leaves quotes untouched — a documentation page showing `<a href="./intro">` in a `<pre>` block reads, byte for byte, exactly like the real thing once its angle brackets are escaped to `&lt;`/`&gt;`, and was silently corrupted (`href="../intro"`) on every subpage build. Separately, `\b` before `href`/`src` also matched inside `data-href="./x"` and `xlink:href="./x"`, neither of which is the href attribute.

The finding named the principled fix as `HtmlHelper::modifyElements()` (RemexHtml). I didn't take that route: it reserializes the whole document — normalizing void tags, attribute quoting, and entities — which would change byte output across every existing page and force re-baselining every fixture, for a documentation-site generator whose own reproducibility is a design goal.

Instead, taking the finding's cited cheaper partial: each candidate now has to fall inside a real `<tag ...>` span (a `<style>` block counts too, for `url()`) before it is rewritten, computed with a lightweight pre-scan rather than a real parser. An escaped example has no such span — only its angle brackets were escaped, not its quotes — so it's left untouched. `\b` is replaced with a literal preceding `\s`, which no longer matches inside `data-href`/`xlink:href`. Verified standalone against the full case matrix (every existing positive-match case rewritten as a realistic tag rather than a bare fragment, plus the two documented bugs reproduced against the old code and confirmed fixed against the new).

15 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_