### PR TITLE
ci: authenticate the static build's GitHub API calls

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -57,7 +57,11 @@ jobs:
 
       # binary.Dockerfile's export target FROMs the loaded image and writes out the compiled binary.
       - name: Build the standalone binary
-        run: docker build -f binary.Dockerfile --target export -o type=local,dest=out .
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          docker build -f binary.Dockerfile --target export
+          --secret id=github-token,env=GITHUB_TOKEN -o type=local,dest=out .
 
       - name: Name it per architecture
         env:

--- a/binary.Dockerfile
+++ b/binary.Dockerfile
@@ -6,6 +6,7 @@
 #   docker build -f binary.Dockerfile --target export -o type=local,dest=out .
 #   # -> out/wikven, a single static executable. Run it with:
 #   #    WIKVEN_WORKDIR=. ./wikven build
+#   # On a GitHub API rate limit, add: --secret id=github-token,env=GITHUB_TOKEN
 
 # Stage 1: the app tree to embed = the wikven image + the binary entry point,
 # minus what the build never needs (keeping all locales, so the binary is not
@@ -35,7 +36,11 @@ ENV SPC_CMD_VAR_FRANKENPHP_XCADDY_MODULES="--with github.com/dunglas/mercure/cad
 ENV PHP_VERSION=8.3
 ENV PHP_EXTENSIONS="gd,intl,pdo_sqlite,sqlite3,mbstring,dom,xml,simplexml,xmlreader,xmlwriter,fileinfo,iconv,ctype,filter,tokenizer,phar,session,calendar,opcache,openssl,sodium,zlib,bcmath,exif"
 ENV PHP_EXTENSION_LIBS="libpng,libjpeg,freetype,libwebp"
-RUN EMBED=dist/app ./build-static.sh
+# static-php-cli resolves most sources through api.github.com, which is 60 requests/hour per IP when
+# anonymous and shared with every other runner on that IP. The token raises it to 1000/hour per repo.
+RUN --mount=type=secret,id=github-token \
+    GITHUB_TOKEN="$(cat /run/secrets/github-token 2>/dev/null || true)" \
+    EMBED=dist/app ./build-static.sh
 
 # Stage 3: expose just the binary (named per arch by build-static.sh) for
 # `docker build --target export -o`.


### PR DESCRIPTION
#365 lost a build to `curl: (22) The requested URL returned error: 403` on `https://api.github.com/repos/static-php/static-php-cli-hosted/releases`, three seconds into `spc download`.

That call is not incidental. static-php-cli resolves most of its sources through the GitHub API, and our source set is squarely in that group: openssl, libsodium, icu, zlib and xz are `ghrel`; libpng, freetype, libwebp, brotli and libxml2 are `ghtagtar`; libjpeg is `ghtar`. Anonymously that budget is 60 requests an hour **per IP**, shared with every other Actions runner on the same address, so the failures arrive on someone else's schedule. Authenticated it is 1000 an hour per repository.

The token goes in as a BuildKit secret rather than a build arg, so it never lands in a layer. This mirrors FrankenPHP's own `static-builder-musl.Dockerfile`, which ends with the same construction and the same secret id:

```dockerfile
RUN --mount=type=secret,id=github-token GITHUB_TOKEN=$(cat /run/secrets/github-token) ./build-static.sh
```

The one addition is `2>/dev/null || true`. That image sets `SHELL ["/bin/ash", "-eo", "pipefail", "-c"]`, which our stage inherits, so a bare `cat` of an absent secret would abort the step and break token-free local builds. Verified both paths against the real BuildKit: with the secret the variable arrives populated, and without it the step still runs under `ash -e`.

Two things this deliberately does not do:

- It does not remove the API dependency. Dropping `--prefer-pre-built` would only kill the one call that happened to fail; the `ghrel` and `ghtagtar` sources still resolve through the API.
- It does not cache resolved sources. `spc download --from-zip` supports that, and would take the in-build call count to zero on a cache hit, but the producing side still needs the API, and the pinned builder image pulls a **nightly** spc (`SPC_REL_TYPE='binary'`), so a cached archive is validated against a moving target. Worth doing for build time and reproducibility, not as a rate-limit fix.

The `binary` job runs on this pull request, since both changed paths are in its filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPZHQvVJbkaP7bjZAxAUec