### PR TITLE
feat: base the image on mediawiki:1.46-fpm-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 # Base images are digest-pinned for reproducible builds; Dependabot keeps them current.
 FROM composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer
 
-FROM mediawiki:1.46@sha256:38989f476fd3226bd608816547e2f8eee88c1582d656e9b39c65a2e5ddbdacc6
+# The alpine variant, because nothing here serves over HTTP: `build` runs a maintenance script and
+# `serve` runs PHP's own server, so the Apache the default variant carries is never started. Same
+# PHP extensions, 873MB against 1.5GB.
+FROM mediawiki:1.46-fpm-alpine@sha256:b0e9413c015268322cfb67908e5f92121372c7407f09f97a4ce8938a4351e4ad
 
-# composer + unzip to install third-party extensions/skins at build time (git/tar/gzip present).
+# composer to install third-party extensions/skins at bake time (git/tar/gzip/unzip present).
+# rsvg-convert renders SVG thumbnails, and alpine splits ImageMagick's delegates out, so its
+# convert reads only the PNG family until these are added. Together they cover every type
+# FileExtensions allows: png and gif are built in, svg goes through rsvg, and these two are the
+# rest. The formats still absent (TIFF, PDF, HEIC, camera RAW) are ones uploads reject anyway.
 COPY --from=composer /usr/bin/composer /usr/bin/composer
-RUN apt-get update \
- && apt-get install -y --no-install-recommends unzip \
- && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 
 # Bundled extensions come from stable external sources; fetch them before copying wikven's own
 # code so edits to that code do not bust the (slow) download/clone layers.

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -1,5 +1,7 @@
-#!/bin/bash
-set -euo pipefail; IFS=$'\n\t'
+#!/bin/sh
+# POSIX sh, so it runs under whatever /bin/sh the base provides. pipefail and $'\n\t' are not in
+# POSIX; there are no pipelines here to need the former, and printf spells the latter portably.
+set -eu; IFS=$(printf '\n\t')
 
 # One working dir for source + output (default /workspace); exported so PHP children inherit it.
 export WIKVEN_WORKDIR="${WIKVEN_WORKDIR:-/workspace}"


### PR DESCRIPTION
Closes #329.

Nothing in this image serves over HTTP. `build` runs a maintenance script and `serve` runs PHP's own server, so the Apache the default variant carries is never started. The alpine variant is the same MediaWiki with an identical `php -m`, and it costs a lot less.

| | on disk |
| --- | --- |
| before | 1.77GB |
| after | 1.06GB |

## What alpine does not ship

- `unzip` is already there, so the `apt-get` layer goes away entirely. It existed because the Debian variant is the one missing it.
- `rsvg-convert` is not. `WikvenSettings.php:109` detects it to render SVG thumbnails, so it is installed, about 4MB.
- ImageMagick's delegates are split into separate packages, leaving `convert` able to read only the PNG family. This one is not cosmetic: without `imagemagick-jpeg` the bake produced 14 images instead of 16 and silently dropped both JPEG thumbnails. `imagemagick-webp` goes with it. Between them every type `FileExtensions` allows is covered (png and gif built in, svg via rsvg). The formats still absent are TIFF, PDF, HEIC and camera RAW, which uploads reject anyway, and ghostscript is missing from both variants so PDF thumbnails never worked here.

`bin/entrypoint` asked for bash, which alpine has no reason to carry. It is POSIX sh now: `pipefail` and `$'\n\t'` are not POSIX, there are no pipelines in the script to need the first, and `printf` spells the second. Busybox ash would have taken both, but writing to POSIX means the script does not depend on which `/bin/sh` the base provides.

## Verified

Baked `docs/` with both images under the same `SOURCE_DATE_EPOCH`:

- 17 pages translated, same as before
- `Stored 16 image(s)`, same as before, and 14 before the delegates were added
- both JPEG thumbnails present

## What is not verified, and why

I cannot claim the output is byte-identical to the Debian build, because main does not currently produce byte-identical output against itself. Two bakes from the unchanged image, same input and same epoch, differ in nine pages: the `<languages/>` bar drops links at random.

    run 1   Licenses=1  JavaScript=2  Why_wikitext=1
    run 2   Licenses=3  JavaScript=1  Why_wikitext=2

That is a bug on main, unrelated to this change, and it makes a byte comparison meaningless as an acceptance test. Filed separately. Setting it aside, the differences between the two images are: thumbnail bytes, since the two carry different ImageMagick builds (7.1.1-43 Q16 against 7.1.2-27 Q16-HDRI), and `Version.html`, which reports the OS and PHP versions and is expected to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
