### PR TITLE
docs: add the Minerva skin to the docs site

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -103,8 +103,8 @@ jobs:
             fi
             expected=$(( expected + langs * ( langs + 1 ) ))
           done
-          # Once per skin the site renders: the default plus the one docs/.wikven.yml adds.
-          expected=$(( expected * 2 ))
+          # Once per skin the site renders: the default plus the two docs/.wikven.yml adds.
+          expected=$(( expected * 3 ))
           found=$(find dist -name '*.html' -exec grep -ho 'mw-pt-progress--' {} + | wc -l)
           if [ "$found" -ne "$expected" ]; then
             echo "::error::$found language-bar entries across dist, expected $expected"

--- a/docs/.wikven.yml
+++ b/docs/.wikven.yml
@@ -9,6 +9,7 @@ extensions:
   - UniversalLanguageSelector
 skins:
   - Citizen
+  - MinervaNeue
 config:
   WikvenFooterUrl: https://github.com/chaotic-ground/wikven
   WikvenEditUrl: https://github.com/chaotic-ground/wikven/edit/main/docs/$1

--- a/tests/e2e/skin-switcher.spec.js
+++ b/tests/e2e/skin-switcher.spec.js
@@ -98,6 +98,26 @@ test("switching back to the main skin from a Korean page returns to the root cop
 	expect(missing, missing.join("; ")).toEqual([]);
 });
 
+// And between two skins that both have a directory, where the old and the new
+// skin directory are at the same depth, then back out to the root copy.
+test("switching between two non-main skins on a Korean page keeps the article", async ({
+	page,
+}) => {
+	const missing = watchForMissingPages(page);
+
+	await page.goto("citizen/Getting_Started/ko.html");
+
+	expect((await chooseSkin(page, "minerva")).status()).toBe(200);
+	await expect(page).toHaveURL("minerva/Getting_Started/ko.html");
+	await expectKoreanArticle(page);
+	await expect(skinSelect(page)).toHaveValue("minerva");
+
+	expect((await chooseSkin(page, "vector-2022")).status()).toBe(200);
+	await expect(page).toHaveURL("Getting_Started/ko.html");
+	await expectKoreanArticle(page);
+	expect(missing, missing.join("; ")).toEqual([]);
+});
+
 // A source page sits one directory higher than its translations; it worked
 // before and has to keep working.
 test("switching the skin on a source page keeps the article", async ({


### PR DESCRIPTION
Stacked on #348.

Enables MinervaNeue (bundled, so no repo entry): smoke's per-skin multiplier goes to 3, and the switcher test covering two non-main skins comes back.

Minerva needs no MobileFrontend, but standalone it builds its own main menu, bypassing `Hider` — Random, Recent changes, Special pages and Preferences are dead links. Follow-up, not this PR.

Not baked: the registry CDN 403s here, so none of this has been run.
