### PR TITLE
fix: resolve $wgWikvenLogos through Title/RepoGroup, not by hand

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -41,7 +41,7 @@
 		"BeforePageDisplay": "adder",
 		"GetLocalURL": "main",
 		"OutputPageAfterGetHeadLinksArray": "main",
-		"SetupAfterCache": "retrier"
+		"SetupAfterCache": ["retrier", "main"]
 	},
 	"HookHandlers": {
 		"main": {

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -15,8 +15,11 @@ use MediaWiki\Title\Title;
 class Main implements
 	\MediaWiki\Hook\GetLocalURLHook,
 	\MediaWiki\Hook\OutputPageAfterGetHeadLinksArrayHook,
+	\MediaWiki\Hook\SetupAfterCacheHook,
 	\MediaWiki\Hook\SkinTemplateNavigation__UniversalHook {
 	private ?Context $rlClientContext = null;
+
+	private Config $config;
 
 	/** The directory the HTML files are written to. */
 	private string $htmlDirectory;
@@ -25,6 +28,7 @@ class Main implements
 	private string $styleDirectory;
 
 	public function __construct(Config $config) {
+		$this->config = $config;
 		$this->htmlDirectory = $config->get('WikvenHtmlDirectory');
 		$this->styleDirectory = $config->get('WikvenStyleDirectory');
 	}
@@ -78,6 +82,61 @@ class Main implements
 		} else {
 			$url = "./$name.html";
 		}
+	}
+
+	/**
+	 * Resolve $wgWikvenLogos -- $wgLogos, but each src is a source-dir file name -- to $wgLogos
+	 * proper, once each file's actual upload URL can be asked for.
+	 *
+	 * This has to run here rather than in WikvenSettings.php (LocalSettings.php time), because the
+	 * service container -- Title, RepoGroup -- does not exist yet that early.
+	 *
+	 * @inheritDoc
+	 */
+	public function onSetupAfterCache(): void {
+		$wikvenLogos = $this->config->get('WikvenLogos');
+		if (!is_array($wikvenLogos) || $wikvenLogos === []) {
+			return;
+		}
+		$sourceDirectory = $this->config->get('WikvenSourceDirectory');
+
+		$logos = is_array($GLOBALS['wgLogos'] ?? null) ? $GLOBALS['wgLogos'] : [];
+		foreach ($wikvenLogos as $key => $value) {
+			if (is_array($value)) {
+				if (!isset($value['src'])) {
+					$logos[$key] = $value;
+					continue;
+				}
+				$src = $this->resolveLogoUrl($sourceDirectory, (string)$value['src']);
+				if ($src === null) {
+					continue;
+				}
+				$value['src'] = $src;
+				$logos[$key] = $value;
+			} else {
+				$url = $this->resolveLogoUrl($sourceDirectory, (string)$value);
+				if ($url !== null) {
+					$logos[$key] = $url;
+				}
+			}
+		}
+		$GLOBALS['wgLogos'] = $logos;
+	}
+
+	/**
+	 * The upload URL a source-dir file name $name will have, or null if it does not exist there.
+	 */
+	private function resolveLogoUrl(string $sourceDirectory, string $name): ?string {
+		if ($sourceDirectory === '' || !is_file("$sourceDirectory/$name")) {
+			error_log("Wikven: logo file '$name' not found in the source directory");
+			return null;
+		}
+		$title = Title::makeTitleSafe(NS_FILE, $name);
+		if ($title === null) {
+			error_log("Wikven: logo file '$name' is not a valid file title");
+			return null;
+		}
+		return MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo()->newFile($title)->getUrl();
 	}
 
 	/**

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -249,44 +249,5 @@ if (
 	$GLOBALS['wgSifterSearchOutputDir'] = "$wikvenDist/pagefind";
 }
 
-// WikvenLogos mirrors $wgLogos but each src is a source-dir file name; resolve to its upload URL.
-if (!empty($wgWikvenLogos) && is_array($wgWikvenLogos)) {
-	// Map a source file name to the flat-storage URL its upload will have.
-	$wikvenLogoUrl = static function ($name) use ($wikvenSrc) {
-		global $wgUploadPath, $wgScriptPath, $wgCapitalLinks;
-		if (!is_file("$wikvenSrc/" . $name)) {
-			error_log("Wikven: logo file '$name' not found in the source directory");
-			return null;
-		}
-		// $wgUploadPath is false this early; resolve to $wgScriptPath/images as Setup.php does.
-		$uploadPath =
-			$wgUploadPath !== false && (string)$wgUploadPath !== ''
-				? $wgUploadPath
-				: ( $wgScriptPath ?? '' ) . '/images';
-		$title = str_replace(' ', '_', trim($name));
-		if ($wgCapitalLinks ?? true) {
-			$title = ucfirst($title);
-		}
-		return rtrim((string)$uploadPath, '/') . '/' . $title;
-	};
-
-	$logos = isset($wgLogos) && is_array($wgLogos) ? $wgLogos : [];
-	foreach ($wgWikvenLogos as $key => $value) {
-		if (is_array($value)) {
-			if (isset($value['src'])) {
-				$src = $wikvenLogoUrl($value['src']);
-				if ($src === null) {
-					continue;
-				}
-				$value['src'] = $src;
-			}
-			$logos[$key] = $value;
-		} else {
-			$url = $wikvenLogoUrl($value);
-			if ($url !== null) {
-				$logos[$key] = $url;
-			}
-		}
-	}
-	$wgLogos = $logos;
-}
+// WikvenLogos ($wgWikvenLogos) mirrors $wgLogos but each src is a source-dir file name, resolved
+// to its upload URL once the service container exists; see Hooks\Main::onSetupAfterCache().

--- a/tests/phpunit/integration/MainSetupAfterCacheTest.php
+++ b/tests/phpunit/integration/MainSetupAfterCacheTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\Hooks\Main;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Hooks\Main
+ */
+class MainSetupAfterCacheTest extends MediaWikiIntegrationTestCase {
+	private function main(): Main {
+		return new Main($this->getServiceContainer()->getMainConfig());
+	}
+
+	/** The upload URL RepoGroup itself would give $name, so tests aren't pinned to its exact form. */
+	private function expectedUrl(string $name): string {
+		$title = Title::makeTitleSafe(NS_FILE, $name);
+		return MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo()->newFile($title)->getUrl();
+	}
+
+	public function testNoWikvenLogosLeavesWgLogosUntouched() {
+		$this->overrideConfigValue('WikvenLogos', []);
+		$this->setMwGlobals('wgLogos', ['icon' => '/existing.svg']);
+		$this->main()->onSetupAfterCache();
+		$this->assertSame(['icon' => '/existing.svg'], $GLOBALS['wgLogos']);
+	}
+
+	public function testAMissingSourceFileIsSkipped() {
+		$this->overrideConfigValue('WikvenSourceDirectory', $this->getNewTempDirectory());
+		$this->overrideConfigValue('WikvenLogos', ['1x' => 'missing.png']);
+		$this->setMwGlobals('wgLogos', []);
+		$this->main()->onSetupAfterCache();
+		$this->assertArrayNotHasKey('1x', $GLOBALS['wgLogos']);
+	}
+
+	/**
+	 * The file exists as "über.png"; under ASCII-only ucfirst() the old hand-rolled code linked it
+	 * as "über.png" while MediaWiki (CapitalLinks) uploads it as "Über.png". Delegating to Title
+	 * gets the UTF-8-aware capitalization right.
+	 */
+	public function testAScalarLogoResolvesThroughTitleAndRepoGroup() {
+		$src = $this->getNewTempDirectory();
+		file_put_contents("$src/über.png", 'not a real png, just needs to exist');
+		$this->overrideConfigValue('WikvenSourceDirectory', $src);
+		$this->overrideConfigValue('WikvenLogos', ['1x' => 'über.png']);
+		$this->setMwGlobals('wgLogos', []);
+
+		$this->main()->onSetupAfterCache();
+
+		$this->assertSame($this->expectedUrl('über.png'), $GLOBALS['wgLogos']['1x']);
+	}
+
+	public function testAnArrayFormLogoHasOnlyItsSrcResolved() {
+		$src = $this->getNewTempDirectory();
+		file_put_contents("$src/logo.png", 'not a real png, just needs to exist');
+		$this->overrideConfigValue('WikvenSourceDirectory', $src);
+		$this->overrideConfigValue('WikvenLogos', [
+			'icon' => ['src' => 'logo.png', 'width' => 50, 'height' => 50]
+		]);
+		$this->setMwGlobals('wgLogos', []);
+
+		$this->main()->onSetupAfterCache();
+
+		$this->assertSame(
+			['src' => $this->expectedUrl('logo.png'), 'width' => 50, 'height' => 50],
+			$GLOBALS['wgLogos']['icon']
+		);
+	}
+
+	public function testAnArrayFormLogoWithoutSrcIsKeptAsIs() {
+		$this->overrideConfigValue('WikvenSourceDirectory', $this->getNewTempDirectory());
+		$this->overrideConfigValue('WikvenLogos', ['icon' => ['width' => 50]]);
+		$this->setMwGlobals('wgLogos', []);
+
+		$this->main()->onSetupAfterCache();
+
+		$this->assertSame(['width' => 50], $GLOBALS['wgLogos']['icon']);
+	}
+
+	public function testExistingWgLogosEntriesNotNamedByWikvenAreKept() {
+		$this->overrideConfigValue('WikvenLogos', []);
+		$this->setMwGlobals('wgLogos', ['wordmark' => '/existing.svg']);
+		$this->main()->onSetupAfterCache();
+		$this->assertSame('/existing.svg', $GLOBALS['wgLogos']['wordmark']);
+	}
+}


### PR DESCRIPTION
`$wikvenLogoUrl()` in `WikvenSettings.php` re-derived a file's upload URL with `str_replace(' ', '_', trim($name))` and an ASCII-only `ucfirst()`: no percent-encoding, so a logo named `logo #1.png` produced a `src` the browser reads as a URL fragment and never fetches; and ASCII-only capitalization, so a logo `über.png` — uploaded by MediaWiki (with `CapitalLinks`) as `Über.png` — linked as the never-uploaded `über.png`.

The reason it was hand-rolled in the first place still holds: `WikvenSettings.php` runs during `LocalSettings.php`, before `Title` or `RepoGroup` exist. The resolution now runs in `Hooks\Main::onSetupAfterCache` instead, which fires once the service container is up ("most of the config is out, some might want to run hooks here," per `Setup.php`'s own comment at the call site) but still early enough for every consumer of `$wgLogos`. `Hooks\Retrier` already uses the same `SetupAfterCache` hook for an equivalent LocalSettings.php-time limitation, so `extension.json` now routes it to both handlers.

`Title::makeTitleSafe(NS_FILE, $name)` plus `RepoGroup::getLocalRepo()->newFile($title)->getUrl()` percent-encodes and is UTF-8 aware, so both bugs go away by construction rather than by patching the hand-rolled version. Moving this out of `WikvenSettings.php` also makes it unit-testable for the first time — previously not possible for LocalSettings.php-time procedural code — covered by a new integration test (`MainSetupAfterCacheTest`) whose expected URLs are computed through the same `Title`/`RepoGroup` calls the code under test uses, rather than hardcoded, so they aren't pinned to `$wgHashedUploadDirectory`'s exact layout.

17 of 18 from #288.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_