### PR TITLE
docs: give the note template a teal icon

### DIFF
--- a/docs/File:Note icon.svg.wikitext
+++ b/docs/File:Note icon.svg.wikitext
@@ -1,0 +1,3 @@
+The icon shown beside a note, in the wikven teal.
+
+Drawn for wikven, and under its licence: [https://github.com/chaotic-ground/wikven/blob/main/LICENSE GPL-3.0-or-later].

--- a/docs/Note icon.svg
+++ b/docs/Note icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+	<title>Note</title>
+	<circle cx="16" cy="16" r="15" fill="#157f93"/>
+	<path d="M16 8 L16 18" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
+	<circle cx="16" cy="24" r="2" fill="#fff"/>
+</svg>

--- a/docs/Template:note.wikitext
+++ b/docs/Template:note.wikitext
@@ -1,4 +1,4 @@
 <onlyinclude><templatestyles src="note/styles.css" /><div class="wikven-note"><!--
-  --><div>[[File:Xclamation SVG.svg|32px]]</div><!--
+  --><div>[[File:Note icon.svg|32px]]</div><!--
   --><div class="wikven-note-text"><p>{{{1|Text here.}}}</p></div>
 </div></onlyinclude>


### PR DESCRIPTION
`Template:note` embedded `[[File:Xclamation SVG.svg|32px]]`, pulled from Wikimedia Commons through InstantCommons. Its blue is Wikimedia's, not ours.

## Route taken

The icon arrives as an `&lt;img&gt;` pointing at a file we do not own, and the embedding page's CSS cannot reach inside an external SVG to recolour it. That rules out a CSS fix and leaves two options: ship a local SVG, or drop the image and draw the icon in markup.

I shipped a local SVG (`docs/Note icon.svg`), because it is what the docs already do for `Bakery oven.jpg` and what `docs/Images.wikitext` tells readers to do — source-directory image files are uploaded into the `File:` namespace at bake time, so the template change is a one-word swap. The markup route would have meant a data-URI background, and `TemplateStyles` sanitizes `url()` against an allowlist that does not include `data:`, so it would have had to live in `MediaWiki:Common.css` — the site theme file — which is the wrong home for one template's icon.

The new file is an exclamation mark in a circle in `#157f93`, hand-drawn in the same plain-path style as `docs/logo.svg`, which hardcodes the same teal.

As a side effect the note icon no longer needs the network at bake time. `{{note}}` appears on four pages plus their Korean translations, so that is four fewer InstantCommons round-trips per bake.

## Licence

**I drew the icon fresh rather than deriving from the Commons file, because I could not verify that file's licence.** Egress to `commons.wikimedia.org` is blocked in the environment I worked in, so I could not read the file description page, and I am not willing to assert a licence I have not checked. An exclamation mark in a circle carries no interesting authorship, so drawing one costs nothing and settles the question.

`docs/File:Note icon.svg.wikitext` states it as what it is: drawn for wikven, under the project's own GPL-3.0-or-later, following the shape of `docs/File:Bakery oven.jpg.wikitext`. Nothing was copied, so there is no upstream attribution to reproduce. `docs/Licenses.wikitext` is untouched — it covers redistributed third-party software, and this is neither.

## Other uses of the old icon

Only `Template:note` embedded it. `tests/phpunit/integration/RetryingForeignRepoTest.php` mentions the name in two assertions, but as an arbitrary fixture for a mocked foreign-repo response, not as a reference to anything in `docs/`. A foreign-repo test wants a foreign file name, so I left it.

## Verification

I could not bake locally — the registry CDN refused the `mediawiki:1.46-fpm-alpine` layers, and Commons is blocked too, so a local bake would have failed at `docs/Images.wikitext` regardless of this change. So I checked the icon locally and then read the real thing out of CI's own output.

Locally: `biome ci` and `typos` clean (biome's one warning, `noImportantStyles` in `MediaWiki:Citizen.css`, is pre-existing and untouched); `rumdl` not applicable, no markdown changed; and I rasterized the SVG and looked at it.

From CI: the smoke bake and the preview deploy both passed, and the preview commit on `gh-pages` shows the whole path worked.

- `File:Note_icon.svg.html` is in the export, so the upload landed under the expected title and its description page was exported.
- `storeImages` names each stored file `img-<md5(path)[:12]>`, which makes the output self-describing. `md5("/Note_icon.svg")` gives `742c602f48fa`, and `pr-preview/pr-341/img-742c602f48fa.svg` is there at 263 bytes — byte-identical to `docs/Note icon.svg` (both are git blob `438a319`).
- `md5("/thumb/Note_icon.svg/32px-Note_icon.svg.png")` gives `62fcb86c2d5a` and `md5(".../64px-...")` gives `40a5b8c47c42`; both PNGs are in the export at 857 and 1686 bytes. rsvg rendered the thumbnails, and `storeImages` only writes a file for a reference it actually found in the HTML — 32px and its 2x srcset are exactly what `[[File:Note icon.svg|32px]]` in `Template:note` asks for, and nothing else on the site requests that size.

What I still have not done is put human eyes on the note box in a browser: the preview at `pr-preview/pr-341/` is blocked from where I am, so I confirmed the icon by its bytes and its thumbnails rather than by looking at the page. Worth a glance before this leaves draft.
