### PR TITLE
fix: hide the empty tools box each skin draws around the toolbox

### DIFF
--- a/includes/Hooks/Hider.php
+++ b/includes/Hooks/Hider.php
@@ -21,7 +21,7 @@ class Hider implements
 		if (!Search::isActive()) {
 			$keys[] = 'SEARCH';
 		}
-		// Empty rather than unset: some skins (e.g. Minerva) require these keys to stay arrays.
+		// Empty rather than unset: Minerva passes $sidebar['TOOLBOX'] to an array parameter; null is fatal.
 		foreach ($keys as $key) {
 			if (isset($sidebar[$key])) {
 				$sidebar[$key] = [];

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -26,6 +26,21 @@
   display: none;
 }
 
+// Core hides the emptied toolbox portlet itself; these are the boxes Timeless
+// and Citizen keep drawing around it, headings and all.
+#site-tools,
+#citizen-page-more-dropdown {
+  display: none;
+}
+
+// Vector's box also carries the page tabs, but only below the width at which it
+// hides the tab row.
+@media ( min-width: @min-width-breakpoint-tablet ) {
+  .vector-page-tools-landmark {
+    display: none;
+  }
+}
+
 a.new {
   pointer-events: none;
 }

--- a/tests/e2e/tools-portlet.spec.js
+++ b/tests/e2e/tools-portlet.spec.js
@@ -1,0 +1,40 @@
+// The toolbox is Special: pages a static host cannot serve, so the bake empties it
+// (Hooks\Hider). Core hides the emptied portlet, but a skin that wraps it in a box
+// of its own draws that box regardless, and it is the box a reader sees as an empty
+// "Tools" panel. The markup is identical either way, so only a laid-out page tells
+// the two apart: the workflow's static assertions cannot.
+//
+// Minerva needs no case here: it drops its overflow menu when the menu has no
+// entries, so it never draws the empty box in the first place.
+
+const { test, expect } = require("@playwright/test");
+
+// Per skin: the page it renders, and the element it wraps the toolbox in.
+const SKINS = [
+	["vector-2022", "Installation.html", ".vector-page-tools-landmark"],
+	["citizen", "citizen/Installation.html", "#citizen-page-more-dropdown"],
+];
+
+for (const [skin, path, box] of SKINS) {
+	test(`${skin} draws no empty tools box`, async ({ page }) => {
+		await page.goto(path);
+		await expect(page.locator("#firstHeading")).toBeVisible();
+
+		// Still emitted, so the assertions below are about what is shown, not what is built.
+		await expect(page.locator("#p-tb")).toBeAttached();
+		for (const element of await page.locator(`#p-tb, ${box}`).all()) {
+			await expect(element).toBeHidden();
+		}
+	});
+}
+
+// Below the width at which Vector hides the tab row it moves the tabs into that
+// box, which is then the only way to reach them, so there it has to stay.
+test("vector-2022 keeps its tools box below the tab-row breakpoint", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 480, height: 800 });
+	await page.goto("Installation.html");
+
+	await expect(page.locator("#vector-page-tools-dropdown")).toBeVisible();
+});

--- a/tests/e2e/tools-portlet.spec.js
+++ b/tests/e2e/tools-portlet.spec.js
@@ -22,7 +22,12 @@ for (const [skin, path, box] of SKINS) {
 
 		// Still emitted, so the assertions below are about what is shown, not what is built.
 		await expect(page.locator("#p-tb")).toBeAttached();
-		for (const element of await page.locator(`#p-tb, ${box}`).all()) {
+		await expect(page.locator("#p-tb")).toBeHidden();
+
+		// The box is what this rule hides, and toBeHidden() passes for an element that
+		// is not there, so a renamed box has to fail here rather than assert nothing.
+		await expect(page.locator(box)).not.toHaveCount(0);
+		for (const element of await page.locator(box).all()) {
 			await expect(element).toBeHidden();
 		}
 	});

--- a/tests/e2e/tools-portlet.spec.js
+++ b/tests/e2e/tools-portlet.spec.js
@@ -33,13 +33,26 @@ for (const [skin, path, box] of SKINS) {
 	});
 }
 
-// Below the width at which Vector hides the tab row it moves the tabs into that
-// box, which is then the only way to reach them, so there it has to stay.
-test("vector-2022 keeps its tools box below the tab-row breakpoint", async ({
+// Below the width at which Vector hides the tab row it moves the tabs into that box,
+// which is then the only way to reach them, so there it has to stay. Both sides of
+// that edge are pinned: the two rules keying off the same breakpoint is what keeps a
+// width with neither the tabs nor the box from opening up between them.
+test("vector-2022 keeps its tools box where Vector hides the tab row", async ({
 	page,
 }) => {
-	await page.setViewportSize({ width: 480, height: 800 });
+	await page.setViewportSize({ width: 639, height: 800 });
 	await page.goto("Installation.html");
 
+	await expect(page.locator(".mw-portlet-views")).toBeHidden();
 	await expect(page.locator("#vector-page-tools-dropdown")).toBeVisible();
+});
+
+test("vector-2022 drops its tools box where the tab row is back", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 640, height: 800 });
+	await page.goto("Installation.html");
+
+	await expect(page.locator(".mw-portlet-views")).toBeVisible();
+	await expect(page.locator("#vector-page-tools-dropdown")).toBeHidden();
 });


### PR DESCRIPTION
The Tools portlet renders as an empty box on the docs site. It is empty because `Hooks\Hider::onSidebarBeforeOutput()` drops the toolbox — every entry `Skin::makeToolbox()` produces (`whatlinkshere`, `recentchangeslinked`, `permalink`, `info`, `print`, the feeds, the user/log specials) is a `Special:` page or an `index.php` query, so a static host can serve none of them.

## Which direction

**(a) give it entries that work statically — not available.** There is nothing honest to put there. The only per-page URLs a wikven export can offer are the repository ones (`WikvenEditUrl` / `WikvenHistoryUrl` / `WikvenViewSourceUrl`), which are already `views` tabs, and they are opt-in: a site that does not configure them would still get the empty box. So it does not fix the general case.

**(b) stop the empty box rendering — done, but not by unsetting the key.**

### The Minerva claim is true, and with Minerva enabled it is a build failure

Checked against MinervaNeue `REL1_46` (the branch matching this image's MediaWiki 1.46), not against the comment:

- `SkinMinerva.php:149` — `$pageActionsDirector->buildMenu( $sidebar['TOOLBOX'], $actions, $views )`, unguarded.
- `PageActionsDirector::buildMenu( array $toolbox, … )` — a non-nullable `array` parameter.

I then baked with `MinervaNeue` in `skins:` and `unset($sidebar[$key])` in `Hider`. It does not degrade, it aborts:

```
TypeError: MediaWiki\Minerva\Menu\PageActions\PageActionsDirector::buildMenu():
Argument #1 ($toolbox) must be of type array, null given,
called in .../skins/MinervaNeue/includes/Skins/SkinMinerva.php on line 149
…
Wikven: build failed for skin 'minerva' (exit 255)
```

And unsetting would not have fixed the box anyway: in a bake with `unset()` Vector still draws its "Tools" panel — `#vector-page-tools` survives, only the `p-tb` portlet inside it goes.

So the emptying stays. `Hider.php`'s comment now records what rests on it rather than hedging with "some skins (e.g. Minerva)".

### What is actually left over

Not the portlet — core marks it `emptyPortlet` and `mediawiki.skinning/interface.less` hides that — but the box a skin wraps around it, which nothing hides:

| skin | box | contents in an export |
| --- | --- | --- |
| Vector 2022 | `.vector-page-tools-landmark`, the "Tools" panel/dropdown | `p-cactions` + `p-tb` |
| Citizen | `#citizen-page-more-dropdown`, the "More actions" card | `p-cactions` + `p-tb` — both always empty |
| Timeless | `#site-tools`, heading "Wiki tools" | `p-tb` only — always empty |
| **Minerva** | — | **draws nothing; see below** |

**Minerva needs no rule.** `PageActionsDirector::buildMenu()` emits `overflowMenu` only `if ( $overflowMenu->hasEntries() )`, and `DefaultOverflowBuilder` keeps only entries that have both an icon and an href. So it either shows a populated menu ("Edit full page") or omits the menu entirely — never an empty box. Confirmed by a second bake with editing denied to anonymous users, where `p-tb`, the ellipsis button and `page-actions-overflow` all disappear from Minerva's output.

**Vector is the one exception.** Its `p-cactions` carries copies of the page tabs as `.vector-more-collapsible-item`, shown only below `@min-width-breakpoint-tablet` — which is exactly where Vector hides the tab row (`PageToolbar.less` sets `.mw-portlet-views { display: none }` below it). Below that width the Tools box is the only way to reach Edit / View history / View source, so it is hidden only at and above the breakpoint, using the same Codex token Vector itself uses.

## Regression test

`tests/e2e/tools-portlet.spec.js`. It has to be a browser test: the fix is CSS, the markup is identical either way, so the workflow's static assertions cannot see it. It covers Vector 2022 and Citizen — the two skins that stay put under both the add-Minerva and drop-Timeless branches, at unchanged paths — plus one narrow-viewport case pinning the Vector exception so the media query cannot be widened away. No Timeless case (it is leaving) and no Minerva case (nothing to assert); the `#site-tools` rule stays in the stylesheet, since it is still right for anyone who enables Timeless.

## How this was verified

**In CI, in a real browser:** `build-and-check` builds the image, bakes `docs/` and runs the Playwright suite in Chromium — **18 passed**, including the three new cases. That covers the parts I could not check locally, the Vector media query among them.

Locally, Docker Hub layer blobs (`production.cloudfront.docker.com`) are blocked by this session's egress policy, so `docker build` could not run here. The bake was reproduced without Docker instead: MediaWiki 1.46 + mediawiki-vendor, Vector / Citizen / MinervaNeue / Timeless at the pinned refs, this extension, `WikvenSettings.php`, and `maintenance/build.php` — the steps `bin/entrypoint` runs — over a small source tree with the docs site's `.wikven.yml` shape.

- **Baked and diffed variants** — current `main`, `unset()`, and this branch — across two skin sets: the docs site's current one, and the one it is moving to (Vector 2022 + Citizen + Minerva).
- **Laid the baked pages out with WeasyPrint** (a real CSS cascade + layout engine, `media_type="screen"`) and diffed the rendered text. Citizen `"More actions"` 1 → 0, Timeless `"Wiki tools"` 1 → 0, Minerva unchanged and still populated.
- **Audited every rule in the baked CSS** touching these selectors: the only other `display` declaration is Vector's own `display: none`, and `ext.Wikven.styles.css` is the last stylesheet linked in every skin.
- `composer phpcs`, `mago format --check`, `mago lint`, `biome ci` all pass, locally and in CI.

### Still unverified

- **Nothing here is a screenshot.** No browser was available in this session (`cdn.playwright.dev` is egress-blocked, Ubuntu's `chromium` is a snap stub) and `chaotic-ground.github.io` is blocked too, so I never looked at the docs site or at a rendered page myself. The browser evidence is CI's passing assertions, not an image.
- The **Minerva** bakes ran against a locally assembled tree, not the image: how `MinervaNeue` gets into the image is #claude/add-minerva's business, and if it arrives at a different ref the `SkinMinerva.php:149` check is worth repeating.
- The local bake used a minimal source tree, not `docs/` (SifterSearch, Translate, ULS and TabberNeue are fetched at image-build time and were unreachable). Search was therefore inactive, which affects the search portlet, not the toolbox. CI's run had the real thing.
