### PR TITLE
fix: give the skin list its own section instead of renaming the toolbox

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -36,7 +36,6 @@
 	"Hooks": {
 		"ParserOutputPostCacheTransform": "hider",
 		"SkinTemplateNavigation::Universal": ["hider", "main"],
-		"MessageCacheFetchOverrides": "adder",
 		"SidebarBeforeOutput": ["hider", "adder"],
 		"SkinAddFooterLinks": "adder",
 		"BeforePageDisplay": "adder",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,7 +3,6 @@
 		"authors": []
 	},
 	"wikven-footer-source": "View project on $1",
-	"wikven-skins-label": "Skins",
 	"wikven-footer-source-plain": "View project source",
 	"wikven-version-intro": "This site is generated with the following open-source software."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,5 +4,6 @@
 	},
 	"wikven-footer-source": "View project on $1",
 	"wikven-footer-source-plain": "View project source",
-	"wikven-version-intro": "This site is generated with the following open-source software."
+	"wikven-version-intro": "This site is generated with the following open-source software.",
+	"wikven-skins": "Skins"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -3,7 +3,6 @@
 		"authors": []
 	},
 	"wikven-footer-source": "Footer link to the project's source repository. $1 is the repository host name (e.g. GitHub, GitLab) or a bare domain.",
-	"wikven-skins-label": "Heading of the toolbox, which a wikven export fills with the site's other skins and nothing else. Overrides {{msg-mw|toolbox}} and Vector 2022's own label for the same menu.",
 	"wikven-footer-source-plain": "Footer link to the project's source repository, used when no host can be derived from the URL.",
 	"wikven-version-intro": "Introductory sentence on the generated version page, which mirrors [[Special:Version]]."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -4,5 +4,6 @@
 	},
 	"wikven-footer-source": "Footer link to the project's source repository. $1 is the repository host name (e.g. GitHub, GitLab) or a bare domain.",
 	"wikven-footer-source-plain": "Footer link to the project's source repository, used when no host can be derived from the URL.",
-	"wikven-version-intro": "Introductory sentence on the generated version page, which mirrors [[Special:Version]]."
+	"wikven-version-intro": "Introductory sentence on the generated version page, which mirrors [[Special:Version]].",
+	"wikven-skins": "Heading of the sidebar section holding the export's other skins, used by skins that render their own sections in the page-tools menu. The section key is the message key."
 }

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -10,15 +10,8 @@ use MediaWiki\Title\Title;
 
 class Adder implements
 	\MediaWiki\Hook\BeforePageDisplayHook,
-	\MediaWiki\Language\Hook\MessageCacheFetchOverridesHook,
 	\MediaWiki\Hook\SidebarBeforeOutputHook,
 	\MediaWiki\Hook\SkinAddFooterLinksHook {
-	/**
-	 * Message keys for the toolbox heading. Core's is 'toolbox'; Vector 2022 ignores it and labels
-	 * the menu itself (VectorComponentPageTools::getMenus), so its own key is listed too.
-	 */
-	private const TOOLBOX_HEADING_KEYS = ['toolbox', 'vector-page-tools-general-label'];
-
 	/**
 	 * Skins whose toolbox is a page-actions menu: Minerva's builder keeps only entries carrying an
 	 * icon, and hands every one of those to SingleMenuEntry, whose $url is typed string -- so an
@@ -61,22 +54,6 @@ class Adder implements
 				$entry['active'] = true;
 			}
 			$sidebar['TOOLBOX']["wikven-skin-$target"] = $entry;
-		}
-	}
-
-	/**
-	 * Name the toolbox for what it holds. Hider empties it and the loop above refills it with
-	 * nothing but the skin list, so "Tools" (or Vector's "General") names a menu that no longer
-	 * exists; a reader would see two product names under a heading that explains neither.
-	 *
-	 * @inheritDoc
-	 */
-	public function onMessageCacheFetchOverrides(array &$keys): void {
-		if (count($GLOBALS['wgWikvenSkins'] ?? []) < 2) {
-			return;
-		}
-		foreach (self::TOOLBOX_HEADING_KEYS as $key) {
-			$keys[$key] = 'wikven-skins-label';
 		}
 	}
 

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -20,7 +20,21 @@ class Adder implements
 	private const PAGE_ACTIONS_TOOLBOX = ['minerva' => 'listBullet'];
 
 	/**
-	 * Offer each enabled skin's copy of this page in the toolbox, which Hider has just emptied.
+	 * Skins that move every sidebar section from the toolbox onward into their page-tools menu
+	 * (SkinVector22::extractPageToolsFromSidebar splices from the toolbox to the end), so a section
+	 * of our own lands there beside it, under a heading naming what it holds. Everywhere else the
+	 * skin list goes in the toolbox: Citizen splices the toolbox alone and Minerva reads no other
+	 * section, so a section of our own would leave their page-tools menus for the sidebar drawer,
+	 * or vanish.
+	 */
+	private const OWN_SECTION_SKINS = ['vector-2022'];
+
+	/** The sidebar section for the skin list, when it does not go in the toolbox. */
+	private const SECTION = 'wikven-skins';
+
+	/**
+	 * Offer each enabled skin's copy of this page, in the toolbox Hider has just emptied or in a
+	 * section of our own.
 	 *
 	 * The href is the same root-relative form every other link is written in ("./x" from the main
 	 * skin's output, "../x" from a skin subdirectory), so rename.php reparents these by the page's
@@ -41,6 +55,9 @@ class Adder implements
 		$page = Title::makeName($title->getNamespace(), $title->getDBkey()) . '.html';
 		$root = $current === $wgWikvenMainSkin ? './' : '../';
 		$icon = self::PAGE_ACTIONS_TOOLBOX[$current] ?? null;
+		// Appended, so it follows the toolbox: core drops SEARCH and LANGUAGES from the section
+		// list, leaving the toolbox last and this section right after it.
+		$section = in_array($current, self::OWN_SECTION_SKINS, true) ? self::SECTION : 'TOOLBOX';
 
 		foreach ($skins as $target) {
 			$entry = ['id' => "t-wikven-skin-$target", 'text' => $this->skinLabel($skin, $target)];
@@ -53,7 +70,7 @@ class Adder implements
 			if ($target === $current) {
 				$entry['active'] = true;
 			}
-			$sidebar['TOOLBOX']["wikven-skin-$target"] = $entry;
+			$sidebar[$section]["wikven-skin-$target"] = $entry;
 		}
 	}
 

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -27,7 +27,8 @@
 }
 
 // The skin the page is already rendered in: listed, marked, and not a link.
-.mw-portlet-tb .mw-list-item.active {
+.mw-portlet-tb .mw-list-item.active,
+.mw-portlet-wikven-skins .mw-list-item.active {
   font-weight: @font-weight-bold;
 }
 

--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -69,32 +69,6 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 		( new Adder() )->onBeforePageDisplay($out, $skin);
 	}
 
-	/**
-	 * The toolbox holds the skin list and nothing else, so its heading is renamed. Vector 2022
-	 * labels that menu with a key of its own, so core's key alone would leave it reading "General".
-	 */
-	public function testToolboxHeadingNamesTheSkinList() {
-		$this->overrideConfigValue('WikvenSkins', ['vector-2022', 'citizen']);
-
-		$keys = [];
-		( new Adder() )->onMessageCacheFetchOverrides($keys);
-
-		$this->assertSame(
-			['toolbox' => 'wikven-skins-label', 'vector-page-tools-general-label' => 'wikven-skins-label'],
-			$keys
-		);
-	}
-
-	/** One skin puts nothing in the toolbox, so the heading is left alone. */
-	public function testToolboxHeadingKeptForASingleSkin() {
-		$this->overrideConfigValue('WikvenSkins', ['vector-2022']);
-
-		$keys = [];
-		( new Adder() )->onMessageCacheFetchOverrides($keys);
-
-		$this->assertSame([], $keys);
-	}
-
 	private function skin(): Skin {
 		$skin = $this->createMock(Skin::class);
 		$skin->method('msg')->willReturnCallback(static function (string $key, ...$params) {

--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Wikven\Tests\Integration;
 use MediaWiki\Extension\Wikven\Hooks\Adder;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Skin\Skin;
+use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use Wikimedia\TestingAccessWrapper;
 
@@ -69,12 +70,59 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 		( new Adder() )->onBeforePageDisplay($out, $skin);
 	}
 
-	private function skin(): Skin {
+	/**
+	 * Vector moves every section from the toolbox onward into its page-tools menu, so the skin list
+	 * gets a section of its own there and the toolbox stays as Hider left it.
+	 */
+	public function testVectorGetsTheSkinListInItsOwnSection() {
+		$sidebar = $this->sidebarFor('vector-2022');
+
+		$this->assertSame([], $sidebar['TOOLBOX'], 'the toolbox is left empty');
+		$this->assertSame(
+			['wikven-skin-vector-2022', 'wikven-skin-citizen'],
+			array_keys($sidebar['wikven-skins'])
+		);
+		$this->assertSame(
+			'./citizen/Installation.html',
+			$sidebar['wikven-skins']['wikven-skin-citizen']['href']
+		);
+		$this->assertArrayNotHasKey('href', $sidebar['wikven-skins']['wikven-skin-vector-2022']);
+	}
+
+	/**
+	 * Every other skin keeps it in the toolbox: Citizen takes only the toolbox into its page-tools
+	 * menu and Minerva reads no other section, so a section of our own would not reach either.
+	 */
+	public function testOtherSkinsKeepTheSkinListInTheToolbox() {
+		$sidebar = $this->sidebarFor('citizen');
+
+		$this->assertArrayNotHasKey('wikven-skins', $sidebar);
+		$this->assertSame(
+			['wikven-skin-vector-2022', 'wikven-skin-citizen'],
+			array_keys($sidebar['TOOLBOX'])
+		);
+		$this->assertSame(
+			'../Installation.html',
+			$sidebar['TOOLBOX']['wikven-skin-vector-2022']['href']
+		);
+	}
+
+	/** The sidebar a two-skin export builds for one of them, on a page at the export root. */
+	private function sidebarFor(string $name): array {
+		$this->overrideConfigValue('WikvenSkins', ['vector-2022', 'citizen']);
+		$this->overrideConfigValue('WikvenMainSkin', 'vector-2022');
+		$sidebar = ['TOOLBOX' => []];
+		( new Adder() )->onSidebarBeforeOutput($this->skin($name), $sidebar);
+		return $sidebar;
+	}
+
+	private function skin(string $name = 'vector'): Skin {
 		$skin = $this->createMock(Skin::class);
 		$skin->method('msg')->willReturnCallback(static function (string $key, ...$params) {
 			return wfMessage($key, ...$params);
 		});
-		$skin->method('getSkinName')->willReturn('vector');
+		$skin->method('getSkinName')->willReturn($name);
+		$skin->method('getTitle')->willReturn(Title::makeTitle(NS_MAIN, 'Installation'));
 		return $skin;
 	}
 }


### PR DESCRIPTION
#351 named the toolbox after the skin list it fills, by overriding core's `toolbox` message and Vector's `vector-page-tools-general-label`. That was the wrong instrument, twice over, and this replaces it with the one MediaWiki already provides.

## What was wrong with the override

**It renamed more than a heading.** Vector labels its tab-row dropdown button with `msg( 'toolbox' )` (`SkinVector22.php:476`), so the button read "Skins". On the live site the panel became a "Skins" button over a "Tools" title over a "Skins" section.

**It assumed what the toolbox holds.** `Hider` empties it because everything `makeToolbox()` produces is unservable, and this extension refills it. That does not make the toolbox the skin list: a site whose own extensions put static-servable entries there would find them under a heading naming something else. The docs site has nothing else in its toolbox, which is what the change was verified against, and wikven cannot assume that of its users.

## What replaces it

A sidebar section of our own. Core turns any sidebar key into a portlet whose heading is the message of the same name (`SkinComponentMenu::getMenuLabel`, falling back to the key), so `$sidebar['wikven-skins']` renders as `p-wikven-skins` headed by `wikven-skins`. Nothing another skin owns is touched, and Vector's button stays "Tools":

```
[Tools ⌄]              tab-row button, msg( 'toolbox' )
  Tools                panel title, vector-page-tools-label
  Skins                our section, msg( 'wikven-skins' )
    Vector (2022)
    Citizen
    MinervaNeue
```

**Vector 2022 only.** `SkinVector22::extractPageToolsFromSidebar()` splices from the toolbox index to the end (`array_splice( $rest, $i )`, no length), so every section appended after the toolbox joins the page-tools menu. Core drops `SEARCH` and `LANGUAGES` from that list, which leaves the toolbox last and ours immediately after it.

The other two skins keep the toolbox, and nothing about them changes:

| skin | why |
| --- | --- |
| Citizen | splices the toolbox alone (`array_splice( $rest, $i, 1 )`), so a section of ours would leave the "More actions" card for the sidebar drawer |
| Minerva | reads only `$sidebar['navigation']` and `$sidebar['TOOLBOX']` (`SkinMinerva.php:149`, `MainMenuDirector.php:75`); every other section is dropped |

Vector's toolbox is then empty, and core hides an empty portlet, so no stray "General" heading is left behind. `ext.Wikven.emptyToolbox` still gates on the skin count and still applies to exactly the case it was written for: a single-skin export, where there is no list to show in any skin.

## Also

The `.active` rule marking the current skin gains the new portlet, since for Vector the entries are no longer inside `.mw-portlet-tb`.

Two tests cover the routing: the section a skin's entries land in, and the href written for a skin at the export root versus one in a subdirectory.
