### PR TITLE
ci: give manually dispatched Tofu runs a descriptive title

### DIFF
--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -1,10 +1,12 @@
 ---
 name: Tofu
 
-run-name: >-
-  ${{ github.event_name == 'workflow_dispatch'
-  && format('Tofu: manual run on {0} by @{1}', github.ref_name, github.actor)
-  || ' ' }}
+run-name: |-
+  ${{ case(
+    github.event_name == 'workflow_dispatch',
+    format('Tofu: manual run on {0} by @{1}', github.ref_name, github.actor),
+    ' '
+  ) }}
 
 on:
   pull_request:

--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -1,7 +1,6 @@
 ---
 name: Tofu
 
-# Manual runs get a descriptive title; other events keep GitHub's default (commit message, PR title).
 run-name: >-
   ${{ github.event_name == 'workflow_dispatch'
   && format('Tofu: manual run on {0} by @{1}', github.ref_name, github.actor)

--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -1,6 +1,12 @@
 ---
 name: Tofu
 
+# Manual runs get a descriptive title; other events keep GitHub's default (commit message, PR title).
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+  && format('Tofu: manual run on {0} by @{1}', github.ref_name, github.actor)
+  || ' ' }}
+
 on:
   pull_request:
     paths: &paths


### PR DESCRIPTION
A `workflow_dispatch` run of Tofu showed up in the Actions list as just "Tofu", so back-to-back manual runs were indistinguishable.

This adds a `run-name` that, for dispatch runs, reads `Tofu: manual run on <ref> by @<actor>`. For every other event the expression evaluates to a single space, and [GitHub falls back to the default run name](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#run-name) when `run-name` is only whitespace, so push and pull_request runs keep their commit message / PR title.

The value is written as a folded scalar to stay under the 120-column yamllint limit; it folds back into one expression line, verified with a YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPZHQvVJbkaP7bjZAxAUec