### PR TITLE
ci: drop the Codecov project status the plan cannot post

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,12 +7,7 @@ comment: false
 
 coverage:
   status:
-    # maintenance/ is half the tree's lines with no unit tests: it dilutes the
-    # project total, and its diffs can never meet a patch target.
-    project:
-      default:
-        target: auto
-        threshold: 2%
+    # maintenance/ is half the tree's lines with no unit tests; its diffs can never meet a patch target.
     patch:
       default:
         target: 70%


### PR DESCRIPTION
Project coverage turns out to be a Codecov Pro feature, and this account is not on it — which is why `codecov/project` has never appeared on any pull request here. The block was describing an enforcement that cannot exist, so it goes.

`comment: false` and the `patch` status are unchanged. Patch at 70% on `includes/` is the check that actually runs.

Follow-up to #340; the full investigation is in [that thread](https://github.com/chaotic-ground/wikven/pull/340#issuecomment-5302513471).

`uv run --frozen --group lint yamllint --strict .` passes. Codecov's own validator is still unreachable from here, so the file is unvalidated against their parser.

---
_Generated by [Claude Code](https://claude.ai/code/session_016qiZSGWHrxkjvFxA8swynp)_