### PR TITLE
ci: install mago through chaotic-ground/setup-mago

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,7 +102,7 @@ jobs:
           php -r '$e = json_decode(file_get_contents("composer.json"), true)["extra"];
                   echo "v=", $e["mago-version"], "\nsha=", $e["mago-sha256"], "\n";' >> "$GITHUB_OUTPUT"
 
-      - uses: chaotic-ground/setup-mago@34ad32c9df581171351b549e5ab1c3a52bcedded  # v1.0.0
+      - uses: chaotic-ground/setup-mago@2b05b7dc0ef2b491d204a80173c5e573b208d032  # v1.0.0
         with:
           version: ${{ steps.version.outputs.v }}
           sha256: ${{ steps.version.outputs.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
-# biome and mago are installed by hand: their setup-* actions spend two GitHub REST calls per run
-# on a fixed download URL and cache nothing, exhausting the repository's shared 1,000/hour budget.
+# biome is installed by hand, mago via our own action: upstream setup-* actions spend two REST
+# calls per run on a fixed download URL and cache nothing, draining the shared 1,000/hour budget.
 
 jobs:
   biome:
@@ -102,29 +102,10 @@ jobs:
           php -r '$e = json_decode(file_get_contents("composer.json"), true)["extra"];
                   echo "v=", $e["mago-version"], "\nsha=", $e["mago-sha256"], "\n";' >> "$GITHUB_OUTPUT"
 
-      - id: cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      - uses: chaotic-ground/setup-mago@34ad32c9df581171351b549e5ab1c3a52bcedded  # v1.0.0
         with:
-          path: ~/.local/bin/mago
-          key: mago-${{ runner.os }}-${{ steps.version.outputs.v }}
-
-      - if: steps.cache.outputs.cache-hit != 'true'
-        env:
-          MAGO_VERSION: ${{ steps.version.outputs.v }}
-          MAGO_SHA256: ${{ steps.version.outputs.sha }}
-        run: |
-          base=https://github.com/carthage-software/mago/releases/download
-          dir="mago-${MAGO_VERSION}-x86_64-unknown-linux-musl"
-          tmp=$(mktemp -d)
-          curl -fsSL -o "$tmp/mago.tar.gz" "$base/${MAGO_VERSION}/${dir}.tar.gz"
-          echo "${MAGO_SHA256}  $tmp/mago.tar.gz" | sha256sum -c -
-          tar -xzf "$tmp/mago.tar.gz" -C "$tmp"
-          mkdir -p ~/.local/bin
-          mv "$tmp/$dir/mago" ~/.local/bin/mago
-
-      - run: |
-          chmod +x ~/.local/bin/mago
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          version: ${{ steps.version.outputs.v }}
+          sha256: ${{ steps.version.outputs.sha }}
 
       - run: mago format --check
       - run: mago lint


### PR DESCRIPTION
The cache-and-fetch steps this replaces were written inline in `lint.yml` because no existing action installed mago without spending GitHub REST calls. They now live in [`chaotic-ground/setup-mago`](https://github.com/chaotic-ground/setup-mago), so the same fix is available to the other repositories in the organisation — `mago-mediawiki-style` still uses `nhedger/setup-mago@v1.0.0` and has the same exposure — instead of being copied into each one.

Net −19 lines here.

## What is unchanged

The version and its sha256 still come from `composer.json`; only the steps that consume them move. The action fetches the release asset from the CDN rather than the REST API, caches by target triple and version, and verifies the checksum before the binary reaches the cached path — the same behaviour that landed in #317, now with the platform mapping and a self-test around it.

## Pinning

Pinned by commit SHA with a version comment, matching how every other action in this repository is pinned. (The `v1` / `v1.0.0` tags are not pushed yet — my credentials can push branches to the new repository but get a 403 on tag refs, so those need creating by hand. The SHA pin does not depend on them.)

## Verification

The action's own suite ran green on first push: `install` on `ubuntu-latest`, `ubuntu-24.04-arm` and `macos-latest` each assert `mago --version`, and a `checksum` job proves a correct sha256 installs while a wrong one **fails** the step — confirmed by the follow-up "a mismatched sha256 was accepted" guard being skipped, which only happens when the outcome really was a failure.

Locally here: `yamllint --strict` and `zizmor --persona=regular` clean.

The cache key changes shape (`mago-Linux-<version>` → `mago-<triple>-<version>-<sha256>`), so the first run after this lands is a cold miss.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_