### PR TITLE
fix: drain translation jobs by hand again, reverting #311

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -223,9 +223,7 @@ class BuildTranslations extends Maintenance {
 
 	/** Run every queued job synchronously (the export has no background runner). */
 	private function drainJobs(): void {
-		$services = $this->getServiceContainer();
-		$group = $services->getJobQueueGroup();
-		$runner = $services->getJobRunner();
+		$group = $this->getServiceContainer()->getJobQueueGroup();
 		// pop() with no type shuffles the queue types to avoid starvation, and these jobs create the
 		// translated pages, so a shuffled order hands them different page and revision ids on every
 		// bake. Drain one type at a time, in name order, until nothing is left anywhere.
@@ -237,8 +235,12 @@ class BuildTranslations extends Maintenance {
 			}
 			sort($types);
 			foreach ($types as $type) {
-				// Runs every job of this type, popping and acking, until the queue is empty.
-				$runner->run(['type' => $type]);
+				$job = $group->pop($type);
+				while ($job) {
+					$job->run();
+					$group->ack($job);
+					$job = $group->pop($type);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Reverts #311. `deploy-docs` and every PR preview have been hanging since it landed; the run for c4a6b22f spun for 45 minutes before I cancelled it, and main cannot deploy right now.

## What breaks

Only bakes that set `SOURCE_DATE_EPOCH`. That is the one functional difference between `./action` (which passes it, and hangs) and the plain `docker run` in `smoke.yml` (which does not, and passes). Same image, same source, same commit:

| invocation | `SOURCE_DATE_EPOCH` | result |
| --- | --- | --- |
| `docker run` (smoke) | unset | completes, 17 pages translated |
| `./action` (preview, deploy-docs) | set | hangs at 100% CPU, 0 pages translated |

It stops right after `Saving... index done` and before the first `Wikven: translated` line, which is `drainJobs()` at the top of `execute()`.

## Why

`JobRunner` leaves a job claimed rather than acked, and the row stays behind:

```
$ showJobs --group
sifterSearchBuildIndex: 1 queued; 0 claimed (0 active, 0 abandoned); 0 delayed
RenderTranslationPageJob: 0 queued; 12 claimed (12 active, 0 abandoned); 0 delayed
```

`JobQueueDB::doGetSiblingQueuesWithJobs()` counts claimed rows deliberately ("this does not check whether the jobs are claimed"), so `getQueuesWithJobs()` keeps naming the type while the runner has nothing left to pop. The loop's only exit is that list going empty, so it spins with no output.

The claim is never released either, and that is the part `SOURCE_DATE_EPOCH` decides. It is stamped with `$dbw->timestamp()`, which honours the frozen clock, while `recycleAndDeleteStaleJobs()` takes its stale cutoff from `time()`. The two clocks never meet, so the claim never ages out.

The manual pop/run/ack loop acks each job itself, which deletes the row, so the queue genuinely empties.

## Verification

Built the image from `c4a6b22f`, baked `docs/` with `SOURCE_DATE_EPOCH` set:

- before: no completion, killed at 5+ minutes, `Wikven: translated` never printed
- after: completes in 151s and 172s over two runs, 17 pages translated
- two bakes of identical input are byte-identical, so #282's guarantee holds
- smoke assertions pass: `index.html`, `webfonts.css`, `:lang(km)`, the Khmer `.woff2`, and every `url()` resolving

## What we give up

Close to nothing, in this build's context.

#311 moved to `JobRunner` for three things the manual loop does not do: run each job's `DeferredUpdates` before popping the next one, respect the configured job backoff list, and abort early on read-only mode or replica lag.

The last two are inert here: a one-shot build against a local SQLite wiki has no throttled job types, no replicas and no read-only mode.

`DeferredUpdates` turns out to be inert too. `maintenance/Maintenance.php` defines `MW_ENTRY_POINT` as `cli`, and `DeferredUpdates::addUpdate()` calls `tryOpportunisticExecute()` as soon as an update is queued. `DeferredUpdatesScopeMediaWikiStack::allowOpportunisticUpdates()` returns true for exactly that case:

```php
if ( MW_ENTRY_POINT !== 'cli' ) {
    return false;
}
if ( $this->areDatabaseTransactionsActive() ) {
    return false;
}
return true;
```

So under a maintenance script a deferred update runs the moment it is added, inside `$job->run()`, long before the ack. The only ones that wait are those queued while a transaction round is open, and they run at the next commit boundary instead. Later, not lost.

The output agrees: the reverted bake produces the same 17 translated pages, 17 language bars and 17 `ko.html` files as a real-clock build, and passes every smoke assertion. This is also simply the arrangement that shipped before #311, under which `deploy-docs` succeeded every time.

## Re-landing #311

The exit condition is the thing to fix first. That loop ends when the queue has no *rows*, not when it has no *poppable jobs*, so any runner used there has to leave the `job` table empty. Worth confirming why `JobRunner` left 12 rows claimed before trying again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
