### PR TITLE
ci: run the translation check on this repository's own docs

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,48 @@
+---
+name: Translations
+
+# Report out-of-date and missing translations in this repository's own docs, and dogfood the
+# composite action that does it: nothing else in continuous integration runs that action.
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'actions/check-translations/**'
+      - 'includes/PageTranslation/**'
+      - 'maintenance/checkTranslations.php'
+      - 'bin/entrypoint'
+      - '.github/workflows/translations.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-translations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+      # Reader only; docker-image.yml exports this cache. See the note in smoke.yml.
+      - name: Build and load this pull request's image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          load: true
+          tags: wikven
+          cache-from: type=gha,scope=wikven-image
+
+      - name: Check the docs translations
+        uses: ./actions/check-translations
+        with:
+          source: docs
+          image: wikven
+          cache: false  # the image was just built locally; nothing to cache or pull
+          gate: false  # translating is not the job of whoever edits the English source

--- a/docs/Translating.wikitext
+++ b/docs/Translating.wikitext
@@ -168,7 +168,7 @@ $ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven tra
 
 <translate>
 <!--T:21-->
-A companion GitHub Action runs the same check on pull requests. To bring a translation back up to date, edit it to match the new source, then <code>translate stamp</code> it again.
+The [https://github.com/chaotic-ground/wikven/tree/main/actions/check-translations check-translations action] runs the same check on pull requests, reporting each one as an annotation on the file it belongs to. It only reports; pass <code>gate: true</code> to fail the build instead. This documentation site is checked this way. To bring a translation back up to date, edit it to match the new source, then <code>translate stamp</code> it again.
 </translate>
 
 {{prevnext|Searching|Deploying}}


### PR DESCRIPTION
The `check-translations` action shipped in #150 has never run anywhere. No workflow used it, no page named it, and release-please was not even stamping its image pin until #359 fixed that. Meanwhile `Translating.wikitext` already told readers "A companion GitHub Action runs the same check on pull requests", which was true of nothing.

A `Translations` workflow now runs it against this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)'s own `docs/`, on pull requests that touch the translations or the code behind them. It builds the image from the pull request and passes `image: wikven, cache: false`, the same dogfooding shape `pr-preview` uses for the bake action, so the action is exercised against the code under review rather than against a published tag.

`gate: false`, deliberately. A stale translation shows up as an annotation on the file it belongs to and never blocks a merge: whoever edits the English source is not responsible for the other languages, and the fuzzy marker in the built site is already the signal to the reader.

The docs sentence now names the action, links it, and says which way `gate` points.

This pull request is its own test case. It touches `docs/`, so the new workflow runs on it, and `docs/Deploying/ko.wikitext` went stale in #359 and has not been retranslated, so the run should annotate that file rather than come back silent. If it reports nothing, the wiring is wrong.

I could not run it locally: `ghcr.io/chaotic-ground/wikven` returns 403 to an anonymous pull, and building the image from cold here is not a useful test of this change. `yamllint --strict .` passes.