### PR TITLE
docs: bring the Korean translations back up to date

### DIFF
--- a/docs/Configuration/ko.wikitext
+++ b/docs/Configuration/ko.wikitext
@@ -7,7 +7,7 @@
 <!--T:2 @e64b166b-->
 파일 이름은 유연합니다. Wikven은 <code>.wikven.yaml</code>, <code>.wikven.yml</code>, <code>.wikven.json</code>과 앞에 점이 없는 같은 세 가지(<code>wikven.yaml</code>, <code>wikven.yml</code>, <code>wikven.json</code>)를 받아들이며, <code>.json</code> 형식은 YAML이 JSON의 상위 집합이므로 같은 구조를 씁니다. 여러 개가 있으면 그 순서대로 첫 번째가 우선하고 나머지는 경고와 함께 무시되므로, 점이 붙은 이름이 평범한 이름보다 우선하고, YAML이 JSON보다, <code>.yaml</code>이 <code>.yml</code>보다 우선합니다.
 
-<!--T:3 @73322bef-->
+<!--T:3 @7d110a4b-->
 Wikven은 자체 기본값(정적 위키를 위한 합리적인 MediaWiki 설정)을 제공하며 그 위에 여러분의 파일을 얹어 읽으므로, 여기서 설정한 것은 무엇이든 기본값을 덮어씁니다. 기본값은 이와 같은 형식을 쓰는 <code>default.yml</code>에 들어 있습니다. 아래 [[#기본값|기본값]]을 참고하십시오.
 
 <!--T:4 @825f9096-->

--- a/docs/Deploying/ko.wikitext
+++ b/docs/Deploying/ko.wikitext
@@ -7,8 +7,8 @@
 <!--T:2 @2f0b756f-->
 == GitHub Pages ==
 
-<!--T:3 @3be77948-->
-이 워크플로는 푸시할 때마다 사이트를 다시 빌드하고 게시합니다. {{SITENAME}} [https://github.com/chaotic-ground/wikven/tree/main/action 복합 액션]으로 소스를 빌드한 뒤 <code>dist/</code>를 Pages에 업로드합니다. 액션은 태그가 아니라 전체 커밋 SHA로 고정되어 있어, 태그가 옮겨지더라도 몰래 바꿔치기될 수 없습니다:
+<!--T:3 @9c12d1e1-->
+이 워크플로는 푸시할 때마다 사이트를 다시 빌드하고 게시합니다. {{SITENAME}} [https://github.com/chaotic-ground/wikven/tree/main/action 복합 액션]으로 소스를 빌드한 뒤 <code>dist/</code>를 Pages에 업로드합니다.
 
 <!--T:4 @cec23135-->
 저장소의 '''Settings → Pages → Build and deployment → Source: GitHub Actions'''에서 Pages를 활성화하세요. 이 문서 사이트도 이렇게 게시됩니다.

--- a/docs/Development/ko.wikitext
+++ b/docs/Development/ko.wikitext
@@ -93,11 +93,11 @@
 <!--T:22 @9c7c0fee-->
 == 지속적 통합 ==
 
-<!--T:23 @89a2af99-->
+<!--T:23 @46577bba-->
 * <code>lint.yml</code>은 포매터와 린터(Biome, mago, rumdl, taplo, typos, yamllint, zizmor, phpcs)를 실행합니다.
-* <code>docker-build.yml</code>은 이미지를 빌드하고 <code>main</code>에서 <code>ghcr.io/chaotic-ground/wikven</code>에 게시합니다.
+* <code>docker-image.yml</code>은 이미지를 빌드하고 <code>main</code>에서 <code>ghcr.io/chaotic-ground/wikven</code>에 게시합니다.
 * <code>deploy-docs.yml</code>은 이미지로 <code>docs/</code> 디렉터리를 빌드하고 그 결과를 GitHub Pages에 배포하므로, 이 사이트 자체가 하나의 {{SITENAME}} 빌드입니다.
-* <code>build-binary.yml</code>은 각 플랫폼용 단독 실행 [[$1|바이너리]]를 빌드하는 재사용 가능한 워크플로입니다. <code>release-please.yml</code>이 이를 호출하여 버전 릴리스에 바이너리를 첨부하고, <code>nightly.yml</code>이 매일 이를 호출하여 날짜가 붙은 <code>nightly-YYYY-MM-DD</code> 프리릴리스를 게시합니다. 둘 다 릴리스를 초안으로 만들고, 바이너리를 첨부한 다음 게시하는데, GitHub의 불변 릴리스는 릴리스가 게시되고 나면 자산을 잠그기 때문입니다.
+* <code>binary.yml</code>은 단독 실행 [[$1|바이너리]]를 빌드합니다. 해당 파일을 건드리는 풀 리퀘스트에서, 그리고 릴리스 때는 각 플랫폼용으로 실행됩니다. <code>release-please.yml</code>이 이를 호출하여 버전 릴리스에 바이너리를 첨부하고, <code>nightly.yml</code>이 매일 이를 호출하여 날짜가 붙은 <code>nightly-YYYY-MM-DD</code> 프리릴리스를 게시합니다. 둘 다 릴리스를 초안으로 만들고, 바이너리를 첨부한 다음 게시하는데, GitHub의 불변 릴리스는 릴리스가 게시되고 나면 자산을 잠그기 때문입니다.
 
 <!--T:24 @b9edc4cf-->
 버전은 [https://www.conventionalcommits.org/ Conventional Commits]를 따르며, release-please가 이를 사용해 변경 로그를 생성하고 버전을 올립니다.

--- a/docs/Skins/ko.wikitext
+++ b/docs/Skins/ko.wikitext
@@ -4,29 +4,31 @@
 <!--T:1 @acd93a69-->
 {{ml|Bundled extensions and skins|번들된 스킨}}은 [[$1|.wikven.yaml]]에서 고를 수 있습니다.
 
-<!--T:2 @09b81e9f-->
-== 사용할 수 있는 스킨 ==
+<!--T:2 @83da4e91-->
+== 지원하는 스킨 ==
 
-<!--T:3 @d959129e-->
-MediaWiki에 번들된 스킨을 사용할 수 있습니다. <code>Vector</code>를 선택하면 Vector 2022(해당 스킨의 <code>vector-2022</code> 변형)가 적용됩니다.
+<!--T:3 @37596812-->
+Wikven은 세 가지 스킨을 지원합니다. 이 문서 사이트는 세 스킨 모두로 빌드되므로, 모든 변경이 각 스킨에서 검증됩니다.
 
-<!--T:4 @94ebf3cb-->
-* {{ml|Skin:Vector|Vector}} (기본값)
-* {{ml|Skin:Timeless|Timeless}}
-* {{ml|Skin:MonoBook|MonoBook}}
+<!--T:4 @edf885f8-->
+* {{ml|Skin:Vector|Vector}} (기본값. <code>Vector</code>를 선택하면 해당 스킨의 <code>vector-2022</code> 변형인 Vector 2022가 적용됩니다)
 * {{ml|Skin:MinervaNeue|MinervaNeue}} (모바일 지향)
+* {{ml|Skin:Citizen|Citizen}} (서드파티, 빌드 시점에 가져옴)
+
+<!--T:11 @b34d3fdc-->
+그 밖의 스킨은 거부되는 것이 아니라 검증되지 않을 뿐입니다. MediaWiki에 번들된 스킨은 MonoBook을 비롯해 모두 이름만으로 사용할 수 있고, 서드파티 스킨은 Citizen처럼 가져올 수 있습니다.
 
 <!--T:5 @1c58d369-->
 == 스킨 설정 ==
 
-<!--T:6 @9c238db2-->
+<!--T:6 @d8d5197c-->
 <code>skins</code>를 설정하여 스킨을 바꿀 수 있습니다. 목록의 첫 번째 스킨이 기본값으로 사용됩니다.
 
 <!--T:7 @bf282a4e-->
 == 서드파티 스킨 ==
 
-<!--T:8 @41deb027-->
-번들되지 않은 스킨도 <code>skins</code>에 나열할 수 있으며, 그 소스는 [[$1|<code>WikvenRepositories</code>]]에 선언합니다. 이 스킨은 빌드 시점에 가져와지며 다른 스킨과 마찬가지로 기본값이 될 수 있습니다. 이 문서 사이트는 이런 방식으로 서드파티 [https://www.mediawiki.org/wiki/Skin:Citizen Citizen] 스킨을 가져와, 바닥글의 스킨 전환기를 통해 Vector와 함께 제공합니다.
+<!--T:8 @20719aa9-->
+번들되지 않은 스킨도 <code>skins</code>에 나열할 수 있으며, 그 소스는 [[$1|<code>WikvenRepositories</code>]]에 선언합니다. 이 스킨은 빌드 시점에 가져와지며 다른 스킨과 마찬가지로 기본값이 될 수 있습니다. 이 문서 사이트는 이런 방식으로 Citizen을 가져와 나머지 두 스킨과 함께 제공합니다.
 
 <!--T:9 @2d358941-->
 == 스킨별 설정 ==

--- a/docs/Translating/ko.wikitext
+++ b/docs/Translating/ko.wikitext
@@ -10,8 +10,8 @@
 <!--T:3 @fb88aa9b-->
 [[$1|<code>.wikven.yaml</code>]]의 <code>extensions</code>에 <code>Translate</code>를 추가하고, Translate가 의존하는 <code>UniversalLanguageSelector</code>도 함께 추가합니다. 둘 다 {{SITENAME}} 이미지에 번들되어 있으므로 설치할 것은 없습니다.
 
-<!--T:4 @b79a448f-->
-정적 내보내기는 UniversalLanguageSelector의 런타임 웹폰트(라이브 엔드포인트에서 불러옴)를 제공할 수 없으므로 {{SITENAME}}은 이를 끕니다. 독자는 각 문자를 자신의 시스템 글꼴로 보게 됩니다.
+<!--T:4 @4641fec3-->
+정적 내보내기는 UniversalLanguageSelector의 런타임 웹폰트(라이브 엔드포인트에서 불러옴)를 제공할 수 없으므로, {{SITENAME}}은 기본적으로 이를 끄고 독자는 각 문자를 자신의 시스템 글꼴로 보게 됩니다. 대신 <code>WikvenBundleWebfonts</code>를 설정하면 글꼴을 사이트에 구워 넣으므로, 어떤 문자의 글꼴이 없는 시스템의 독자도 의도한 서체를 볼 수 있습니다.
 
 <!--T:5 @4bb4feb7-->
 번역할 언어를 나열하지 않습니다. Translate 자체와 마찬가지로, 어떤 언어의 번역이 존재하는 순간 그 언어가 존재하게 됩니다. 문서를 작성하는 언어는 원본 언어로 유지됩니다.


### PR DESCRIPTION
A full scan of `docs/` found ten units behind. This brings them level: **stale 0, untranslated 0, orphan 0, ok 263.**

| Page | Unit | What moved |
| --- | --- | --- |
| `Skins` | T:2, T:3, T:4, T:8 | the skin list and its prose, from the supported-skins work |
| `Skins` | T:11 | new unit, had no Korean at all |
| `Development` | T:23 | `docker-build.yml` → `docker-image.yml`, `build-binary.yml` → `binary.yml`, and the binary workflow's trigger description |
| `Translating` | T:4 | the source gained a sentence about `WikvenBundleWebfonts` |
| `Deploying` | T:3 | the source dropped a sentence about SHA pinning; the Korean still carried it |
| `Configuration` | T:3, `Skins` T:6 | **prose untouched** — only the adjacent code example changed |

Those last two are stamped rather than rewritten. A unit's hash covers the code block that follows it, so changing `skins: - MonoBook` to `skins: - MinervaNeue` staled units whose Korean did not need a word altered. Restamping there is the honest thing: it asserts the translation is current, which it is. Rewriting anything would have been noise, and leaving them stale would have sent a translator to review a diff with nothing in it for them.

## How the scan was done

`maintenance/checkTranslations.php` does exactly this and has a `--gate` flag, but it needs a MediaWiki bootstrap, so it was reproduced by driving `StalenessComputer` and `TranslationSource` directly — the same classes it uses. The only stand-in was `Parser::extractTagsAndParams`, which those classes call to blank verbatim spans before looking for a real `<translate>` tag.

**Worth knowing separately: `checkTranslations.php` is referenced by no workflow.** The gate exists and nothing runs it, which is why ten units accumulated unnoticed. Three of them came from Dependabot SHA bumps landing inside example workflows — changes with nothing in them for a translator, which the hash span swallowed anyway.

## Verification

The report was re-run after the edits and returns `every unit is up to date`. Nothing outside `docs/*/ko.wikitext` is touched, and no source page changed, so no other translation is affected.

**The Korean is mine and has not been reviewed by another speaker.** It follows the register and terminology already in these files (번들된, 빌드 시점, 바닥글), but it is worth a read before this leaves draft.

---
_Generated by [Claude Code](https://claude.ai/code)_