### PR TITLE
ci: add a Renovate custom manager for the SifterSearch version pin

### DIFF
--- a/.github/workflows/bump-siftersearch.yml
+++ b/.github/workflows/bump-siftersearch.yml
@@ -3,6 +3,12 @@ name: Bump SifterSearch
 
 # Dependabot cannot track a GitHub-release tarball pinned in a Dockerfile ARG, so check weekly
 # and open a bump PR when SifterSearch publishes a new release.
+#
+# renovate.json already declares a custom manager for this same ARG line, ready for whenever the
+# Renovate GitHub App is installed on the org -- that also requires no code change here, just an
+# org admin's action -- at which point this workflow is redundant and can be removed. Renovate's
+# own PRs trigger CI normally (unlike the GITHUB_TOKEN-opened ones below) and supersede an older
+# bump PR instead of leaving it open, neither of which this workflow can do on its own.
 on:
   schedule:
     - cron: "0 5 * * 1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 ARG TARGETARCH
+# renovate: datasource=github-releases depName=chaotic-ground/SifterSearch
 ARG SIFTERSEARCH_VERSION=v0.6.1
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"enabledManagers": ["custom.regex"],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"description": "Dependabot cannot track a GitHub-release tarball pinned in a Dockerfile ARG; the other five ecosystems here (composer, npm, github-actions, docker, gomod) already have Dependabot covering them in .github/dependabot.yml, so this manager is the only one enabled.",
+			"managerFilePatterns": ["/^Dockerfile$/"],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)\\s+ARG SIFTERSEARCH_VERSION=(?<currentValue>.+?)\\s"
+			]
+		}
+	],
+	"packageRules": [
+		{
+			"matchDepNames": ["chaotic-ground/SifterSearch"],
+			"commitMessageTopic": "SifterSearch",
+			"semanticCommits": "enabled",
+			"semanticCommitType": "build",
+			"semanticCommitScope": "deps"
+		}
+	]
+}


### PR DESCRIPTION
`bump-siftersearch.yml` hand-rolls dependency bumping: `sed` reads the pin, `gh release view` finds the latest, `sed` writes it back, then a PR is opened by manually configuring `git`, committing, and pushing with a tokenised URL. Two real costs follow: a PR opened with `GITHUB_TOKEN` doesn't trigger the repo's normal CI, which the workflow's own comment already works around by baking the image inline instead and tells whoever reviews the PR to close and reopen it for the full suite; and each bumped version gets its own branch, so an older bump PR is left open instead of being superseded.

Dependabot cannot cover this at all — it has no notion of a GitHub release tarball pinned in a Dockerfile `ARG`, which is the whole reason this workflow exists. `renovate.json` now declares a custom regex manager for exactly that `ARG` line, keyed off a `# renovate: datasource=... depName=...` comment — the standard way to point Renovate's regex manager at something none of its built-in managers already understand. `enabledManagers` is scoped to just that one manager, leaving the other five ecosystems already on Dependabot (`.github/dependabot.yml`) alone, so running both bots doesn't risk duplicate PRs for anything.

**Scope note:** turning this on for real needs an org admin to install the Renovate GitHub App on `chaotic-ground` — outside what a code change can do. `bump-siftersearch.yml` stays in place and functional until then; I added a comment pointing at `renovate.json` as the eventual replacement, so a future cleanup doesn't have to rediscover the connection.

18 of 18 from #288 — the last one.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_