### PR TITLE
fix: turn the parser cache off so a bake reads its own finished state

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -90,10 +90,9 @@ jobs:
                 test -f "dist/$ref" || { echo "::error::webfonts.css references missing $ref"; exit 1; }
               done
 
-          # Every <languages/> bar must list every language the source has, on every copy of the
-          # page. A page with N languages is emitted N+1 times (X.html plus X/<lang>.html) and each
-          # carries N entries, so the target comes from the source tree rather than a fixed number.
-          # This is the shape #333 broke: bars came out short, silently, and differently per bake.
+          # Every <languages/> bar lists every language the source has (#333 baked them short).
+          # A page with N languages is emitted N+1 times and each copy carries N entries, so the
+          # target is derived from the source tree rather than pinned to a number.
           expected=0
           for f in src/*.wikitext; do
             grep -q '<languages */>' "$f" || continue

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -94,12 +94,12 @@ jobs:
           # A page with N languages is emitted N+1 times and each copy carries N entries, so the
           # target is derived from the source tree rather than pinned to a number.
           expected=0
-          for f in src/*.wikitext; do
+          for f in docs/*.wikitext; do
             grep -q '<languages */>' "$f" || continue
             base=$(basename "$f" .wikitext)
             langs=1
-            if [ -d "src/$base" ]; then
-              langs=$(( langs + $(ls "src/$base"/*.wikitext 2>/dev/null | wc -l) ))
+            if [ -d "docs/$base" ]; then
+              langs=$(( langs + $(ls "docs/$base"/*.wikitext 2>/dev/null | wc -l) ))
             fi
             expected=$(( expected + langs * ( langs + 1 ) ))
           done

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -90,6 +90,28 @@ jobs:
                 test -f "dist/$ref" || { echo "::error::webfonts.css references missing $ref"; exit 1; }
               done
 
+          # Every <languages/> bar must list every language the source has, on every copy of the
+          # page. A page with N languages is emitted N+1 times (X.html plus X/<lang>.html) and each
+          # carries N entries, so the target comes from the source tree rather than a fixed number.
+          # This is the shape #333 broke: bars came out short, silently, and differently per bake.
+          expected=0
+          for f in src/*.wikitext; do
+            grep -q '<languages */>' "$f" || continue
+            base=$(basename "$f" .wikitext)
+            langs=1
+            if [ -d "src/$base" ]; then
+              langs=$(( langs + $(ls "src/$base"/*.wikitext 2>/dev/null | wc -l) ))
+            fi
+            expected=$(( expected + langs * ( langs + 1 ) ))
+          done
+          # Once per skin the site renders: the default plus the two docs/.wikven.yml adds.
+          expected=$(( expected * 3 ))
+          found=$(find dist -name '*.html' -exec grep -ho 'mw-pt-progress--' {} + | wc -l)
+          if [ "$found" -ne "$expected" ]; then
+            echo "::error::$found language-bar entries across dist, expected $expected"
+            exit 1
+          fi
+
           echo "Smoke checks passed."
 
       # Node.js is preinstalled on the runner; no setup-node (its caching trips

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -57,6 +57,14 @@ Wikimedia\Timestamp\ConvertibleTimestamp::setFakeTime($wikvenEpoch);
 // attempt; the Retrier hook handler sees to that.
 $wgMainCacheType = CACHE_DB;
 
+// The parser cache, though, has to go. A build keeps changing the wiki under itself: pages are
+// marked for translation, units are written, jobs settle stats. A parse made before that finished
+// stays valid as far as the cache is concerned, so the render pass served one and baked a
+// <languages/> bar short of the languages that landed after it. Which pages that hit moved with
+// the job order, so two bakes of the same source disagreed. Every page here is parsed a fixed
+// number of times and thrown away, so the cache was buying little to begin with.
+$wgParserCacheType = CACHE_NONE;
+
 // Let pages opt out of indexing with __NOINDEX__ in any namespace.
 $wgExemptFromUserRobotsControl = [];
 

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -57,17 +57,9 @@ Wikimedia\Timestamp\ConvertibleTimestamp::setFakeTime($wikvenEpoch);
 // attempt; the Retrier hook handler sees to that.
 $wgMainCacheType = CACHE_DB;
 
-// The parser cache, though, cannot be left on, because the frozen clock below disables the only
-// thing that would invalidate it. CacheTime::expired() asks whether getCacheTime() < page_touched,
-// strictly, and setFakeTime gives a parse and the edit that follows it the same timestamp. So a
-// parse taken while the build is still changing the wiki, which it does all through
-// buildTranslations, never looks stale. freezePageTouched() then writes page_touched back to a
-// constant in the past, so the skin passes cannot expire anything either. The symptom was a
-// <languages/> bar baked short of the languages that landed after the parse it was served from.
-//
-// This costs the passes the cache was paying for: every page is parsed once per skin now, plus
-// once more per translated page for RetranslateChrome, rather than once per bake. On the wikis
-// this builds that is inside the noise; on one with heavy templates it would not be.
+// The frozen clock makes this one impossible to invalidate: CacheTime::expired() tests
+// getCacheTime() < page_touched strictly and setFakeTime gives both the same value, so a parse
+// taken mid-build never looks stale (#333). Costs a parse per skin instead of one per bake.
 $wgParserCacheType = CACHE_NONE;
 
 // Let pages opt out of indexing with __NOINDEX__ in any namespace.

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -57,12 +57,17 @@ Wikimedia\Timestamp\ConvertibleTimestamp::setFakeTime($wikvenEpoch);
 // attempt; the Retrier hook handler sees to that.
 $wgMainCacheType = CACHE_DB;
 
-// The parser cache, though, has to go. A build keeps changing the wiki under itself: pages are
-// marked for translation, units are written, jobs settle stats. A parse made before that finished
-// stays valid as far as the cache is concerned, so the render pass served one and baked a
-// <languages/> bar short of the languages that landed after it. Which pages that hit moved with
-// the job order, so two bakes of the same source disagreed. Every page here is parsed a fixed
-// number of times and thrown away, so the cache was buying little to begin with.
+// The parser cache, though, cannot be left on, because the frozen clock below disables the only
+// thing that would invalidate it. CacheTime::expired() asks whether getCacheTime() < page_touched,
+// strictly, and setFakeTime gives a parse and the edit that follows it the same timestamp. So a
+// parse taken while the build is still changing the wiki, which it does all through
+// buildTranslations, never looks stale. freezePageTouched() then writes page_touched back to a
+// constant in the past, so the skin passes cannot expire anything either. The symptom was a
+// <languages/> bar baked short of the languages that landed after the parse it was served from.
+//
+// This costs the passes the cache was paying for: every page is parsed once per skin now, plus
+// once more per translated page for RetranslateChrome, rather than once per bake. On the wikis
+// this builds that is inside the noise; on one with heavy templates it would not be.
 $wgParserCacheType = CACHE_NONE;
 
 // Let pages opt out of indexing with __NOINDEX__ in any namespace.


### PR DESCRIPTION
Closes #333.

## The measurement

Three bakes of `docs/`, same image, same `SOURCE_DATE_EPOCH`, counting `mw-pt-progress` on each English page:

The target comes from the source tree, not from a run: a page with N languages is emitted N+1 times (`X.html` plus `X/<lang>.html`) and each copy carries N entries, so `docs/` should hold 108 per skin and 324 across the three.

| bake | language-bar entries | |
| --- | --- | --- |
| before, 1 | 321 | 3 short |
| before, 2 | 318 | 6 short |
| before, 3 | 318 | 6 short |
| after | **324** | complete |

Three consecutive bakes after the change are byte-identical and hit the derived number exactly, so this is the complete set and not a stable subset. Note that the failing bakes only reproduce with `SOURCE_DATE_EPOCH` set, which is the path `./action` uses; a bake without it has an inert parser cache already.

## It was not the stats

Worth recording, because it is the obvious suspect. In a run whose `JavaScript/en.html` has no Korean link, `translate_groupstats` says:

```
('page-JavaScript', 'ko', 9, 9, 0)
('page-Why wikitext', 'ko', 8, 8, 0)
```

9 of 9 translated, none fuzzy. The numbers `<languages/>` reads were right; the HTML around them was old. `JavaScript/ko.html` is present in that same output too, so nothing failed to materialize either, which is what separates this from #241.

## What it was

The frozen clock disables the only thing that would invalidate a parse. `CacheTime::expired()` asks whether `getCacheTime() < $touched`, strictly, and `ConvertibleTimestamp::setFakeTime($wikvenEpoch)` gives a parse and the edit that follows it the same timestamp. So a parse taken while the build is still changing the wiki, which it does all through `buildTranslations`, never looks stale. `freezePageTouched()` then writes `page_touched` back to a constant in the past, so the skin passes cannot expire anything either.

What still varies from run to run is not identified. Job order is not it: `wgJobTypeConf['default']['order'] = 'fifo'` has been set since 6aa694ed and both drains walk sorted types one at a time. The staleness above is structural and would on its own give a stably wrong bar, so something else decides which parse gets reused. That is worth knowing but does not change the fix, since the cache cannot be trusted either way.

`$wgParserCacheType = CACHE_NONE` is the change. `$wgMainCacheType` stays on `CACHE_DB`, which is what the comment above it is for: it keeps the Commons thumbnail lookups from being repeated per parse, and that is unaffected.

It is not free. The cache was paying for passes 2..N, so every page is now parsed once per skin rather than once per bake, plus once more per translated page for RetranslateChrome. On `docs/` that lands inside the noise, about 2 minutes either way; on a wiki with heavy templates or Scribunto it would not.

## Regression guard

There was none, which is why this shipped. `smoke.yml` asserted `test -s dist/index.html` and the webfont set, and the only language-bar test clicks one link on one page, which survived a deploy that dropped links elsewhere. This adds the derived-count assertion above to `smoke.yml`. Checked both ways: it passes on the fixed bake at 324 and fails on all three bakes from #333.

## Things that did not work

Two other shapes were tried and measured before this one, in case they come up in review:

- Moving `MessageGroupStats::forGroup` out of the per-page render loop and taking it after a final drain. This made the output deterministic and deterministically wrong: `JavaScript=1` and `Why_wikitext=1` on every run, so it froze the bug rather than fixing it.
- Purging each translatable page with `doPurge()` after the render loop. Still flapped, two runs at 1 and one at 2.

Neither touches the parse that was actually being reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
