### PR TITLE
ci: express the binary matrix conditionals with case()

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -32,8 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ inputs.tag != '' && fromJSON('["x86_64", "aarch64"]') || fromJSON('["x86_64"]') }}
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+        arch: ${{ case(inputs.tag != '', fromJSON('["x86_64", "aarch64"]'), fromJSON('["x86_64"]')) }}
+    runs-on: ${{ case(matrix.arch == 'aarch64', 'ubuntu-24.04-arm', 'ubuntu-latest') }}
     permissions:
       contents: write  # gh release upload
       id-token: write  # sign the build provenance attestation
@@ -52,8 +52,8 @@ jobs:
           load: true
           tags: wikven
           # A pull request reads the layer cache the image build shares, and writes nothing back.
-          cache-from: type=gha,scope=wikven-image${{ inputs.tag != '' && format('-{0}', matrix.arch) || '' }}
-          cache-to: ${{ inputs.tag != '' && format('type=gha,mode=max,scope=wikven-image-{0}', matrix.arch) || '' }}
+          cache-from: type=gha,scope=wikven-image${{ case(inputs.tag != '', format('-{0}', matrix.arch), '') }}
+          cache-to: ${{ case(inputs.tag != '', format('type=gha,mode=max,scope=wikven-image-{0}', matrix.arch), '') }}
 
       # binary.Dockerfile's export target FROMs the loaded image and writes out the compiled binary.
       - name: Build the standalone binary


### PR DESCRIPTION
Follow-up to #364. These four `&&` / `||` ternaries in `binary.yml` are the last ones in the repository that select a *value*; [`case()`](https://docs.github.com/actions/reference/workflows-and-actions/expressions#case) says the same thing without leaning on short-circuit evaluation.

Left alone deliberately:

- `${{ github.event.pull_request.number || github.ref }}` in the concurrency groups. That is null coalescing, not a ternary, and `case()` would force inventing a predicate.
- The boolean `if:` conditions, `docker-image.yml`'s `push:` and its `enable=` tag flag. Those compute a boolean rather than pick a value.
- The `&&` / `||` inside `run:` blocks, which are shell, not expressions.

This pull request edits `.github/workflows/binary.yml`, which is in the workflow's own path filter, so the `binary` job runs here with `tag` unset. That exercises the false branch of all four: one `x86_64` leg on `ubuntu-latest`, an unsuffixed `cache-from` scope and an empty `cache-to`. The `aarch64` and release-cache legs stay untested until a tagged `workflow_call` from release-please or nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPZHQvVJbkaP7bjZAxAUec