### PR TITLE
ci: stop lint tools burning the shared GitHub API budget, and cancel superseded runs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,13 @@ permissions:
   contents: read
   packages: write
 
+# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
+# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run, which
+# also covers the workflow_call path from release-please: a release build is never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,9 +21,7 @@ permissions:
   contents: read
   packages: write
 
-# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
-# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run, which
-# also covers the workflow_call path from release-please: a release build is never cancelled.
+# Cancel superseded runs; pushes to main (including release-please's workflow_call) are left alone.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,15 +8,63 @@ on:
 
 permissions: {}
 
+# A superseded push (a force-push while CI is mid-flight) leaves a run building a commit nobody
+# will merge. Keyed on the PR number rather than github.ref so it also holds for pull_request_target,
+# where github.ref is the base branch and every PR would otherwise share one group. Pushes to main
+# are left to finish: each merged commit should keep its own CI result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+# biome and mago are installed by hand rather than through their setup-* actions on purpose. Each
+# of those actions spends two GitHub REST calls per run to resolve a download URL that the pinned
+# version already determines, and caches nothing, so it pays them every time. They come out of the
+# 1,000/hour GITHUB_TOKEN budget that every run in this repository shares, which a burst of pull
+# requests exhausts -- the jobs then fail on a 403 with nothing wrong in the code. Fetching the
+# release asset directly touches the CDN, not the REST API, and a cache hit skips even that. Caches
+# written by main runs are readable from every pull request branch, so a miss is rare.
+
 jobs:
   biome:
     runs-on: ubuntu-latest
+    env:
+      # Must match biome.json's $schema URL; the guard step below fails if the two drift apart.
+      BIOME_VERSION: "2.4.16"
+      BIOME_SHA256: "f6904c208ce8884cf859460178f32f885250b375da1810c551912a029f4abf79"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      # The version is autodetected from the $schema URL in biome.json.
-      - uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51  # v2.7.1
+
+      # biome.json is where the version is chosen; this job only mirrors it, so say so out loud
+      # rather than silently linting with a different biome than the editor uses.
+      - name: Check the pinned version still matches biome.json
+        run: |
+          schema=$(sed -n 's#.*biomejs\.dev/schemas/\([^/]*\)/.*#\1#p' biome.json)
+          if [ "$schema" != "$BIOME_VERSION" ]; then
+            echo "::error file=biome.json::biome.json asks for $schema, lint.yml pins $BIOME_VERSION"
+            exit 1
+          fi
+
+      - id: cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: ~/.local/bin/biome
+          key: biome-${{ runner.os }}-${{ env.BIOME_VERSION }}
+
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          base=https://github.com/biomejs/biome/releases/download
+          tmp=$(mktemp -d)
+          curl -fsSL -o "$tmp/biome" "$base/@biomejs/biome@${BIOME_VERSION}/biome-linux-x64"
+          echo "${BIOME_SHA256}  $tmp/biome" | sha256sum -c -
+          mkdir -p ~/.local/bin
+          mv "$tmp/biome" ~/.local/bin/biome
+
+      - run: |
+          chmod +x ~/.local/bin/biome
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - run: biome ci
 
   rumdl:
@@ -50,6 +98,9 @@ jobs:
 
   mago:
     runs-on: ubuntu-latest
+    env:
+      MAGO_VERSION: "1.29.0"
+      MAGO_SHA256: "5e99d1232fa93e6adc6feaaddaf2b46c148b2990173cdcf18400b474646bf046"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -60,9 +111,28 @@ jobs:
           tools: composer
       # mago.toml extends the shared style config installed under vendor/, so install it first.
       - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
-      - uses: nhedger/setup-mago@473d3a2bfe0b32a62c8b910059d7f03a16519f2e  # v2.0.0
+
+      - id: cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
-          version: "1.29.0"
+          path: ~/.local/bin/mago
+          key: mago-${{ runner.os }}-${{ env.MAGO_VERSION }}
+
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          base=https://github.com/carthage-software/mago/releases/download
+          dir="mago-${MAGO_VERSION}-x86_64-unknown-linux-musl"
+          tmp=$(mktemp -d)
+          curl -fsSL -o "$tmp/mago.tar.gz" "$base/${MAGO_VERSION}/${dir}.tar.gz"
+          echo "${MAGO_SHA256}  $tmp/mago.tar.gz" | sha256sum -c -
+          tar -xzf "$tmp/mago.tar.gz" -C "$tmp"
+          mkdir -p ~/.local/bin
+          mv "$tmp/$dir/mago" ~/.local/bin/mago
+
+      - run: |
+          chmod +x ~/.local/bin/mago
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - run: mago format --check
       - run: mago lint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,24 +8,15 @@ on:
 
 permissions: {}
 
-# A superseded push (a force-push while CI is mid-flight) leaves a run building a commit nobody
-# will merge. Keyed on the PR number rather than github.ref so it also holds for pull_request_target,
-# where github.ref is the base branch and every PR would otherwise share one group. Pushes to main
-# are left to finish: each merged commit should keep its own CI result.
+# Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
-# biome and mago are installed by hand rather than through their setup-* actions on purpose. Each
-# of those actions spends two GitHub REST calls per run to resolve a download URL that the pinned
-# version already determines, and caches nothing, so it pays them every time. They come out of the
-# 1,000/hour GITHUB_TOKEN budget that every run in this repository shares, which a burst of pull
-# requests exhausts -- the jobs then fail on a 403 with nothing wrong in the code. Fetching the
-# release asset directly touches the CDN, not the REST API, and a cache hit skips even that. Caches
-# written by main runs are readable from every pull request branch, so a miss is rare.
-#
-# Neither version is written down here: biome's comes from biome.json's $schema, which is what an
-# editor reads too, and mago's from composer.json, beside the rest of the PHP tooling.
+# biome and mago are installed by hand, not via their setup-* actions: those spend two GitHub REST
+# calls per run to resolve a fixed download URL and cache nothing, exhausting the 1,000/hour
+# GITHUB_TOKEN budget the whole repository shares. Versions come from biome.json's $schema and,
+# since mago has none of its own, composer.json.
 
 jobs:
   biome:
@@ -35,8 +26,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # biome.json's $schema already names the version, and it is the one an editor honours, so it
-      # stays the only place the version is written down.
       - id: version
         run: |
           v=$(sed -n 's#.*biomejs\.dev/schemas/\([^/]*\)/.*#\1#p' biome.json)
@@ -110,8 +99,6 @@ jobs:
       # mago.toml extends the shared style config installed under vendor/, so install it first.
       - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
 
-      # mago has no config file of its own that carries a version, so the pin lives beside the
-      # other PHP tooling in composer.json rather than here.
       - id: version
         run: |
           php -r '$e = json_decode(file_get_contents("composer.json"), true)["extra"];

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
-# biome and mago are installed by hand, not via their setup-* actions: those spend two GitHub REST
-# calls per run to resolve a fixed download URL and cache nothing, exhausting the 1,000/hour
-# GITHUB_TOKEN budget the whole repository shares. Versions come from biome.json's $schema and,
-# since mago has none of its own, composer.json.
+# biome and mago are installed by hand: their setup-* actions spend two GitHub REST calls per run
+# on a fixed download URL and cache nothing, exhausting the repository's shared 1,000/hour budget.
 
 jobs:
   biome:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,41 +23,42 @@ concurrency:
 # requests exhausts -- the jobs then fail on a 403 with nothing wrong in the code. Fetching the
 # release asset directly touches the CDN, not the REST API, and a cache hit skips even that. Caches
 # written by main runs are readable from every pull request branch, so a miss is rare.
+#
+# Neither version is written down here: biome's comes from biome.json's $schema, which is what an
+# editor reads too, and mago's from composer.json, beside the rest of the PHP tooling.
 
 jobs:
   biome:
     runs-on: ubuntu-latest
-    env:
-      # Must match biome.json's $schema URL; the guard step below fails if the two drift apart.
-      BIOME_VERSION: "2.4.16"
-      BIOME_SHA256: "f6904c208ce8884cf859460178f32f885250b375da1810c551912a029f4abf79"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
-      # biome.json is where the version is chosen; this job only mirrors it, so say so out loud
-      # rather than silently linting with a different biome than the editor uses.
-      - name: Check the pinned version still matches biome.json
+      # biome.json's $schema already names the version, and it is the one an editor honours, so it
+      # stays the only place the version is written down.
+      - id: version
         run: |
-          schema=$(sed -n 's#.*biomejs\.dev/schemas/\([^/]*\)/.*#\1#p' biome.json)
-          if [ "$schema" != "$BIOME_VERSION" ]; then
-            echo "::error file=biome.json::biome.json asks for $schema, lint.yml pins $BIOME_VERSION"
+          v=$(sed -n 's#.*biomejs\.dev/schemas/\([^/]*\)/.*#\1#p' biome.json)
+          if [ -z "$v" ]; then
+            echo "::error file=biome.json::could not read a version from the \$schema URL"
             exit 1
           fi
+          echo "v=$v" >> "$GITHUB_OUTPUT"
 
       - id: cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.local/bin/biome
-          key: biome-${{ runner.os }}-${{ env.BIOME_VERSION }}
+          key: biome-${{ runner.os }}-${{ steps.version.outputs.v }}
 
       - if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          BIOME_VERSION: ${{ steps.version.outputs.v }}
         run: |
           base=https://github.com/biomejs/biome/releases/download
           tmp=$(mktemp -d)
           curl -fsSL -o "$tmp/biome" "$base/@biomejs/biome@${BIOME_VERSION}/biome-linux-x64"
-          echo "${BIOME_SHA256}  $tmp/biome" | sha256sum -c -
           mkdir -p ~/.local/bin
           mv "$tmp/biome" ~/.local/bin/biome
 
@@ -98,9 +99,6 @@ jobs:
 
   mago:
     runs-on: ubuntu-latest
-    env:
-      MAGO_VERSION: "1.29.0"
-      MAGO_SHA256: "5e99d1232fa93e6adc6feaaddaf2b46c148b2990173cdcf18400b474646bf046"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -112,13 +110,23 @@ jobs:
       # mago.toml extends the shared style config installed under vendor/, so install it first.
       - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
 
+      # mago has no config file of its own that carries a version, so the pin lives beside the
+      # other PHP tooling in composer.json rather than here.
+      - id: version
+        run: |
+          php -r '$e = json_decode(file_get_contents("composer.json"), true)["extra"];
+                  echo "v=", $e["mago-version"], "\nsha=", $e["mago-sha256"], "\n";' >> "$GITHUB_OUTPUT"
+
       - id: cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.local/bin/mago
-          key: mago-${{ runner.os }}-${{ env.MAGO_VERSION }}
+          key: mago-${{ runner.os }}-${{ steps.version.outputs.v }}
 
       - if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          MAGO_VERSION: ${{ steps.version.outputs.v }}
+          MAGO_SHA256: ${{ steps.version.outputs.sha }}
         run: |
           base=https://github.com/carthage-software/mago/releases/download
           dir="mago-${MAGO_VERSION}-x86_64-unknown-linux-musl"

--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -8,9 +8,7 @@ on:
 
 permissions: {}
 
-# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
-# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run: each
-# merged commit should keep its own CI result.
+# Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}

--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -8,6 +8,13 @@ on:
 
 permissions: {}
 
+# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
+# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run: each
+# merged commit should keep its own CI result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   # phan needs a full MediaWiki environment to resolve core symbols; mago and phpcs can't provide one.
   phan:

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -13,6 +13,13 @@ on:
 
 permissions: {}
 
+# Cancel a superseded run instead of finishing one for a commit nobody will merge. Keyed on the
+# pull request number rather than github.ref: under pull_request_target github.ref is the base
+# branch, so every pull request would land in one group and cancel the others.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   semantic-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -13,9 +13,8 @@ on:
 
 permissions: {}
 
-# Cancel a superseded run instead of finishing one for a commit nobody will merge. Keyed on the
-# pull request number rather than github.ref: under pull_request_target github.ref is the base
-# branch, so every pull request would land in one group and cancel the others.
+# Cancel superseded runs. Keyed on the pull request number, not github.ref: under
+# pull_request_target that is the base branch, so every pull request would share one group.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,6 +31,13 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
+# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run: each
+# merged commit should keep its own CI result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   build-and-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,9 +31,7 @@ on:
 permissions:
   contents: read
 
-# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
-# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run: each
-# merged commit should keep its own CI result.
+# Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,7 @@ on:
 
 permissions: {}
 
-# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
-# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run: each
-# merged commit should keep its own CI result.
+# Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,13 @@ on:
 
 permissions: {}
 
+# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
+# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run: each
+# merged commit should keep its own CI result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   # Compile the Caddy plugin so a Go build error is caught on the PR, not later in the binary build.
   caddy:

--- a/.github/workflows/tf.yml
+++ b/.github/workflows/tf.yml
@@ -14,6 +14,13 @@ on:
 
 permissions: {}
 
+# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
+# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run: each
+# merged commit should keep its own CI result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   plan:
     runs-on: ubuntu-latest

--- a/.github/workflows/tf.yml
+++ b/.github/workflows/tf.yml
@@ -14,9 +14,7 @@ on:
 
 permissions: {}
 
-# Cancel a superseded run -- a force-push lands a new commit while CI is still building the old
-# one -- instead of finishing a commit nobody will merge. Pushes to main are left to run: each
-# merged commit should keep its own CI result.
+# Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
 			"no-api": true
 		}
 	],
+	"extra": {
+		"mago-version": "1.29.0",
+		"mago-sha256": "5e99d1232fa93e6adc6feaaddaf2b46c148b2990173cdcf18400b474646bf046"
+	},
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,


### PR DESCRIPTION
Two CI failures this week were the same root cause, and neither was a code defect:

> API rate limit exceeded **for installation**

That's the `GITHUB_TOKEN` installation limit — **1,000 requests/hour shared by every run in the repository**. A burst of pull requests exhausts it and jobs fail on a 403. Passing a token doesn't help; `setup-biome` and `setup-mago` were both already handed one.

## Why those two jobs specifically

Reading both actions' sources: each spends **two REST calls per run** — `getReleaseByTag`, then a paginated `listReleaseAssets` — purely to compute `asset.browser_download_url`. That URL is fully determined by the pinned version. And neither caches: there is no `tc.find()` call in either source, so they pay it on *every* run.

I audited the other seven lint jobs; none of them touch the REST API (`typos`, `taplo` fetch `releases/download/…` directly, `rumdl` follows the `releases/latest` HTML redirect). So fixing these two covers the whole class.

## What changed

**Caching.** biome and mago are restored from `actions/cache`, and on a miss fetched straight from the release CDN — the same URL the actions end up at, minus the two calls spent discovering it. A cache hit skips the download entirely.

The part that makes this hold under load: Actions caches are branch-scoped, and a pull request branch can read caches written on the **default branch**. `lint.yml` already runs on push to main, so main keeps them warm and concurrent pull requests all hit. If the cache were only ever written by pull request runs, ten simultaneous pull requests would each be a cold miss and we'd be back where we started.

**Version pins live in project config, not in the workflow.** biome's comes from `biome.json`'s `$schema` — already the single source, and the one an editor honours. mago has no config file of its own that carries a version, so its pin sits in `composer.json` beside the rest of the PHP tooling, where Dependabot's composer ecosystem can see it.

Requiring `carthage-software/mago` outright was the obvious alternative and does work — its composer bin is a shim that resolves the same `releases/download` URL from `InstalledVersions`, with no REST call. It's **not** used because its dist is an `api.github.com` zipball (the exact endpoint being avoided here, and currently 403), and composer falls back to cloning the Rust source when that's unavailable: **495 MB of vendor for a linter**. `composer.json` already sets `no-api` on the one VCS repository it declares, for the same reason.

mago's sha256 moved next to its version. biome has none: its version is read from `biome.json`, and a checksum pinned anywhere else would reintroduce exactly the second source of truth this removes. Neither setup action verified a checksum either, so nothing regresses.

**Concurrency.** Only 1 of the 8 workflows a pull request triggers had a concurrency group, so a force-push left the other 7 building a commit nobody would merge. All of them now cancel superseded runs:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
cancel-in-progress: ${{ github.event_name != 'push' }}
```

Keyed on the pull request number rather than `github.ref` because `semantic-pull-request.yml` runs on `pull_request_target`, where `github.ref` is the **base branch** — with `github.ref` every pull request would land in one group and cancel the others. Pushes to main are exempt so each merged commit keeps its own CI result, which also leaves the `release-please` → `docker-build` `workflow_call` path uncancellable.

## Verification

Run locally, not assumed:

- Executed the full chain verbatim — read version from project config → download → checksum → run: `mago 1.29.0` and `biome 2.4.16` both correct.
- Ran the real CI commands with those binaries: `biome ci`, `mago format --check`, `mago lint` all pass.
- Both version-extraction steps emit exactly the `key=value` lines `$GITHUB_OUTPUT` expects.
- Actually installed `carthage-software/mago` via composer before ruling it out — that's where the 495 MB and the 403 on the zipball came from.
- `yamllint --strict .` clean, `composer validate` clean, `zizmor --persona=regular` clean (offline — see caveat).
- The first push of this PR exercised the cold-miss path (no cache existed for these keys yet) and the `biome`/`mago` jobs passed.

## Caveats

- **Residual cold misses.** A version bump changes the cache key, so the first run after one still pays the download. No REST calls either way.
- **Cache eviction.** 10 GiB per repo, LRU, 7-day idle expiry. `docker-build.yml` exports a buildx `type=gha` cache, so there's competition; these binaries are tens of MB, but an eviction means a cold miss.
- **zizmor.** Its `online-audits` default to `true` and it is passed `github.token`. The one online call I observed uses the git protocol (`git-upload-pack`), which has a separate quota from the REST API, and zizmor never failed during either incident — so it's likely not a contributor, but I haven't exhaustively verified it. Left untouched; disabling its online audits would cost real security coverage.
- **Not addressed:** path filters to cut job count. These are required checks, and a required check that never reports leaves a pull request permanently unmergeable — `smoke.yml` and `docker-build.yml` already document exactly this.

🤖 Generated with [Claude Code](https://claude.ai/code)