### PR TITLE
build: pin version-bearing tags alongside the image digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,19 @@ updates:
       docker:
         patterns:
           - "*"
+    # Full version tags dropped the stream guard the floating tags carried, so restore it here.
+    # MediaWiki holds its minor too: moving to 1.47 has to be deliberate.
+    ignore:
+      - dependency-name: composer
+        update-types:
+          - version-update:semver-major
+      - dependency-name: dunglas/frankenphp
+        update-types:
+          - version-update:semver-major
+      - dependency-name: mediawiki
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
   - package-ecosystem: uv
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,22 +42,19 @@ updates:
     cooldown:
       default-days: 7
     groups:
+      # A dependency joins the first group it matches, so MediaWiki always gets its own pull
+      # request: a release-branch move needs REL* CI and extension bumps alongside it, and must
+      # not hold the routine patches hostage.
+      mediawiki:
+        patterns:
+          - mediawiki
       docker:
         patterns:
           - "*"
-    # Full version tags dropped the stream guard the floating tags carried, so restore it here.
-    # MediaWiki holds its minor too: moving to 1.47 has to be deliberate.
-    ignore:
-      - dependency-name: composer
+        # Majors land as their own pull requests instead of riding along in the group.
         update-types:
-          - version-update:semver-major
-      - dependency-name: dunglas/frankenphp
-        update-types:
-          - version-update:semver-major
-      - dependency-name: mediawiki
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
+          - minor
+          - patch
   - package-ecosystem: uv
     directory: /
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-# Base images are digest-pinned for reproducible builds; Dependabot keeps them current.
-FROM composer:2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer
+# Base images are digest-pinned for reproducible builds and version-tagged so Dependabot's bumps
+# read as version numbers rather than digests. Dependabot keeps them current.
+FROM composer:2.10.2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer
 
 # The alpine variant, because nothing here serves over HTTP: `build` runs a maintenance script and
 # `serve` runs PHP's own server, so the Apache the default variant carries is never started. Same
 # PHP extensions, 873MB against 1.5GB.
-FROM mediawiki:1.46-fpm-alpine@sha256:b0e9413c015268322cfb67908e5f92121372c7407f09f97a4ce8938a4351e4ad
+FROM mediawiki:1.46.0-fpm-alpine@sha256:b0e9413c015268322cfb67908e5f92121372c7407f09f97a4ce8938a4351e4ad
 
 # composer to install third-party extensions/skins at bake time (git/tar/gzip/unzip present).
 # rsvg-convert renders SVG thumbnails, and alpine splits ImageMagick's delegates out, so its

--- a/binary.Dockerfile
+++ b/binary.Dockerfile
@@ -23,8 +23,8 @@ RUN find /var/www/html -type d -name tests -prune -exec rm -rf {} + \
 # Stage 2: compile a static PHP + FrankenPHP and embed the app. curl is omitted:
 # its HTTP/3 (ngtcp2/nghttp3) static libs fail to link, and it is unneeded
 # (MediaWiki/Guzzle uses PHP stream wrappers over openssl).
-# Digest-pinned for reproducible builds; Dependabot keeps it current.
-FROM dunglas/frankenphp:static-builder-musl@sha256:f839cbec0d140c3be234dde7a9fcbd9d9dbca6882d8fb288d8d3e84c88822cd2 AS builder
+# Digest-pinned for reproducible builds, version-tagged so Dependabot's bumps read as versions.
+FROM dunglas/frankenphp:static-builder-musl-1.12.4@sha256:f839cbec0d140c3be234dde7a9fcbd9d9dbca6882d8fb288d8d3e84c88822cd2 AS builder
 WORKDIR /go/src/app
 COPY --from=app /var/www/html ./dist/app
 # A small Caddy module registers the `build` subcommand, so the binary can be run


### PR DESCRIPTION
All three base images were pinned on tags that carry no version (`composer:2`, `mediawiki:1.46-fpm-alpine`, `dunglas/frankenphp:static-builder-musl`). Dependabot's idea of the "version" is then the digest string, so a Docker PR is a digest-to-digest diff that says nothing: #337 reads `bump dunglas/frankenphp from f839cbe to 3cb1170` when it is really FrankenPHP 1.12.4 to 1.12.7.

Dependabot's docker tag parser does understand prefix+version tags (`VERSION_WITH_PFX` in `dependabot-core`'s `docker/lib/dependabot/docker/tag.rb`), so `static-builder-musl-1.12.4` parses as prefix `static-builder-musl-` plus version `1.12.4`. This PR writes the version-bearing tag next to the digest that was already pinned.

## What changed

| image | old pin | new pin | actual version of that digest |
| --- | --- | --- | --- |
| composer | `composer:2@sha256:4d71c3c2` | `composer:2.10.2@sha256:4d71c3c2` | 2.10.2 |
| mediawiki | `mediawiki:1.46-fpm-alpine@sha256:b0e9413c` | `mediawiki:1.46.0-fpm-alpine@sha256:b0e9413c` | 1.46.0 |
| dunglas/frankenphp | `...:static-builder-musl@sha256:f839cbec` | `...:static-builder-musl-1.12.4@sha256:f839cbec` | v1.12.4 |

**No digest changed.** Every `FROM` still resolves to the exact same image bytes it did before, and the tag is only a label: Docker resolves `name:tag@digest` by digest.

Verification, with `skopeo` against Docker Hub:

- `composer:2.10.2` → `sha256:4d71c3c2…`, identical to the pinned digest and to what `composer:2` resolves to today. Its config carries `COMPOSER_VERSION=2.10.2`.
- `mediawiki:1.46.0-fpm-alpine` → `sha256:b0e9413c…`, identical to the pinned digest and to what `mediawiki:1.46-fpm-alpine` resolves to today. Its config carries `MEDIAWIKI_VERSION=1.46.0`.
- `dunglas/frankenphp@sha256:f839cbec…` carries the label `org.opencontainers.image.version=v1.12.4`, so the tag written here names the right version. One honest caveat: upstream rebuilt the `static-builder-musl-1.12.4` tag on 2026-07-19, so that tag now points at `sha256:4b4f493a…` (also labelled v1.12.4). This PR deliberately keeps the digest we already had rather than following the moved tag, so nothing pulled changes here either.

## dependabot.yml grouping

`composer:2` and `mediawiki:1.46-fpm-alpine` encoded "stay on this stream" in the tag itself, and full version tags drop that guard. The answer is not to re-add the ceiling as `ignore` rules: a Composer 3 or MediaWiki 1.47 release is exactly the thing worth hearing about, and an ignored update is silently invisible. Dependabot should propose it and let a human decide.

What the tags did carry, and what is worth keeping, is blast radius. So the docker entry groups by risk instead:

- `mediawiki` gets its own group. A dependency joins the first group it matches, so a release-branch move always arrives as its own pull request, with the `REL*` CI matrix and extension bumps it needs, and never holds routine patches hostage.
- the catch-all `docker` group takes `update-types: [minor, patch]`, so majors (Composer 3, FrankenPHP 2) leave the group and arrive as individual pull requests too.

Everything still flows; nothing is suppressed. The difference is that a risky bump can no longer ride along inside an otherwise routine grouped PR.

## About #337

Untouched by this PR. Once this merges, #337 will conflict; the fix is to comment `@dependabot recreate` on it. The recreated PR will read as a version bump rather than a digest swap. Note that upstream has not published a `static-builder-musl-1.12.7` tag yet (the highest versioned tag today is `-1.12.6`, while the floating `static-builder-musl` tag currently carries a v1.12.7 build), so the recreated PR will most likely target 1.12.6.

## Lint

`yamllint --strict .` with the repo's pinned 1.38.0 passes. No Dockerfile linter is configured in CI, and no local Docker build was run; CI builds the images.
