### PR TITLE
fix: read units the way Translate does

### DIFF
--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -47,8 +47,12 @@ class StalenessComputer {
 	 */
 	private const VERBATIM_TAGS = 'syntaxhighlight|source|nowiki|pre';
 
-	/** A <translate> block, its contents captured. Translate accepts attributes on the opening tag. */
-	private const TRANSLATE_BLOCK = '#(<translate(?:\s[^>]*)?>)(.*?)(</translate>)#s';
+	/**
+	 * A <translate> block, its contents captured. Exactly the two spellings parse() accepts: it takes
+	 * no other attribute, so anything else is a tag containsMarkup() offers for marking and parse()
+	 * then refuses, which checkTranslations reports rather than this quietly reading as a block.
+	 */
+	private const TRANSLATE_BLOCK = '#(<translate(?: nowrap)?>)(.*?)(</translate>)#s';
 
 	/** What TranslatablePageParser::armourNowiki() hides: exactly this, no attributes, no other tag. */
 	private const ARMOURED_NOWIKI = '#<nowiki>.*?</nowiki>#s';
@@ -116,7 +120,9 @@ class StalenessComputer {
 	 */
 	public static function translationUnits(string $text): array {
 		$verbatim = self::verbatimRanges($text);
-		return self::unitsAt($text, static fn(int $offset): bool => !self::insideVerbatim($offset, $verbatim));
+		return self::unitsAt($text, static function (int $offset) use ($verbatim): bool {
+			return !self::insideVerbatim($offset, $verbatim);
+		});
 	}
 
 	/**
@@ -126,7 +132,9 @@ class StalenessComputer {
 	 */
 	private static function sourcePageUnits(string $text): array {
 		$blocks = self::blockRanges($text);
-		return self::unitsAt($text, static fn(int $offset): bool => self::containingRange($offset, $blocks) !== null);
+		return self::unitsAt($text, static function (int $offset) use ($blocks): bool {
+			return self::containingRange($offset, $blocks) !== null;
+		});
 	}
 
 	/**
@@ -313,7 +321,9 @@ class StalenessComputer {
 	private static function blockRanges(string $text): array {
 		$masked = preg_replace_callback(
 			self::ARMOURED_NOWIKI,
-			static fn(array $span): string => str_repeat("\x00", strlen($span[0])),
+			static function (array $span): string {
+				return str_repeat("\x00", strlen($span[0]));
+			},
 			$text
 		);
 

--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -48,9 +48,9 @@ class StalenessComputer {
 	private const VERBATIM_TAGS = 'syntaxhighlight|source|nowiki|pre';
 
 	/**
-	 * A <translate> block, its contents captured. Exactly the two spellings parse() accepts: it takes
-	 * no other attribute, so anything else is a tag containsMarkup() offers for marking and parse()
-	 * then refuses, which checkTranslations reports rather than this quietly reading as a block.
+	 * A <translate> block, its contents captured. Exactly the two spellings parse() accepts: any other
+	 * attribute makes a tag it opens no block for, and reading one here would put markers where the
+	 * engine sees none. checkTranslations compares the two readings and reports where they differ.
 	 */
 	private const TRANSLATE_BLOCK = '#(<translate(?: nowrap)?>)(.*?)(</translate>)#s';
 

--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -31,7 +31,7 @@ class StalenessComputer {
 	 * own title, which the source wikitext never repeats, so it exists only in a translation file
 	 * ("<!--T:title @<hash>-->" followed by the translated title).
 	 *
-	 * mark() only ever hands out numbers, so the tooling never produces this id; splitUnits() does
+	 * mark() only ever hands out numbers, so the tooling never produces this id; the unit scan does
 	 * accept it, though, so a source page could still carry a hand-written "<!--T:title-->". That
 	 * unit would collide with the page title and be lost, so sourceUnits() rejects it outright and
 	 * usesReservedId() lets the check report it.
@@ -41,12 +41,17 @@ class StalenessComputer {
 	private const HASH_LENGTH = 8;
 
 	/**
-	 * Verbatim spans whose contents are shown, not parsed. A <!--T:n--> or <translate> that appears
-	 * inside one -- as on the page documenting page translation -- is an example, not real markup, so
-	 * unit splitting and marking skip it. This mirrors the tags TranslationSource::isTranslatable and
-	 * #239 treat as verbatim.
+	 * Verbatim spans in a translation file, whose contents are shown rather than read as units. A
+	 * translation carries bare markers and no <translate> block, so it is wikven's own format and
+	 * this is wikven's own rule; source pages go by Translate's, which is blockRanges().
 	 */
 	private const VERBATIM_TAGS = 'syntaxhighlight|source|nowiki|pre';
+
+	/** A <translate> block, its contents captured. Translate accepts attributes on the opening tag. */
+	private const TRANSLATE_BLOCK = '#(<translate(?:\s[^>]*)?>)(.*?)(</translate>)#s';
+
+	/** What TranslatablePageParser::armourNowiki() hides: exactly this, no attributes, no other tag. */
+	private const ARMOURED_NOWIKI = '#<nowiki>.*?</nowiki>#s';
 
 	/** Short content hash of a source unit; the value carried as @<hash> in a translation marker. */
 	public static function hashUnit(string $unitText): string {
@@ -58,71 +63,89 @@ class StalenessComputer {
 	 *
 	 * Units are the blank-line-separated blocks Translate segments on; an already-marked unit keeps
 	 * its number and new ones continue from the highest on the page. The marker goes on its own line
-	 * before the unit, which both splitUnits() and Translate's own re-parse honour. Idempotent.
+	 * before the unit, which both the unit scan and Translate's own re-parse honour. Idempotent.
 	 */
 	public static function mark(string $text): string {
-		$verbatim = self::verbatimRanges($text);
+		$blocks = self::blockRanges($text);
 
-		// Only count real markers when picking the next number; a <!--T:n--> shown inside an example
-		// must not push the numbering of the actual units along.
+		// Only a marker inside a block is a unit, so only those numbers are taken; one shown elsewhere
+		// on the page must not push the real units along.
 		preg_match_all('/<!--T:(\d+)/', $text, $existing, PREG_OFFSET_CAPTURE);
 		$numbers = [];
 		foreach ($existing[0] as $i => $marker) {
-			if (!self::insideVerbatim($marker[1], $verbatim)) {
+			if (self::containingRange($marker[1], $blocks) !== null) {
 				$numbers[] = (int)$existing[1][$i][0];
 			}
 		}
 		$next = $numbers === [] ? 1 : max($numbers) + 1;
 
-		return preg_replace_callback(
-			'#(<translate(?:\s[^>]*)?>)(.*?)(</translate>)#s',
-			static function (array $block) use (&$next, $verbatim): string {
-				// A <translate> pair inside a verbatim span is an example; leave it exactly as written.
-				if (self::insideVerbatim($block[0][1], $verbatim)) {
-					return $block[0][0];
-				}
-				// The two newlines must be adjacent, matching Translate's own sectioniser
-				// ('~(^\s*|\s*\n\n\s*|\s*$)~'): a line of spaces or tabs between them is still the same
-				// unit to Translate, and marking it as two would put a <!--T:n--> mid-unit, which
-				// Translate rejects (pt-shake-position).
-				$units = preg_split('/(\n\n)/', $block[2][0], -1, PREG_SPLIT_DELIM_CAPTURE);
-				$marked = '';
-				foreach ($units as $index => $segment) {
-					// Odd indices are the blank-line separators between units; keep them verbatim.
-					if (( $index % 2 ) === 1 || trim($segment) === '' || str_contains($segment, '<!--T:')) {
-						$marked .= $segment;
-						continue;
-					}
-					preg_match('/^(\s*)(.*)$/s', $segment, $parts);
-					$marked .= $parts[1] . '<!--T:' . $next++ . "-->\n" . $parts[2];
-				}
-				return $block[1][0] . $marked . $block[3][0];
-			},
-			$text,
-			-1,
-			$count,
-			PREG_OFFSET_CAPTURE
-		);
+		$marked = '';
+		$offset = 0;
+		foreach ($blocks as [$start, $end]) {
+			$marked .=
+				substr($text, $offset, $start - $offset) . self::markBlock(substr($text, $start, $end - $start), $next);
+			$offset = $end;
+		}
+		return $marked . substr($text, $offset);
+	}
+
+	/** Number the still-unmarked units of one <translate> block's contents, continuing from $next. */
+	private static function markBlock(string $contents, int &$next): string {
+		// The two newlines must be adjacent, matching Translate's own sectioniser
+		// ('~(^\s*|\s*\n\n\s*|\s*$)~'): a line of spaces or tabs between them is still the same unit to
+		// Translate, and marking it as two would put a <!--T:n--> mid-unit, which Translate rejects
+		// (pt-shake-position).
+		$units = preg_split('/(\n\n)/', $contents, -1, PREG_SPLIT_DELIM_CAPTURE);
+		$marked = '';
+		foreach ($units as $index => $segment) {
+			// Odd indices are the blank-line separators between units; keep them verbatim.
+			if (( $index % 2 ) === 1 || trim($segment) === '' || str_contains($segment, '<!--T:')) {
+				$marked .= $segment;
+				continue;
+			}
+			preg_match('/^(\s*)(.*)$/s', $segment, $parts);
+			$marked .= $parts[1] . '<!--T:' . $next++ . "-->\n" . $parts[2];
+		}
+		return $marked;
 	}
 
 	/**
-	 * Split page text into units keyed by their <!--T:n--> marker id.
+	 * Split a translation file into units keyed by their <!--T:n--> marker id.
 	 *
-	 * @return array<string,array{hash:?string,text:string}> id => [synced-source hash (translations only), unit text]
+	 * @return array<string,array{hash:?string,text:string}> id => [synced-source hash, unit text]
 	 */
-	public static function splitUnits(string $text): array {
+	public static function translationUnits(string $text): array {
+		$verbatim = self::verbatimRanges($text);
+		return self::unitsAt($text, static fn(int $offset): bool => !self::insideVerbatim($offset, $verbatim));
+	}
+
+	/**
+	 * Split a source page into units keyed by their <!--T:n--> marker id.
+	 *
+	 * @return array<string,array{hash:?string,text:string}> id => [null, unit text]
+	 */
+	private static function sourcePageUnits(string $text): array {
+		$blocks = self::blockRanges($text);
+		return self::unitsAt($text, static fn(int $offset): bool => self::containingRange($offset, $blocks) !== null);
+	}
+
+	/**
+	 * Units keyed by marker id, counting only the markers whose offset $keep accepts. A unit's body
+	 * runs to the next counted marker, so a skipped one leaves the surrounding unit whole.
+	 *
+	 * @param string $text
+	 * @param callable(int):bool $keep
+	 * @return array<string,array{hash:?string,text:string}>
+	 */
+	private static function unitsAt(string $text, callable $keep): array {
 		$pattern = '/<!--T:(?<id>[A-Za-z0-9]+)(?:\s+@(?<hash>[0-9a-f]{' . self::HASH_LENGTH . '}))?\s*-->/';
 		if (!preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
 			return [];
 		}
 
-		// Drop markers that sit inside a verbatim span: they are shown as an example, not real units.
-		// A real unit's body still spans any verbatim block that falls between two real markers, so an
-		// existing translation's boundaries -- and its @<hash> stamps -- are unchanged.
-		$verbatim = self::verbatimRanges($text);
 		$markers = [];
 		foreach ($matches as $marker) {
-			if (!self::insideVerbatim($marker[0][1], $verbatim)) {
+			if ($keep($marker[0][1])) {
 				$markers[] = $marker;
 			}
 		}
@@ -150,7 +173,7 @@ class StalenessComputer {
 	 * a unit wearing it has nowhere to go. Reported by the check, and refused by sourceUnits().
 	 */
 	public static function usesReservedId(string $sourceText): bool {
-		return isset(self::splitUnits($sourceText)[self::TITLE_UNIT_ID]);
+		return isset(self::sourcePageUnits($sourceText)[self::TITLE_UNIT_ID]);
 	}
 
 	/**
@@ -166,7 +189,7 @@ class StalenessComputer {
 	 * @throws InvalidArgumentException If the source page marks a unit with the reserved title id.
 	 */
 	public static function sourceUnits(string $sourceText, ?string $pageTitle = null): array {
-		$units = self::splitUnits($sourceText);
+		$units = self::sourcePageUnits($sourceText);
 		// Refused whether or not this page has a translatable title: merging the two would drop one
 		// of them silently, and a page that gains a translatable title later must not lose a unit
 		// the moment it does.
@@ -193,7 +216,7 @@ class StalenessComputer {
 	 */
 	public static function analyze(string $sourceText, ?string $translationText, ?string $pageTitle = null): array {
 		$source = self::sourceUnits($sourceText, $pageTitle);
-		$translation = $translationText === null ? [] : self::splitUnits($translationText);
+		$translation = $translationText === null ? [] : self::translationUnits($translationText);
 
 		$result = [];
 		foreach ($source as $id => $unit) {
@@ -227,16 +250,22 @@ class StalenessComputer {
 	 */
 	public static function restamp(string $sourceText, string $translationText, ?string $pageTitle = null): string {
 		$source = self::sourceUnits($sourceText, $pageTitle);
+		// A marker the translation merely shows is prose, not a unit: stamping one would edit the
+		// sentence around it whenever its id happened to match a real unit.
+		$verbatim = self::verbatimRanges($translationText);
 		return preg_replace_callback(
 			'/<!--T:(?<id>[A-Za-z0-9]+)(?:\s+@[0-9a-f]{' . self::HASH_LENGTH . '})?\s*-->/',
-			static function ($marker) use ($source) {
-				$id = $marker['id'];
-				if (!isset($source[$id])) {
-					return $marker[0];
+			static function ($marker) use ($source, $verbatim) {
+				$id = $marker['id'][0];
+				if (!isset($source[$id]) || self::insideVerbatim($marker[0][1], $verbatim)) {
+					return $marker[0][0];
 				}
 				return '<!--T:' . $id . ' @' . self::hashUnit($source[$id]['text']) . '-->';
 			},
-			$translationText
+			$translationText,
+			-1,
+			$count,
+			PREG_OFFSET_CAPTURE
 		);
 	}
 
@@ -255,7 +284,7 @@ class StalenessComputer {
 		?string $existingTranslation = null,
 		?string $pageTitle = null
 	): string {
-		$existing = $existingTranslation === null ? [] : self::splitUnits($existingTranslation);
+		$existing = $existingTranslation === null ? [] : self::translationUnits($existingTranslation);
 		$additions = '';
 		foreach (self::sourceUnits($sourceText, $pageTitle) as $id => $unit) {
 			if (!isset($existing[$id])) {
@@ -269,6 +298,33 @@ class StalenessComputer {
 			return $additions;
 		}
 		return rtrim($existingTranslation, "\n") . "\n\n" . $additions;
+	}
+
+	/**
+	 * Byte ranges of the <translate> block contents in a source page, each as [start, endExclusive].
+	 *
+	 * Translate armours <nowiki> before it looks for a block, so a whole pair shown in one is
+	 * invisible to it; blanking the span with a same-length filler keeps every offset the page's own.
+	 * A <nowiki> merely inside a block still yields its markers, because Translate unarmours a block's
+	 * contents before segmenting them.
+	 *
+	 * @return list<array{int,int}>
+	 */
+	private static function blockRanges(string $text): array {
+		$masked = preg_replace_callback(
+			self::ARMOURED_NOWIKI,
+			static fn(array $span): string => str_repeat("\x00", strlen($span[0])),
+			$text
+		);
+
+		$ranges = [];
+		$offset = 0;
+		$length = strlen($masked);
+		while ($offset < $length && preg_match(self::TRANSLATE_BLOCK, $masked, $match, PREG_OFFSET_CAPTURE, $offset)) {
+			$ranges[] = [$match[2][1], $match[2][1] + strlen($match[2][0])];
+			$offset = $match[0][1] + strlen($match[0][0]);
+		}
+		return $ranges;
 	}
 
 	/**

--- a/includes/PageTranslation/TranslationSource.php
+++ b/includes/PageTranslation/TranslationSource.php
@@ -19,25 +19,21 @@ use Throwable;
  * buildTranslations (materialize) so both agree on what is a base and what is a translation.
  */
 class TranslationSource {
-	/**
-	 * An opening <translate> tag, attributes and all. Translate accepts <translate nowrap>, and
-	 * StalenessComputer::mark() matches the same shape, so both halves of the pipeline agree on
-	 * what counts as a translatable page.
-	 */
-	private const TRANSLATE_TAG = '#<translate(?:\s[^>]*)?>#';
+	/** A translate tag of either half, as Translate's own containsMarkup() looks for one. */
+	private const TRANSLATE_TAG = '#</?translate[ >]#';
+
+	/** What TranslatablePageParser::armourNowiki() hides: exactly this, no attributes, no other tag. */
+	private const ARMOURED_NOWIKI = '#<nowiki>.*?</nowiki>#s';
+
+	/** Tags MediaWiki hands to an extension unparsed, so a magic word inside one never runs. */
+	private const UNEXPANDED_TAGS = ['nowiki', 'pre'];
 
 	/** Whether a page's wikitext marks it as translatable (a real <translate>, not one shown as an example). */
 	public static function isTranslatable(string $text): bool {
-		// A <translate> inside a verbatim span -- <syntaxhighlight>, <nowiki>, <pre>, <source> -- is an
-		// example, as on the page documenting page translation, not real markup. Blank those spans with
-		// MediaWiki's own tag extraction (it handles attributes, self-closing tags and comments) before
-		// looking for a real tag, rather than trusting a hand-rolled regex.
-		$matches = [];
-		$stripped = Parser::extractTagsAndParams(['syntaxhighlight', 'source', 'nowiki', 'pre'], $text, $matches);
-		// Match the tag the way Translate itself does, attributes included: <translate nowrap> is a real
-		// translatable page, and StalenessComputer::mark() accepts the same shape, so the two agree on
-		// what marks a page for CI checks and the translated build.
-		return preg_match(self::TRANSLATE_TAG, $stripped) === 1;
+		// Translate's parser hook runs on raw wikitext, before any extension tag is stripped, so a
+		// <translate> shown in a <syntaxhighlight> is one it parses. Only <nowiki> hides a tag from it.
+		// A placeholder rather than an empty string: removing the span could splice "</" onto "translate>".
+		return preg_match(self::TRANSLATE_TAG, preg_replace(self::ARMOURED_NOWIKI, "\x7f", $text)) === 1;
 	}
 
 	/**
@@ -66,10 +62,11 @@ class TranslationSource {
 
 	/** Whether a page's wikitext sets its own display title (a real magic word, not one shown as an example). */
 	public static function hasFixedDisplayTitle(string $text): bool {
-		// As in isTranslatable: a {{DISPLAYTITLE:}} shown inside a verbatim span -- as on the page
-		// documenting page translation -- is an example, not a magic word the parser ever runs.
+		// Unlike isTranslatable, this asks what MediaWiki expands. <pre> and <nowiki> are core tag
+		// hooks, so a magic word inside one never runs; <syntaxhighlight> is only a tag where that
+		// extension is loaded, and reading it as verbatim would blank a real one on a site without it.
 		$matches = [];
-		$stripped = Parser::extractTagsAndParams(['syntaxhighlight', 'source', 'nowiki', 'pre'], $text, $matches);
+		$stripped = Parser::extractTagsAndParams(self::UNEXPANDED_TAGS, $text, $matches);
 		// DISPLAYTITLE is a localized magic word: on a de-content wiki the working spelling is
 		// {{ANZEIGETITEL:}}. Checking every synonym in the content language covers that, or such a page
 		// is handed a title unit its own magic word then overrides.

--- a/includes/PageTranslation/TranslationSource.php
+++ b/includes/PageTranslation/TranslationSource.php
@@ -25,8 +25,12 @@ class TranslationSource {
 	/** What TranslatablePageParser::armourNowiki() hides: exactly this, no attributes, no other tag. */
 	private const ARMOURED_NOWIKI = '#<nowiki>.*?</nowiki>#s';
 
-	/** Tags MediaWiki hands to an extension unparsed, so a magic word inside one never runs. */
-	private const UNEXPANDED_TAGS = ['nowiki', 'pre'];
+	/**
+	 * Tags whose contents MediaWiki hands over unparsed, so a magic word inside one never runs.
+	 * <pre> and <nowiki> always; <syntaxhighlight> and <source> only where that extension is loaded,
+	 * which is the common case and the one wikven's own docs run under.
+	 */
+	private const UNEXPANDED_TAGS = ['syntaxhighlight', 'source', 'nowiki', 'pre'];
 
 	/** Whether a page's wikitext marks it as translatable (a real <translate>, not one shown as an example). */
 	public static function isTranslatable(string $text): bool {
@@ -62,9 +66,7 @@ class TranslationSource {
 
 	/** Whether a page's wikitext sets its own display title (a real magic word, not one shown as an example). */
 	public static function hasFixedDisplayTitle(string $text): bool {
-		// Unlike isTranslatable, this asks what MediaWiki expands. <pre> and <nowiki> are core tag
-		// hooks, so a magic word inside one never runs; <syntaxhighlight> is only a tag where that
-		// extension is loaded, and reading it as verbatim would blank a real one on a site without it.
+		// Unlike isTranslatable, this asks what MediaWiki expands rather than what Translate parses.
 		$matches = [];
 		$stripped = Parser::extractTagsAndParams(self::UNEXPANDED_TAGS, $text, $matches);
 		// DISPLAYTITLE is a localized magic word: on a de-content wiki the working spelling is

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -6,6 +6,7 @@
  * @phan-file-suppress PhanUndeclaredClassMethod
  * @phan-file-suppress PhanUndeclaredClassConstant
  * @phan-file-suppress PhanUndeclaredConstant
+ * @phan-file-suppress PhanUndeclaredClassCatch
  */
 
 namespace MediaWiki\Extension\Wikven;
@@ -14,7 +15,9 @@ use Maintenance;
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\ContentHandler;
 use MediaWiki\Context\RequestContext;
+use MediaWiki\Extension\Translate\PageTranslation\ParsingFailure;
 use MediaWiki\Extension\Translate\PageTranslation\TranslatablePage;
+use MediaWiki\Extension\Translate\PageTranslation\TranslatablePageMarkException;
 use MediaWiki\Extension\Translate\PageTranslation\TranslatablePageSettings;
 use MediaWiki\Extension\Translate\PageTranslation\UpdateTranslatablePageJob;
 use MediaWiki\Extension\Translate\Services as TranslateServices;
@@ -97,7 +100,7 @@ class BuildTranslations extends Maintenance {
 	 * @param string[] $languages
 	 * @param ?string $pageTitle Source text of the page's title unit, or null if its title is fixed.
 	 * @param User $user
-	 * @return bool Whether the page was marked (false if it could not be loaded or had invalid units).
+	 * @return bool Whether the page was marked (false if it could not be loaded, parsed or validated).
 	 */
 	private function prepare(
 		Title $title,
@@ -121,16 +124,27 @@ class BuildTranslations extends Maintenance {
 			$this->output("Wikven: could not load {$title->getPrefixedText()} for translation; skipping\n");
 			return false;
 		}
-		$operation = $marker->getMarkOperation($record, null, $pageTitle !== null);
-		if (!$operation->getUnitValidationStatus()->isOK()) {
-			$this->output("Wikven: {$title->getPrefixedText()} has invalid translation units; skipping\n");
+		// A page Translate cannot parse -- an unclosed <translate>, two markers in one unit -- throws
+		// out of the marker. One page must not end the bake, so report it and leave it untranslated;
+		// checkTranslations reports the same page, which is where the author is meant to see it.
+		try {
+			$operation = $marker->getMarkOperation($record, null, $pageTitle !== null);
+			if (!$operation->getUnitValidationStatus()->isOK()) {
+				$this->output("Wikven: {$title->getPrefixedText()} has invalid translation units; skipping\n");
+				return false;
+			}
+			// Keep Translate's "Page display title" unit only for a page whose title is translatable;
+			// a page that fixes its own display title has nothing to translate and would otherwise sit
+			// short of 100% forever. No priority languages, transclusion, or forced syntax upgrade.
+			$settings = new TranslatablePageSettings([], false, '', [], $pageTitle !== null, false, false);
+			$marker->markForTranslation($operation, $settings, RequestContext::getMain(), $user);
+		} catch (ParsingFailure|TranslatablePageMarkException $failure) {
+			$this->output(
+				"Wikven: {$title->getPrefixedText()} cannot be marked for translation"
+				. " ({$failure->getMessage()}); skipping\n"
+			);
 			return false;
 		}
-		// Keep Translate's "Page display title" unit only for a page whose title is translatable;
-		// a page that fixes its own display title has nothing to translate and would otherwise sit
-		// short of 100% forever. No priority languages, transclusion, or forced syntax upgrade.
-		$settings = new TranslatablePageSettings([], false, '', [], $pageTitle !== null, false, false);
-		$marker->markForTranslation($operation, $settings, RequestContext::getMain(), $user);
 
 		// markForTranslation only queues the update job; run the queue so the source units exist
 		// before we fill in translations.
@@ -182,7 +196,7 @@ class BuildTranslations extends Maintenance {
 				continue;
 			}
 			$translationText = (string)file_get_contents($translationFile);
-			$units = StalenessComputer::splitUnits($translationText);
+			$units = StalenessComputer::translationUnits($translationText);
 
 			$status = [];
 			foreach (StalenessComputer::analyze($sourceText, $translationText, $pageTitle) as $unit) {

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -92,9 +92,9 @@ class BuildTranslations extends Maintenance {
 		return true;
 	}
 
-	/** Report a page Translate refused, and answer prepare()'s "was it marked" with no. */
-	private function skipUnmarkable(Title $title, string $reason): bool {
-		$this->output("Wikven: {$title->getPrefixedText()} cannot be marked for translation ($reason); skipping\n");
+	/** Report a page Translate would not take, and answer prepare()'s "was it marked" with no. */
+	private function skipUnmarkable(Title $title, string $what, string $reason): bool {
+		$this->output("Wikven: {$title->getPrefixedText()} $what ($reason); skipping\n");
 		return false;
 	}
 
@@ -145,9 +145,9 @@ class BuildTranslations extends Maintenance {
 			$settings = new TranslatablePageSettings([], false, '', [], $pageTitle !== null, false, false);
 			$marker->markForTranslation($operation, $settings, RequestContext::getMain(), $user);
 		} catch (ParsingFailure $failure) {
-			return $this->skipUnmarkable($title, $failure->getMessage());
+			return $this->skipUnmarkable($title, 'is not wikitext Translate can parse', $failure->getMessage());
 		} catch (TranslatablePageMarkException $failure) {
-			return $this->skipUnmarkable($title, $failure->getMessage());
+			return $this->skipUnmarkable($title, 'was refused for translation', $failure->getMessage());
 		}
 
 		// markForTranslation only queues the update job; run the queue so the source units exist

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -92,6 +92,12 @@ class BuildTranslations extends Maintenance {
 		return true;
 	}
 
+	/** Report a page Translate refused, and answer prepare()'s "was it marked" with no. */
+	private function skipUnmarkable(Title $title, string $reason): bool {
+		$this->output("Wikven: {$title->getPrefixedText()} cannot be marked for translation ($reason); skipping\n");
+		return false;
+	}
+
 	/**
 	 * Mark one page for translation and load its translations from the source files.
 	 *
@@ -138,12 +144,10 @@ class BuildTranslations extends Maintenance {
 			// short of 100% forever. No priority languages, transclusion, or forced syntax upgrade.
 			$settings = new TranslatablePageSettings([], false, '', [], $pageTitle !== null, false, false);
 			$marker->markForTranslation($operation, $settings, RequestContext::getMain(), $user);
-		} catch (ParsingFailure|TranslatablePageMarkException $failure) {
-			$this->output(
-				"Wikven: {$title->getPrefixedText()} cannot be marked for translation"
-				. " ({$failure->getMessage()}); skipping\n"
-			);
-			return false;
+		} catch (ParsingFailure $failure) {
+			return $this->skipUnmarkable($title, $failure->getMessage());
+		} catch (TranslatablePageMarkException $failure) {
+			return $this->skipUnmarkable($title, $failure->getMessage());
 		}
 
 		// markForTranslation only queues the update job; run the queue so the source units exist

--- a/maintenance/checkTranslations.php
+++ b/maintenance/checkTranslations.php
@@ -137,10 +137,8 @@ class CheckTranslations extends Maintenance {
 		}
 		// The two readings agreeing is what makes every check below it mean anything: a unit only
 		// wikven sees is never translated on the wiki, and one only Translate sees is never gated.
-		$wikven = array_values(array_diff(
-			array_map('strval', array_keys(StalenessComputer::sourceUnits($sourceText))),
-			[StalenessComputer::TITLE_UNIT_ID]
-		));
+		// No page title is passed, so the title unit Translate has no counterpart for is never added.
+		$wikven = array_map('strval', array_keys(StalenessComputer::sourceUnits($sourceText)));
 		if ($wikven !== $ids) {
 			$problems++;
 			$this->output(
@@ -154,3 +152,6 @@ class CheckTranslations extends Maintenance {
 		return $problems;
 	}
 }
+
+$maintClass = CheckTranslations::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/checkTranslations.php
+++ b/maintenance/checkTranslations.php
@@ -1,8 +1,18 @@
 <?php
+/**
+ * Translate is an optional, image-bundled dependency that phan does not analyse, so its symbols
+ * are undeclared to static analysis here. Reading a page with Translate's own parser only happens
+ * when Translate is loaded.
+ *
+ * @phan-file-suppress PhanUndeclaredClassMethod
+ * @phan-file-suppress PhanUndeclaredClassCatch
+ */
 
 namespace MediaWiki\Extension\Wikven;
 
 use Maintenance;
+use MediaWiki\Extension\Translate\PageTranslation\ParsingFailure;
+use MediaWiki\Extension\Translate\Services as TranslateServices;
 use MediaWiki\Extension\Wikven\PageTranslation\StalenessComputer;
 use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
 use MediaWiki\Registration\ExtensionRegistry;
@@ -56,6 +66,7 @@ class CheckTranslations extends Maintenance {
 				);
 				continue;
 			}
+			$problems += $this->checkSourcePage($prefix . substr($baseFile, strlen($source) + 1), $sourceText);
 			$pageTitle = TranslationSource::translatableTitle($baseFile, $source, $sourceText);
 			foreach (TranslationSource::translationLanguages($baseFile, $isKnownLanguage) as $lang) {
 				$translationFile = TranslationSource::translationPath($baseFile, $lang);
@@ -88,7 +99,58 @@ class CheckTranslations extends Maintenance {
 		}
 		return true;
 	}
-}
 
-$maintClass = CheckTranslations::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+	/**
+	 * Read a source page with Translate's own parser and report where wikven would read it
+	 * differently, so the author hears it here rather than from a page that bakes wrong.
+	 *
+	 * @return int Problems found.
+	 */
+	private function checkSourcePage(string $reportFile, string $sourceText): int {
+		try {
+			$output = TranslateServices::getInstance()->getTranslatablePageParser()->parse($sourceText);
+		} catch (ParsingFailure $failure) {
+			// The bake skips such a page, leaving it untranslated; nothing downstream would say why.
+			$this->output(
+				"::error file=$reportFile::Translate cannot parse this page: {$failure->getMessage()}\n"
+			);
+			return 1;
+		}
+
+		$ids = [];
+		$unmarked = 0;
+		foreach ($output->units() as $unit) {
+			if ((string)$unit->id === '-1') {
+				$unmarked++;
+			} else {
+				$ids[] = (string)$unit->id;
+			}
+		}
+
+		$problems = 0;
+		if ($unmarked > 0) {
+			$problems++;
+			$this->output(
+				"::error file=$reportFile::$unmarked translation unit(s) have no <!--T:n--> marker;"
+				. " run translate mark\n"
+			);
+		}
+		// The two readings agreeing is what makes every check below it mean anything: a unit only
+		// wikven sees is never translated on the wiki, and one only Translate sees is never gated.
+		$wikven = array_values(array_diff(
+			array_map('strval', array_keys(StalenessComputer::sourceUnits($sourceText))),
+			[StalenessComputer::TITLE_UNIT_ID]
+		));
+		if ($wikven !== $ids) {
+			$problems++;
+			$this->output(
+				"::error file=$reportFile::Translate reads units "
+				. ( $ids ? implode(', ', $ids) : '(none)' )
+				. ' where wikven reads '
+				. ( $wikven ? implode(', ', $wikven) : '(none)' )
+				. "\n"
+			);
+		}
+		return $problems;
+	}
+}

--- a/tests/phpunit/integration/TranslationSourceTest.php
+++ b/tests/phpunit/integration/TranslationSourceTest.php
@@ -21,22 +21,22 @@ class TranslationSourceTest extends MediaWikiIntegrationTestCase {
 	public static function provideIsTranslatable(): array {
 		return [
 			'a real translate block' => ["<languages/>\n<translate>\n<!--T:1-->\nHi.\n</translate>", true],
-			// Translate accepts attributes on the tag.
+			// containsMarkup() matches any translate tag, so nowrap is one it offers for marking.
 			'a translate block with an attribute' => [
 				"<languages/>\n<translate nowrap>\n<!--T:1-->\nHi.\n</translate>",
 				true
 			],
 			'a tag that merely starts the same way' => ['<translatex>Hi.</translatex>', false],
 			'plain text' => ['Just prose, no markup.', false],
-			// The page documenting page translation shows <translate> as an example; it is not a source.
+			// Translate's parser hook runs on raw wikitext, so only <nowiki> hides a tag from it.
 			'translate inside syntaxhighlight' => [
 				"x\n<syntaxhighlight>\n<translate>\n<!--T:1-->\nBody\n</translate>\n</syntaxhighlight>",
-				false
+				true
 			],
 			'translate inside nowiki' => ['Wrap it in <code><nowiki><translate></nowiki></code>.', false],
-			'translate inside pre' => ['<pre><translate>example</translate></pre>', false],
-			'a real block alongside an example' => [
-				"<translate>Real</translate>\n<syntaxhighlight><translate>x</translate></syntaxhighlight>",
+			'translate inside pre' => ['<pre><translate>example</translate></pre>', true],
+			'a real block beside one shown in nowiki' => [
+				"<translate>Real</translate>\n<nowiki><translate>x</translate></nowiki>",
 				true
 			]
 		];

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -214,7 +214,7 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 
 	public function testASourceBlockInsideACodeExampleStillCounts() {
 		// Translate's parser hook runs before <syntaxhighlight> is stripped, so a whole pair written
-		// there is one it parses. Reading it as an example is what used to disagree with the engine.
+		// there is one it parses.
 		$text = "<syntaxhighlight>\n<translate>\n<!--T:1-->\nBody\n</translate>\n</syntaxhighlight>";
 		$this->assertSame([1], array_keys(StalenessComputer::sourceUnits($text)));
 	}
@@ -239,8 +239,7 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 	}
 
 	public function testMarkNumbersABlockShownInACodeExample() {
-		// Translate would number it, so wikven does too; leaving it alone is what let the wiki copy
-		// and the source file drift apart.
+		// Translate numbers it and saves the result back to the wiki, so wikven must number it too.
 		$example = "<syntaxhighlight>\n<translate>\nExample.\n</translate>\n</syntaxhighlight>";
 		$this->assertSame(
 			"<translate>\n<!--T:1-->\nReal.\n</translate>\n\n"
@@ -255,6 +254,29 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 			"<translate>\n<!--T:1-->\nReal.\n</translate>\n<nowiki><translate>\nShown.\n</translate></nowiki>",
 			StalenessComputer::mark($text)
 		);
+	}
+
+	public function testAnUnclosedCodeTagDoesNotStopLaterBlocksBeingRead() {
+		// Only <nowiki> armours anything for Translate, so an unclosed <pre> earlier on the page leaves
+		// every later block, and every marker in one, exactly as real.
+		$text = "<pre>\n<translate>\nShown.\n</translate>\n<translate>\n<!--T:4-->\nReal.\n</translate>";
+		$this->assertSame([4], array_keys(StalenessComputer::sourceUnits($text)));
+		$this->assertStringEndsWith(
+			"<translate>\n<!--T:4-->\nReal.\n</translate>",
+			StalenessComputer::mark($text)
+		);
+	}
+
+	public function testSourceUnitsSpanSeveralBlocksAndIgnoreMarkersBetweenThem() {
+		// Each block contributes its own units; a marker written between two of them belongs to
+		// neither, so the numbering of the real ones is untouched.
+		$text =
+			"<translate>\n<!--T:1-->\nOne.\n</translate>\n"
+			. "<pre>\n<!--T:8-->\nExample.\n</pre>\n"
+			. "<translate>\n<!--T:2-->\nTwo.\n</translate>\n"
+			. "<nowiki><!--T:9--></nowiki>\n"
+			. "<translate>\n<!--T:3-->\nThree.\n</translate>";
+		$this->assertSame([1, 2, 3], array_keys(StalenessComputer::sourceUnits($text)));
 	}
 
 	public function testAnalyzeIgnoresAnExampleMarkerInACodeBlock() {
@@ -333,7 +355,7 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 		// An HTML comment is inert to MediaWiki's parser, so a tag name it merely mentions -- as a
 		// reviewer note might -- must not read as a real, unclosed opener; that would otherwise run
 		// to the end of the page and hide every later unit.
-		$text = "<!--T:1-->\n하나.\n" . "<!-- reviewer: do not wrap this in <nowiki> -->\n" . "<!--T:2-->\n둘.";
+		$text = "<!--T:1-->\n하나.\n<!-- reviewer: do not wrap this in <nowiki> -->\n<!--T:2-->\n둘.";
 		$this->assertSame([1, 2], array_keys(StalenessComputer::translationUnits($text)));
 	}
 }

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -203,24 +203,57 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 		);
 	}
 
-	public function testSplitUnitsIgnoresMarkersShownInsideACodeExample() {
-		// The page documenting page translation shows <!--T:n--> markers in code examples; those are
-		// not real units, so a marker inside a verbatim span never becomes one.
+	public function testASourceMarkerOutsideEveryBlockIsNotAUnit() {
+		// Translate reads markers only inside a <translate> block, so one shown in a code example --
+		// as the page documenting page translation does -- is prose wherever it sits.
 		$text =
 			"<translate>\n<!--T:1-->\nReal.\n</translate>\n\n"
 			. "<syntaxhighlight lang=\"wikitext\">\n<!--T:2-->\nExample.\n</syntaxhighlight>";
-		$this->assertSame([1], array_keys(StalenessComputer::splitUnits($text)));
+		$this->assertSame([1], array_keys(StalenessComputer::sourceUnits($text)));
 	}
 
-	public function testMarkLeavesATranslatePairShownInsideACodeExampleUntouched() {
-		// A <translate>...</translate> pair inside a code example must be copied verbatim, and the
-		// <!--T:1--> it contains must not push the real unit's number along.
-		$example =
-			"<syntaxhighlight lang=\"wikitext\">\n"
-			. "<translate>\n<!--T:1-->\nExample.\n</translate>\n</syntaxhighlight>";
+	public function testASourceBlockInsideACodeExampleStillCounts() {
+		// Translate's parser hook runs before <syntaxhighlight> is stripped, so a whole pair written
+		// there is one it parses. Reading it as an example is what used to disagree with the engine.
+		$text = "<syntaxhighlight>\n<translate>\n<!--T:1-->\nBody\n</translate>\n</syntaxhighlight>";
+		$this->assertSame([1], array_keys(StalenessComputer::sourceUnits($text)));
+	}
+
+	public function testNowikiInsideABlockHidesNothing() {
+		// parse() unarmours a block's contents before segmenting them, so <nowiki> shelters a marker
+		// from the block scan but not from the unit scan. Translate rejects the page; wikven must see
+		// the same two units for the check to be able to say so.
+		$text = "<translate>\n<!--T:1-->\nUse <nowiki><!--T:9--></nowiki> here.\n</translate>";
+		$this->assertSame([1, 9], array_keys(StalenessComputer::sourceUnits($text)));
+	}
+
+	public function testAWholeBlockArmouredByNowikiIsInvisible() {
+		// armourNowiki() runs before the block scan, so a pair shown in <nowiki> is no block at all --
+		// and its <!--T:1--> must not shadow the real unit 1, which the body assertion is what catches.
+		$text =
+			"<translate>\n<!--T:1-->\nReal.\n</translate>\n"
+			. "<nowiki><translate>\n<!--T:1-->\nShown.\n</translate></nowiki>";
+		$units = StalenessComputer::sourceUnits($text);
+		$this->assertSame([1], array_keys($units));
+		$this->assertStringStartsWith("\nReal.\n", $units[1]['text']);
+	}
+
+	public function testMarkNumbersABlockShownInACodeExample() {
+		// Translate would number it, so wikven does too; leaving it alone is what let the wiki copy
+		// and the source file drift apart.
+		$example = "<syntaxhighlight>\n<translate>\nExample.\n</translate>\n</syntaxhighlight>";
 		$this->assertSame(
-			"<translate>\n<!--T:1-->\nReal.\n</translate>\n\n" . $example,
+			"<translate>\n<!--T:1-->\nReal.\n</translate>\n\n"
+			. "<syntaxhighlight>\n<translate>\n<!--T:2-->\nExample.\n</translate>\n</syntaxhighlight>",
 			StalenessComputer::mark("<translate>\nReal.\n</translate>\n\n" . $example)
+		);
+	}
+
+	public function testMarkLeavesABlockArmouredByNowikiAlone() {
+		$text = "<translate>\nReal.\n</translate>\n<nowiki><translate>\nShown.\n</translate></nowiki>";
+		$this->assertSame(
+			"<translate>\n<!--T:1-->\nReal.\n</translate>\n<nowiki><translate>\nShown.\n</translate></nowiki>",
+			StalenessComputer::mark($text)
 		);
 	}
 
@@ -235,16 +268,25 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 		);
 	}
 
+	public function testRestampLeavesAMarkerTheTranslationMerelyShowsAlone() {
+		// Stamping one would edit the sentence around it whenever its id matched a real unit.
+		$source = "<translate>\n<!--T:1-->\nHello.\n</translate>";
+		$translation = "<!--T:1-->\n안녕.\n\n<code><nowiki><!--T:1--></nowiki></code> 표시자.";
+		$this->assertStringEndsWith(
+			'<code><nowiki><!--T:1--></nowiki></code> 표시자.',
+			StalenessComputer::restamp($source, $translation)
+		);
+	}
+
 	/**
-	 * Every verbatim tag hides a marker, not just the ones the docs happen to use. <nowiki> matters
-	 * most: it is the only span Translate's own parser armours, so it is what the Translating page
-	 * wraps its examples in.
+	 * A translation file carries bare markers and no <translate> block, so it is wikven's own format:
+	 * every verbatim tag hides a marker there, not just the <nowiki> Translate armours.
 	 *
 	 * @dataProvider provideVerbatimTags
 	 */
-	public function testSplitUnitsIgnoresMarkersInsideEveryVerbatimTag(string $example) {
-		$text = "<translate>\n<!--T:1-->\nReal.\n</translate>\n\n" . $example;
-		$this->assertSame([1], array_keys(StalenessComputer::splitUnits($text)));
+	public function testTranslationUnitsIgnoreMarkersInsideEveryVerbatimTag(string $example) {
+		$text = "<!--T:1-->\n안녕.\n\n" . $example;
+		$this->assertSame([1], array_keys(StalenessComputer::translationUnits($text)));
 	}
 
 	public static function provideVerbatimTags(): array {
@@ -260,23 +302,12 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 		];
 	}
 
-	public function testSplitUnitsIgnoresMarkersAcrossSeveralVerbatimRegions() {
-		// Each verbatim span is skipped independently, and real units between them still count.
-		$text =
-			"<translate>\n<!--T:1-->\nOne.\n</translate>\n"
-			. "<pre>\n<!--T:8-->\nExample.\n</pre>\n"
-			. "<translate>\n<!--T:2-->\nTwo.\n</translate>\n"
-			. "<nowiki><!--T:9--></nowiki>\n"
-			. "<translate>\n<!--T:3-->\nThree.\n</translate>";
-		$this->assertSame([1, 2, 3], array_keys(StalenessComputer::splitUnits($text)));
-	}
-
-	public function testAnUnclosedVerbatimTagRunsToTheEndOfThePage() {
+	public function testAnUnclosedVerbatimTagRunsToTheEndOfATranslation() {
 		// MediaWiki renders an unclosed <nowiki> as verbatim to the end of the page, and reading it
 		// that way is the safer failure mode: the text after it stays examples rather than becoming
 		// counted units.
-		$text = "<translate>\n<!--T:1-->\nReal.\n</translate>\n<nowiki>\n<!--T:2-->\nStill an example.";
-		$this->assertSame([1], array_keys(StalenessComputer::splitUnits($text)));
+		$text = "<!--T:1-->\n안녕.\n<nowiki>\n<!--T:2-->\nStill an example.";
+		$this->assertSame([1], array_keys(StalenessComputer::translationUnits($text)));
 	}
 
 	/**
@@ -286,9 +317,8 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 	 * @dataProvider provideSelfContainedVerbatim
 	 */
 	public function testAClosedVerbatimSpanDoesNotSwallowLaterUnits(string $span) {
-		$text =
-			"<translate>\n<!--T:1-->\nOne.\n</translate>\n" . $span . "\n<translate>\n<!--T:2-->\nTwo.\n</translate>";
-		$this->assertSame([1, 2], array_keys(StalenessComputer::splitUnits($text)));
+		$text = "<!--T:1-->\n하나.\n" . $span . "\n<!--T:2-->\n둘.";
+		$this->assertSame([1, 2], array_keys(StalenessComputer::translationUnits($text)));
 	}
 
 	public static function provideSelfContainedVerbatim(): array {
@@ -302,20 +332,8 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 	public function testACommentMerelyMentioningAVerbatimTagDoesNotSwallowLaterUnits() {
 		// An HTML comment is inert to MediaWiki's parser, so a tag name it merely mentions -- as a
 		// reviewer note might -- must not read as a real, unclosed opener; that would otherwise run
-		// to the end of the page and hide the second <translate> block entirely.
-		$text =
-			"<translate>\n<!--T:1-->\nOne.\n</translate>\n"
-			. "<!-- reviewer: do not wrap this in <nowiki> -->\n"
-			. "<translate>\n<!--T:2-->\nTwo.\n</translate>";
-		$this->assertSame([1, 2], array_keys(StalenessComputer::splitUnits($text)));
-	}
-
-	public function testMarkIgnoresATranslatePairAfterAnUnclosedVerbatimTag() {
-		// The same rule applies to marking: nothing after the unclosed tag is numbered.
-		$text = "<translate>\nReal.\n</translate>\n<pre>\n<translate>\nExample.\n</translate>";
-		$this->assertSame(
-			"<translate>\n<!--T:1-->\nReal.\n</translate>\n<pre>\n<translate>\nExample.\n</translate>",
-			StalenessComputer::mark($text)
-		);
+		// to the end of the page and hide every later unit.
+		$text = "<!--T:1-->\n하나.\n" . "<!-- reviewer: do not wrap this in <nowiki> -->\n" . "<!--T:2-->\n둘.";
+		$this->assertSame([1, 2], array_keys(StalenessComputer::translationUnits($text)));
 	}
 }


### PR DESCRIPTION
wikven read a `<!--T:n-->` as a unit anywhere outside a verbatim tag. Translate reads one only inside a `<translate>` block, and armours `<nowiki>` *before* it looks for a block rather than after. The two disagreed in both directions:

- a marker shown in a code example **outside** every block became a unit Translate never creates — `scaffold` emitted it, `check --gate` chased it, `loadTranslations` wrote `Translations:<Page>/n/<lang>` pages that do not exist;
- a block written **inside** `<syntaxhighlight>` was ignored, although Translate parses it, numbers it, and saves the rewritten text back to the wiki — where wikven then never writes it to the source file, so the two copies drift apart permanently.

## The split

Source pages go by blocks; translation files keep the verbatim rule. A translation carries bare markers and no `<translate>` block, Translate never parses one, so that rule is wikven's own — and `docs/Translating/ko.wikitext` depends on it: without the carve-out its `<nowiki><!--T:n--></nowiki>` becomes a phantom unit `"n"` that `analyze()` reports as an orphan and `--gate` fails on.

`splitUnits()` becomes `sourcePageUnits()` and `translationUnits()` over one body-builder, so a call site has to say which kind of file it is holding. A boolean parameter would have read as nothing at the call site, which is how the single behaviour reached both sides unnoticed.

`blockRanges()` masks `<nowiki>` spans with a same-length filler before scanning, mirroring `parse()` → `armourNowiki()`. That reproduces both halves of the asymmetry: a whole pair shown in `<nowiki>` disappears, while a `<nowiki>` merely *inside* a block still yields its markers, because Translate unarmours a block's contents before segmenting them.

## Also in here

- **A page Translate cannot parse used to end the whole bake.** `getMarkOperation()` throws `ParsingFailure` uncaught. An unclosed `<translate>` shown in a code example — the most ordinary thing a page about page translation does — would abort everything. Now reported and skipped.
- **`checkTranslations` reads every source page with Translate's own parser**, and reports a parse failure, unmarked units, and any id set the two readings disagree on. wikven cannot detect `pt-shake-multiple` or `pt-shake-empty` itself without becoming a second engine to keep in sync; calling `parse()` gets them for free and stays right when Translate changes them. This is also the standing assertion that the parity above holds, evaluated on every PR.
- **`restamp()` gains the verbatim skip it never had.** It rewrote any marker it matched, so a translation quoting `<!--T:1-->` in prose had that sentence silently edited. Only the id in `docs/Translating/ko.wikitext` being `n` rather than a number kept it from firing.
- `hasFixedDisplayTitle()` keeps all four tags and is otherwise unchanged; only its inline array moves to a named constant. Narrowing it was tried and reverted: the docs site loads SyntaxHighlight, so there a `{{DISPLAYTITLE:}}` shown in one genuinely does not run, and reading it as verbatim is right.

## Verified by execution

- **All 84 `docs/**/*.wikitext` compared against `main`: identical unit ids, identical unit body hashes, and `mark()` a byte-for-byte no-op on every source page.** Body hashes matter — an earlier draft of `blockRanges()` without the armour left the ids unchanged while `Translating.wikitext`'s real units 1 and 2 were overwritten by its `<nowiki>` examples. An ids-only check passes that.
- The four intended changes, against the real class: marker outside a block `[1,2]`→`[1]`; block in `<syntaxhighlight>` `[]`→`[1]`; `<nowiki>` inside a block `[1]`→`[1,9]`; armoured pair invisible with unit 1's body intact.
- The whole rewritten test class — 51 assertions including every pre-existing one — run against the real implementation with a small harness, 0 failures.
- `phpcs`, `mago format --check`, `mago lint`, `minus-x`, `php -l`.

**Not verified:** PHPUnit is not installed outside the image, so the assertions were executed but the PHPUnit *harness* integration was not; `TranslationSourceTest` needs MediaWiki and did not run at all. No bake. CI is the first run for all three.

## Left out

Two follow-ups this raised, both filed rather than folded in: #374 (`translate check` never runs in this repo, so the new skip has no reporter here) and #375 (a translation file quoting `<translate>` would be read as a base page — the route predates this, which widens it).

A unit's body still runs past `</translate>` to the next marker, so `Translating.wikitext` T:3's hash includes the YAML example after it — editing that YAML stales the Korean although Translate considers the unit unchanged. That is a third divergence, and bounding bodies at the block end would restamp every translation in the tree. Separate change.

---
_Generated by [Claude Code](https://claude.ai/code)_

