### PR TITLE
docs: correct what the Dockerfile's pins actually guarantee

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 ARG TARGETARCH
-# Bumped by updatecli, see updatecli/updatecli.d/siftersearch.yaml; no package manager reads this.
 ARG SIFTERSEARCH_VERSION=v0.6.1
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# Base images are digest-pinned for reproducible builds and version-tagged so Dependabot's bumps
-# read as version numbers rather than digests. Dependabot keeps them current.
+# Base images are digest-pinned and version-tagged so Dependabot's bumps read as version numbers
+# rather than digests. Dependabot keeps them current. The pin fixes the base images alone: apk,
+# codeload and Packagist below are all read at build time, so the image is not reproducible.
 FROM composer:2.10.2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer
 
 # The alpine variant, because nothing here serves over HTTP: `build` runs a maintenance script and
@@ -21,7 +22,7 @@ RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 ARG TARGETARCH
-# renovate: datasource=github-releases depName=chaotic-ground/SifterSearch
+# Bumped by updatecli, see updatecli/updatecli.d/siftersearch.yaml; no package manager reads this.
 ARG SIFTERSEARCH_VERSION=v0.6.1
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \


### PR DESCRIPTION
Same correction as #368, one file over. `Dockerfile` opened with "Base images are digest-pinned for reproducible builds", and the pins do fix the base images, but three later layers read live state at build time:

- `apk add --no-cache` resolves against the current Alpine index. Note that a digest-pinned base does not freeze this; `--no-cache` fetches the index fresh.
- codeload serves `refs/heads/REL1_46` for Translate and UniversalLanguageSelector, which is a branch tip, not a tag. That branch took commits on 2026-07-31, 2026-08-07 and 2026-08-14.
- Translate ships no `composer.lock`, and its requirements are ranges (`composer/installers >=1.0.1`, `mustangostang/spyc ^0.6.3`), so `composer install` resolves against Packagist on every build.

Two builds of the same commit a week apart do not agree, and nothing in the image records which Translate it got.

Separately, the SifterSearch pin carried:

```dockerfile
# renovate: datasource=github-releases depName=chaotic-ground/SifterSearch
```

That annotation is inert, since the repository has no renovate configuration. The ARG is in fact bumped weekly by updatecli, through `updatecli/updatecli.d/siftersearch.yaml`, so the comment now points there.

This pull request only fixes the comments. The three floating inputs are filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPZHQvVJbkaP7bjZAxAUec