### PR TITLE
build(deps): let Renovate bump the mago and biome pins

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,12 +100,11 @@ jobs:
       - id: version
         run: |
           php -r '$e = json_decode(file_get_contents("composer.json"), true)["extra"];
-                  echo "v=", $e["mago-version"], "\nsha=", $e["mago-sha256"], "\n";' >> "$GITHUB_OUTPUT"
+                  echo "v=", $e["mago-version"], "\n";' >> "$GITHUB_OUTPUT"
 
       - uses: chaotic-ground/setup-mago@2b05b7dc0ef2b491d204a80173c5e573b208d032  # v1.0.0
         with:
           version: ${{ steps.version.outputs.v }}
-          sha256: ${{ steps.version.outputs.sha }}
 
       - run: mago format --check
       - run: mago lint

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
 		}
 	],
 	"extra": {
-		"mago-version": "1.29.0",
-		"mago-sha256": "5e99d1232fa93e6adc6feaaddaf2b46c148b2990173cdcf18400b474646bf046"
+		"mago-version": "1.29.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/renovate.json
+++ b/renovate.json
@@ -9,12 +9,34 @@
 			"matchStrings": [
 				"# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)\\s+ARG SIFTERSEARCH_VERSION=(?<currentValue>.+?)\\s"
 			]
+		},
+		{
+			"customType": "regex",
+			"description": "mago is a release binary installed by the Lint workflow, not a composer dependency, so the composer manager does not see the version in extra.",
+			"managerFilePatterns": ["/^composer\\.json$/"],
+			"matchStrings": ["\"mago-version\": \"(?<currentValue>[^\"]+)\""],
+			"datasourceTemplate": "github-releases",
+			"depNameTemplate": "carthage-software/mago"
+		},
+		{
+			"customType": "regex",
+			"description": "biome is installed from a release asset; the version lives only in the $schema URL, which has to keep matching the binary.",
+			"managerFilePatterns": ["/^biome\\.json$/"],
+			"matchStrings": ["biomejs\\.dev/schemas/(?<currentValue>[^/]+)/"],
+			"datasourceTemplate": "npm",
+			"depNameTemplate": "@biomejs/biome"
 		}
 	],
 	"packageRules": [
 		{
 			"matchDepNames": ["chaotic-ground/SifterSearch"],
 			"commitMessageTopic": "SifterSearch",
+			"semanticCommits": "enabled",
+			"semanticCommitType": "build",
+			"semanticCommitScope": "deps"
+		},
+		{
+			"matchDepNames": ["carthage-software/mago", "@biomejs/biome"],
 			"semanticCommits": "enabled",
 			"semanticCommitType": "build",
 			"semanticCommitScope": "deps"


### PR DESCRIPTION
Both lint tools are installed straight from release assets, so no package manager sees their versions and nothing has been bumping them. They are behind:

| tool | pinned | latest |
| --- | --- | --- |
| mago | 1.29.0 | 1.46.0 |
| biome | 2.4.16 | 2.5.8 |

Two regex managers point Renovate at where the versions actually live — `composer.json`'s `extra.mago-version` and the `$schema` URL in `biome.json` — and a package rule gives them the `build(deps)` title the `Semantic Pull Request` check requires. This also doubles as a live check that the newly installed Renovate app works: if it does, two bump PRs should appear shortly after merge.

The `setup-mago` action pin is not covered here; Dependabot's `github-actions` ecosystem already tracks it.

## Dropping `mago-sha256`

The checksum has to be recomputed by hand for every version, which is the step being automated away, and mago publishes no `checksums.txt`/`SHA256SUMS` to derive it from (all the usual names 404). Leaving it in place would mean every Renovate PR arrives with a stale checksum and a red `mago` job until someone edits it — automation that still needs a manual step is not automation.

`setup-mago` verifies only when the input is set, so removing it makes the download unverified. That is the accepted trade-off: the asset is fetched over HTTPS from the `github.com` release CDN, and the version is pinned, so the remaining exposure is a compromised or re-cut upstream release rather than a network attacker. If mago starts publishing checksums, the input can come back with Renovate keeping it current.

## Verified

- `renovate-config-validator` passes.
- Both regexes extract the current pins (`1.29.0`, `2.4.16`) from the real files.
- `yamllint --strict`, `zizmor --offline`, and `biome ci` on the changed files are clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_