### PR TITLE
build(deps): read the mago version through setup-mago v1.1.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -97,14 +97,8 @@ jobs:
       # mago.toml extends the shared style config installed under vendor/, so install it first.
       - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
 
-      - id: version
-        run: |
-          php -r '$e = json_decode(file_get_contents("composer.json"), true)["extra"];
-                  echo "v=", $e["mago-version"], "\n";' >> "$GITHUB_OUTPUT"
-
-      - uses: chaotic-ground/setup-mago@2b05b7dc0ef2b491d204a80173c5e573b208d032  # v1.0.0
-        with:
-          version: ${{ steps.version.outputs.v }}
+      # No version input: the action reads extra.mago-version out of composer.json itself.
+      - uses: chaotic-ground/setup-mago@d79272ad1380980e87ff0c7da01b7131ccb0083b  # v1.1.0
 
       - run: mago format --check
       - run: mago lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -97,7 +97,6 @@ jobs:
       # mago.toml extends the shared style config installed under vendor/, so install it first.
       - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
 
-      # No version input: the action reads extra.mago-version out of composer.json itself.
       - uses: chaotic-ground/setup-mago@d79272ad1380980e87ff0c7da01b7131ccb0083b  # v1.1.0
 
       - run: mago format --check


### PR DESCRIPTION
Picks up [setup-mago v1.1.0](https://github.com/chaotic-ground/setup-mago/releases/tag/v1.1.0), whose headline feature is reading `extra.mago-version` out of `composer.json` itself. That is exactly what the `php -r` step here was doing, so the step goes and the `uses:` needs no `with:` at all:

```yaml
- uses: chaotic-ground/setup-mago@d79272ad1380980e87ff0c7da01b7131ccb0083b  # v1.1.0
```

The pin stays stated in one place — `composer.json` — and is now read by whatever needs it rather than copied through a workflow output.

## What else v1.1.0 brings, and why it is not used here

- **`extra.mago-sha256`, optionally keyed per target triple.** Not adopted: a stated checksum is only honoured for the version stated next to it, which protects a workflow that pins a *different* version — it does not help a Renovate bump, where the version and the stale checksum move together and the job goes red. That is the case #319 removed the checksum over.
- **`token`.** Only authenticates the `git ls-remote --tags` call, which runs only when a range has to be resolved. `1.29.0` is concrete, so nothing here reaches the network to resolve it.
- **`working-directory`.** Defaults to the workspace, which is where wikven's `composer.json` is.
- **Windows support and the arm64-Windows rejection.** Linux-only job.

`chaotic-ground/mago-mediawiki-style`'s parity workflow also pins v1.0.0; it passes `version: latest` deliberately and gains nothing from detection, so Dependabot's `github-actions` bump is enough there.

## Verified

- Ran v1.1.0's `bin/version.sh` against this repo's real `composer.json`: `detect` → `1.29.0`, `resolve 1.29.0` → `1.29.0` with no network call, `checksum` → empty.
- `yamllint --strict` and `zizmor --offline` clean.

Stacked on #319, which removes `mago-sha256`; base retargets to `main` when that merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_