### PR TITLE
fix: replace hand-rolled balanced-div matcher with RemexHtml

### DIFF
--- a/includes/HtmlElementRemover.php
+++ b/includes/HtmlElementRemover.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use Wikimedia\RemexHtml\HTMLData;
+use Wikimedia\RemexHtml\Tokenizer\Attributes;
+use Wikimedia\RemexHtml\Tokenizer\NullTokenHandler;
+use Wikimedia\RemexHtml\Tokenizer\Tokenizer;
+
+/**
+ * Removes whole elements, subtree included, from raw HTML by byte range.
+ *
+ * RemexHtml's tokenizer -- the same one MediaWiki's own parser uses -- finds real tag boundaries
+ * and nesting depth regardless of tag name, attribute quoting, or a ">" inside an attribute value.
+ * Only the matched ranges are spliced out with substr(); everything else is untouched, byte for
+ * byte, unlike a tree-builder-based rewrite that would reserialize the whole document.
+ */
+class HtmlElementRemover {
+	/**
+	 * @param string $html
+	 * @param callable(string,array<string,string>):bool $matches Given a start tag's lowercase name
+	 *   and its attributes (name => value), whether that element and its subtree should be removed.
+	 */
+	public static function remove(string $html, callable $matches): string {
+		$handler = new class($matches) extends NullTokenHandler {
+			/** @var callable(string,array<string,string>):bool */
+			private $matches;
+			private array $voidElements;
+			private int $depth = 0;
+			private ?int $activeDepth = null;
+			private int $activeStart = 0;
+			/** @var list<array{int,int}> */
+			public array $ranges = [];
+
+			public function __construct(callable $matches) {
+				$this->matches = $matches;
+				$this->voidElements = HTMLData::TAGS['void'];
+			}
+
+			/** @inheritDoc */
+			public function startTag($name, Attributes $attrs, $selfClose, $sourceStart, $sourceLength) {
+				// A void element (e.g. <img>, <input>) or a self-closed one (<path .../>) never gets a
+				// matching end tag, so it neither opens a span nor adds to the nesting depth.
+				$isVoid = $selfClose || isset($this->voidElements[$name]);
+
+				if ($this->activeDepth === null && ( $this->matches )($name, $attrs->getValues())) {
+					if ($isVoid) {
+						$this->ranges[] = [$sourceStart, $sourceStart + $sourceLength];
+					} else {
+						$this->activeDepth = $this->depth;
+						$this->activeStart = $sourceStart;
+					}
+				}
+
+				if (!$isVoid) {
+					$this->depth++;
+				}
+			}
+
+			/** @inheritDoc */
+			public function endTag($name, $sourceStart, $sourceLength) {
+				if ($this->depth > 0) {
+					$this->depth--;
+				}
+				// Depth returning to the level it was at when a match opened means this end tag is the
+				// one that closes it: every intervening open has already been matched by a close.
+				if ($this->activeDepth !== null && $this->depth === $this->activeDepth) {
+					$this->ranges[] = [$this->activeStart, $sourceStart + $sourceLength];
+					$this->activeDepth = null;
+				}
+			}
+		};
+
+		( new Tokenizer($handler, $html, ['skipPreprocess' => true]) )->execute();
+
+		$result = $html;
+		// Back to front, so an earlier range's offsets are still valid as later ones are spliced out.
+		foreach (array_reverse($handler->ranges) as [$start, $end]) {
+			$result = substr($result, 0, $start) . substr($result, $end);
+		}
+		return $result;
+	}
+}

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -126,12 +126,17 @@ class RewriteScripts extends Maintenance {
 
 			// Without SifterSearch, drop the search boxes and body class so nothing mounts or fetches.
 			if (!$sifterEnabled) {
-				$html = $this->removeElements($html, 'vector-search-box-vue');
+				$html = HtmlElementRemover::remove($html, static function ($unusedName, array $attrs) {
+					$classes = isset($attrs['class']) ? preg_split('/\s+/', trim($attrs['class'])) : [];
+					return in_array('vector-search-box-vue', $classes, true);
+				});
 				$html = str_replace(' skin-vector-search-vue', '', $html);
 			}
 
 			// Remove the appearance menu: its widgets pull codex+vue from load.php, which 404s statically.
-			$html = $this->removeElements($html, 'id="vector-appearance"');
+			$html = HtmlElementRemover::remove($html, static function ($unusedName, array $attrs) {
+				return ( $attrs['id'] ?? null ) === 'vector-appearance';
+			});
 
 			file_put_contents($file, $html, LOCK_EX);
 		}
@@ -156,67 +161,6 @@ class RewriteScripts extends Maintenance {
 			}
 		}
 		return $modules;
-	}
-
-	/** Remove every balanced <div ...$marker...>...</div> (nested-aware) from the HTML. */
-	private function removeElements(string $html, string $marker): string {
-		while (true) {
-			$start = $this->findOpeningDiv($html, $marker);
-			if ($start === -1) {
-				return $html;
-			}
-			$end = $this->matchingDivEnd($html, $start);
-			if ($end === -1) {
-				return $html;
-			}
-			$html = substr($html, 0, $start) . substr($html, $end);
-		}
-	}
-
-	/**
-	 * @return int Byte offset of the opening <div, or -1.
-	 */
-	private function findOpeningDiv(string $html, string $marker): int {
-		$pos = strpos($html, '<div');
-		while ($pos !== false) {
-			$tagEnd = strpos($html, '>', $pos);
-			if ($tagEnd === false) {
-				return -1;
-			}
-			if (str_contains(substr($html, $pos, $tagEnd - $pos), $marker)) {
-				return $pos;
-			}
-			$pos = strpos($html, '<div', $tagEnd + 1);
-		}
-		return -1;
-	}
-
-	/**
-	 * Find the end of the <div> opening at byte offset $start.
-	 * @return int Byte offset just past the matching </div>, or -1.
-	 */
-	private function matchingDivEnd(string $html, int $start): int {
-		$depth = 0;
-		$len = strlen($html);
-		$i = $start;
-		while ($i < $len) {
-			$open = strpos($html, '<div', $i);
-			$close = strpos($html, '</div>', $i);
-			if ($close === false) {
-				return -1;
-			}
-			if ($open !== false && $open < $close) {
-				$depth++;
-				$i = $open + 4;
-			} else {
-				$depth--;
-				$i = $close + 6;
-				if ($depth === 0) {
-					return $i;
-				}
-			}
-		}
-		return -1;
 	}
 }
 

--- a/tests/phpunit/unit/HtmlElementRemoverTest.php
+++ b/tests/phpunit/unit/HtmlElementRemoverTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\HtmlElementRemover;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\HtmlElementRemover
+ */
+class HtmlElementRemoverTest extends MediaWikiUnitTestCase {
+	private function byId(): callable {
+		return static function ($name, array $attrs) {
+			return ( $attrs['id'] ?? null ) === 'vector-appearance';
+		};
+	}
+
+	public function testRemovesAMatchedElementAndItsSubtree() {
+		$html = '<body><div id="vector-appearance"><div>nested</div>text</div><p>keep</p></body>';
+		$this->assertSame(
+			'<body><p>keep</p></body>',
+			HtmlElementRemover::remove($html, $this->byId())
+		);
+	}
+
+	public function testMatchesRegardlessOfTagName() {
+		// Vector may render the targeted chrome as <nav>, <aside>, or <form> instead of <div>; a
+		// matcher hardcoded to "<div" would silently leave it in place.
+		$html = '<body><nav id="vector-appearance"><span>x</span></nav><p>keep</p></body>';
+		$this->assertSame(
+			'<body><p>keep</p></body>',
+			HtmlElementRemover::remove($html, $this->byId())
+		);
+	}
+
+	public function testAGreaterThanInsideAnAttributeValueIsNotTheTagEnd() {
+		$html = '<body><div id="vector-appearance" data-note="a > b">x</div><p>keep</p></body>';
+		$this->assertSame(
+			'<body><p>keep</p></body>',
+			HtmlElementRemover::remove($html, $this->byId())
+		);
+	}
+
+	public function testAVoidOrSelfClosedElementInsideTheSubtreeDoesNotDesyncDepth() {
+		$html =
+			'<body><div id="vector-appearance"><input type="search"><svg><path d="M0 0"/></svg></div>'
+			. '<p>keep</p></body>';
+		$this->assertSame(
+			'<body><p>keep</p></body>',
+			HtmlElementRemover::remove($html, $this->byId())
+		);
+	}
+
+	public function testClassMatchingIsByTokenNotSubstring() {
+		$matches = static function ($name, array $attrs) {
+			$classes = isset($attrs['class']) ? preg_split('/\s+/', trim($attrs['class'])) : [];
+			return in_array('vector-search-box-vue', $classes, true);
+		};
+
+		$html = '<body><div class="vector-search-box-vue extra"><span>x</span></div><p>keep</p></body>';
+		$this->assertSame('<body><p>keep</p></body>', HtmlElementRemover::remove($html, $matches));
+
+		// A class that merely contains the marker as a substring must not match.
+		$lookalike = '<body><div class="my-vector-search-box-vue-extra">x</div><p>keep</p></body>';
+		$this->assertSame($lookalike, HtmlElementRemover::remove($lookalike, $matches));
+	}
+
+	public function testTwoSiblingMatchesAreBothRemoved() {
+		$html = '<body><div id="vector-appearance">a</div><p>mid</p><div id="vector-appearance">b</div></body>';
+		$this->assertSame(
+			'<body><p>mid</p></body>',
+			HtmlElementRemover::remove($html, $this->byId())
+		);
+	}
+
+	public function testNoMatchLeavesTheHtmlUntouched() {
+		$html = '<body><div class="other">x</div></body>';
+		$this->assertSame($html, HtmlElementRemover::remove($html, $this->byId()));
+	}
+}


### PR DESCRIPTION
`removeElements()`/`findOpeningDiv()`/`matchingDivEnd()` removed subtrees by counting raw byte occurrences of `<div` and `</div>`. Three real gaps followed:

- Hardcoded to a literal `<div`: if Vector renders the targeted chrome as a `<nav>`, `<aside>`, or `<form>` wrapper instead, the matcher returns `-1` and the removal is silently skipped.
- Took the first `>` after `<div` as the tag's end, so a `>` inside an earlier attribute value (`data-note="a > b"`) caused the matcher to miss the marker.
- No notion of a void or self-closed element, so an `<input>` or a self-closed `<path/>` inside the subtree could desync the depth count.

The finding named `Wikimedia\RemexHtml\Tokenizer\Tokenizer` as the fix, and it's a good fit here specifically because it doesn't need to reserialize the document (unlike C1's `HtmlHelper::modifyElements()` route, which was passed over for exactly that reason) — the tokenizer's `startTag`/`endTag` events only need to report `$sourceStart`/`$sourceLength`, which get spliced out of the original bytes with `substr()`. Everything outside a removed range stays untouched, byte for byte.

`HtmlElementRemover` (new, `includes/`) walks the page with that tokenizer, tracking element depth from its events — skipping void and self-closed elements, which never get a matching end tag — instead of scanning for one hardcoded tag name. Both call sites move from a raw marker substring to a real attribute predicate: the search box by actual class-list membership (not a substring match that could also fire inside an unrelated attribute value), and the appearance menu by its `id` attribute. Verified standalone against real `RemexHtml` (all three documented gaps reproduced as failing cases and confirmed fixed) before adding the equivalent PHPUnit test.

16 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_