### PR TITLE
fix: drop the .git the bundled extension clones leave in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ARG ULS_VERSION=REL1_46
 # including a require-dev one that --no-dev then never installs. Translate's dev requirements pin
 # a phpcs release that has one, which broke every build reaching this layer without a warm cache.
 # The audit still reports on what is installed; only the hard stop is off.
+# The clones' .git go in the same layer that made them, or the image carries them anyway.
 RUN composer config --global policy.advisories.block false \
  && git clone --depth 1 --branch "$ULS_VERSION" \
       https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector.git \
@@ -41,7 +42,9 @@ RUN composer config --global policy.advisories.block false \
       https://github.com/wikimedia/mediawiki-extensions-Translate.git \
       /var/www/html/extensions/Translate \
  && composer install --no-dev --no-interaction \
-      --working-dir=/var/www/html/extensions/Translate
+      --working-dir=/var/www/html/extensions/Translate \
+ && rm -rf /var/www/html/extensions/UniversalLanguageSelector/.git \
+      /var/www/html/extensions/Translate/.git
 
 COPY ./ /var/www/html/extensions/Wikven
 COPY includes/WikvenSettings.php /var/www/html/


### PR DESCRIPTION
Closes #328.

`--depth 1` keeps the history out of the clone but not the repository itself. Both bundled extensions ship their `.git` directory in the image, and nothing ever runs git against either tree: they are pinned by `$ULS_VERSION` and `$TRANSLATE_VERSION` and rebuilt when those change.

Removing them in the `RUN` that created them keeps them out of that layer as well, rather than adding a later layer that only masks them.

## Measured

Built both ways from this branch's parent and read the tree out of each image:

| | `/var/www/html/extensions` |
| --- | --- |
| before | 318,082,035 bytes |
| after | 301,461,963 bytes |

16.6MB, matching the 13MB + 3.4MB the issue predicted. `docker images` reports 1.8GB against 1.77GB.

## Scale

Small on purpose. The image is about 1.8GB and roughly 1.5GB of that is the `mediawiki` base, so this is under 1%. #329 is the change that actually moves the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
