### PR TITLE
fix: fetch the bundled extensions as tarballs, not clones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,18 +33,21 @@ ARG ULS_VERSION=REL1_46
 # including a require-dev one that --no-dev then never installs. Translate's dev requirements pin
 # a phpcs release that has one, which broke every build reaching this layer without a warm cache.
 # The audit still reports on what is installed; only the hard stop is off.
-# The clones' .git go in the same layer that made them, or the image carries them anyway.
+# Fetched as tarballs: a clone carries a .git nothing here reads, and transfers several times the
+# bytes for it. Downloaded before extracting rather than piped, so a failed fetch fails the build
+# instead of feeding tar an empty stream.
 RUN composer config --global policy.advisories.block false \
- && git clone --depth 1 --branch "$ULS_VERSION" \
-      https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector.git \
-      /var/www/html/extensions/UniversalLanguageSelector \
- && git clone --depth 1 --branch "$TRANSLATE_VERSION" \
-      https://github.com/wikimedia/mediawiki-extensions-Translate.git \
-      /var/www/html/extensions/Translate \
+ && ext=/var/www/html/extensions \
+ && curl -fsSL -o /tmp/uls.tar.gz \
+      "https://codeload.github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector/tar.gz/refs/heads/$ULS_VERSION" \
+ && curl -fsSL -o /tmp/translate.tar.gz \
+      "https://codeload.github.com/wikimedia/mediawiki-extensions-Translate/tar.gz/refs/heads/$TRANSLATE_VERSION" \
+ && mkdir -p "$ext/UniversalLanguageSelector" "$ext/Translate" \
+ && tar -xzf /tmp/uls.tar.gz --strip-components=1 -C "$ext/UniversalLanguageSelector" \
+ && tar -xzf /tmp/translate.tar.gz --strip-components=1 -C "$ext/Translate" \
+ && rm /tmp/uls.tar.gz /tmp/translate.tar.gz \
  && composer install --no-dev --no-interaction \
-      --working-dir=/var/www/html/extensions/Translate \
- && rm -rf /var/www/html/extensions/UniversalLanguageSelector/.git \
-      /var/www/html/extensions/Translate/.git
+      --working-dir="$ext/Translate"
 
 COPY ./ /var/www/html/extensions/Wikven
 COPY includes/WikvenSettings.php /var/www/html/


### PR DESCRIPTION
Follow-up to #330, now that it is merged. That removed the `.git` the clones left behind; this removes the clones, so there is nothing to remove.

To be clear about what is and is not left to gain: #330 already took the 16MB out of the image, and this does not take out any more. `/var/www/html/extensions` measures 301,462,175 bytes here against 301,461,963 on main, a few hundred bytes of tar metadata. What is left is the transfer.

| | cloned | as a tarball |
| --- | --- | --- |
| UniversalLanguageSelector | 32MB | 12.7MB |
| Translate | 20MB | 2.6MB |

A shallow clone still has to pack objects rather than send a tree, so it moves several times the bytes even though `--depth 1` keeps the history out. Every cold build paid that, and the `rm -rf` afterwards only hid the result.

codeload takes a branch name directly, so `$ULS_VERSION` and `$TRANSLATE_VERSION` are used unchanged and nothing about pinning changes. This is also the shape the SifterSearch layer directly above already uses, so the two fetches now match.

## Downloaded, not piped

The tarballs go to a file before being extracted. In a `sh` pipeline the exit status is `tar`'s, so a failed `curl` would hand `tar` an empty stream and the build could pass with an extension missing. `pipefail` would fix that too, but it needs `SHELL` set to bash, which would not survive a later move to an alpine base (#329).

## Verified on the built image

- no `.git` anywhere under `extensions/`
- `Translate/vendor/` still has `autoload.php`, `composer/` and `mustangostang/`, so `load_composer_autoloader` still resolves
- both extension trees present and populated

## Left alone

The `policy.advisories.block false` workaround above stays. Dropping it needs Translate's `require-dev` to stop being resolved at all, which is a separate change with its own verification, not a side effect of how the code is fetched.

## On Wikimedia

This keeps the fetch on GitHub rather than moving to Wikimedia's extension distributor. That would hand us a tarball with Composer dependencies already installed, but Translate's runtime `require` is only `composer/installers` and `mustangostang/spyc`, so the prize is two small packages and the cost is Wikimedia Cloud serving every image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
