### PR TITLE
docs: stop claiming the static binary build is reproducible

### DIFF
--- a/binary.Dockerfile
+++ b/binary.Dockerfile
@@ -24,7 +24,8 @@ RUN find /var/www/html -type d -name tests -prune -exec rm -rf {} + \
 # Stage 2: compile a static PHP + FrankenPHP and embed the app. curl is omitted:
 # its HTTP/3 (ngtcp2/nghttp3) static libs fail to link, and it is unneeded
 # (MediaWiki/Guzzle uses PHP stream wrappers over openssl).
-# Digest-pinned for reproducible builds, version-tagged so Dependabot's bumps read as versions.
+# Digest-pinned, version-tagged so Dependabot's bumps read as versions. The pin fixes the toolchain
+# but not the build: build-static.sh fetches a nightly static-php-cli, which picks the library versions.
 FROM dunglas/frankenphp:static-builder-musl-1.12.6@sha256:e83b6dc244b8e170c5324cb8db32817b88703da495d40d14ce7751456e448a0d AS builder
 WORKDIR /go/src/app
 COPY --from=app /var/www/html ./dist/app


### PR DESCRIPTION
Follow-up to #367, where chasing the 403 turned up what the digest pin actually buys.

`binary.Dockerfile` said the builder image is "Digest-pinned for reproducible builds". The pin does fix the toolchain, but it does not fix the build. FrankenPHP's `static-builder-musl.Dockerfile` sets `SPC_REL_TYPE='binary'`, and `build-static.sh` then does:

```sh
curl -o spc -fsSL "https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-${dl_arch}"
```

A nightly, and it is static-php-cli that selects the library versions the binary gets compiled against. #365's build reported `v2.8.6`, which is not even a tag in that repository. So two builds of the same commit a day apart do not agree, and the comment was pointing a future reader at a guarantee we do not have.

The Dependabot half of the comment is accurate and stays.

`Dockerfile`'s similar line is left alone: it claims only that the base images are digest-pinned, which is true of what it pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPZHQvVJbkaP7bjZAxAUec