### PR TITLE
docs: stop translating the WikvenRepositories code block

### DIFF
--- a/docs/Configuration.wikitext
+++ b/docs/Configuration.wikitext
@@ -92,28 +92,25 @@ Sources for the third-party extensions and skins you list in <code>extensions</c
 Each entry chooses one of three methods by the key it carries:
 </translate>
 
-<translate nowrap>
-<!--T:34-->
 <syntaxhighlight lang="yaml">
-<tvar name="1">config:
-  WikvenRepositories:</tvar>
+config:
+  WikvenRepositories:
     # 1. A tarball, e.g. from Special:ExtensionDistributor, whose archive already
     #    bundles the extension's dependencies. Add sha256 to verify the download.
-    <tvar name="2">Foo:
+    Foo:
       tarball: https://extdist.wmflabs.org/dist/extensions/Foo-REL1_46-abc1234.tar.gz
-      sha256: 4f5e...</tvar>  # 64 hex characters; the build aborts on a mismatch
+      sha256: 4f5e...  # 64 hex characters; the build aborts on a mismatch
     # 2. A Git repository. Pin it with commit (an exact SHA, reproducible) or
     #    reference (a tag or branch). Add composer: true to run Composer inside
     #    the cloned directory.
-    <tvar name="3">Bar:
+    Bar:
       repository: https://github.com/example/Bar.git
       commit: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
-      composer: true</tvar>
+      composer: true
     # 3. A Composer package, resolved through MediaWiki's composer.local.json.
-    <tvar name="4">SemanticMediaWiki:
-      package: mediawiki/semantic-media-wiki:~4.1</tvar>
+    SemanticMediaWiki:
+      package: mediawiki/semantic-media-wiki:~4.1
 </syntaxhighlight>
-</translate>
 
 <translate>
 <!--T:23-->


### PR DESCRIPTION
One file. The `WikvenRepositories` YAML example on `Configuration` was the only code block in the docs living inside a translate section — a `translate nowrap` block holding a single unit, `T:34`, with the YAML wrapped in four `tvar`s so just the `#` comments were translatable. Every other code block in `docs/` sits outside translation. A code block is not prose.

It now reads like all the others: no wrapper, no `tvar`s, the split `sha256` line rejoined.

## The Korean lands in a follow-up

Deliberately not in this PR. Until that follow-up, `docs/Configuration/ko.wikitext` is left as it is on `main`, which has two visible consequences on the Korean page:

- **`T:22` goes fuzzy.** A unit's hash runs to the *next* marker, so the freed code block is now folded into the span of the paragraph before it. The Korean prose is unchanged and still correct, but the stamp no longer matches, so `buildTranslations` writes it with a `!!FUZZY!!` prefix. Translate strips that marker at render and instead wraps the paragraph in `mw-translate-fuzzy`, plus adds its "Outdated translations are marked like this." header. So: one paragraph highlighted, one banner. The Korean text still shows — `$wgTranslateKeepOutdatedTranslations` defaults to true and wikven does not override it.
- **`T:34` is orphaned.** `loadTranslations` iterates the *source* units, so a translation unit with no source unit is simply never written — no error, no output. Its content was the translated YAML comments, and those are exactly what this PR retires, so fuzzy/absent is the honest signal rather than something to paper over with a restamp.

Nothing renumbers: `T:34` was the highest id, every other marker is explicit, and `StalenessComputer::mark()` is a no-op on the result.

## CI

Green. `build-and-check` passes: the image builds, `docs/` bakes, and the smoke assertions hold — **including the language-bar count**, which is the one that could plausibly have moved. It does not: `tpProgressIcon()` emits exactly one `mw-pt-progress--<bucket>` class per language entry whatever the completion, so `--complete` simply becomes `--high` and the count is unchanged. No workflow gates on translation staleness (`action-check` is shipped for wikven's users, not run on this repo). The full Playwright suite passes too.

Locally, driving `StalenessComputer::analyze()` standalone over `docs/` reports exactly the expected two new items — `Configuration/ko` `T:22` stale and `T:34` orphan — on top of the two units already stale on `main` (`Deploying` `T:3`, `Translating` `T:4`). `yamllint --strict .` clean.
