### PR TITLE
build: pin Translate's runtime dependencies to exact versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ RUN arch="$TARGETARCH" \
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ARG TRANSLATE_VERSION=REL1_46
 ARG ULS_VERSION=REL1_46
+# Translate asks for its two runtime deps by range, so an unpinned install takes whatever Packagist
+# serves that day. Core's own answer to this is exact versions and no lock file, so: exact versions,
+# passed as temporary constraints rather than written into Translate's manifest. Bumped by updatecli.
+ARG SPYC_VERSION=0.6.3
+ARG COMPOSER_INSTALLERS_VERSION=v2.3.0
 # Composer refuses to resolve at all when any package in the tree carries a security advisory,
 # including a require-dev one that --no-dev then never installs. Translate's dev requirements pin
 # a phpcs release that has one, which broke every build reaching this layer without a warm cache.
@@ -42,6 +47,8 @@ ARG ULS_VERSION=REL1_46
 # Fetched as tarballs: a clone carries a .git nothing here reads, and transfers several times the
 # bytes for it. Downloaded before extracting rather than piped, so a failed fetch fails the build
 # instead of feeding tar an empty stream.
+# The php check ahead of the update fails the build if Translate's runtime requirements ever stop
+# matching what the ARGs pin, so a new upstream dependency cannot slip in unpinned.
 RUN composer config --global policy.advisories.block false \
  && ext=/var/www/html/extensions \
  && curl -fsSL -o /tmp/uls.tar.gz \
@@ -52,8 +59,12 @@ RUN composer config --global policy.advisories.block false \
  && tar -xzf /tmp/uls.tar.gz --strip-components=1 -C "$ext/UniversalLanguageSelector" \
  && tar -xzf /tmp/translate.tar.gz --strip-components=1 -C "$ext/Translate" \
  && rm /tmp/uls.tar.gz /tmp/translate.tar.gz \
- && composer install --no-dev --no-interaction \
-      --working-dir="$ext/Translate"
+ && php -r '$have = array_keys(json_decode(file_get_contents($argv[1]), true)["require"]); $want = explode(" ", $argv[2]); sort($have); sort($want); if ($have !== $want) { fwrite(STDERR, "Translate requires " . implode(" ", $have) . ", pinned " . implode(" ", $want) . "\n"); exit(1); }' \
+      -- "$ext/Translate/composer.json" "composer/installers mustangostang/spyc" \
+ && composer update --no-dev --no-interaction \
+      --working-dir="$ext/Translate" \
+      --with "mustangostang/spyc:$SPYC_VERSION" \
+      --with "composer/installers:$COMPOSER_INSTALLERS_VERSION"
 
 COPY ./ /var/www/html/extensions/Wikven
 COPY includes/WikvenSettings.php /var/www/html/

--- a/updatecli/updatecli.d/translate-deps.yaml
+++ b/updatecli/updatecli.d/translate-deps.yaml
@@ -1,0 +1,64 @@
+---
+name: "build(deps): bump Translate's runtime dependencies"
+pipelineid: translate-deps
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: chaotic-ground
+      repository: wikven
+      branch: main
+      user: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - dependencies
+
+# Translate requires both by range, so the Dockerfile pins them exactly and passes the pins to
+# composer as temporary constraints. Tag shapes differ between the two projects; both are copied
+# verbatim into the ARG, which is what composer is given.
+sources:
+  spyc:
+    name: Latest spyc release
+    kind: githubrelease
+    spec:
+      owner: mustangostang
+      repository: spyc
+      versionfilter:
+        kind: semver
+  installers:
+    name: Latest composer/installers release
+    kind: githubrelease
+    spec:
+      owner: composer
+      repository: installers
+      versionfilter:
+        kind: semver
+
+targets:
+  spyc:
+    name: 'build(deps): bump spyc to {{ source "spyc" }}'
+    kind: dockerfile
+    scmid: default
+    sourceid: spyc
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: SPYC_VERSION
+  installers:
+    name: 'build(deps): bump composer/installers to {{ source "installers" }}'
+    kind: dockerfile
+    scmid: default
+    sourceid: installers
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: COMPOSER_INSTALLERS_VERSION


### PR DESCRIPTION
Closes #372.

Translate requires its two runtime dependencies by range and ships no lock, so every build took whatever Packagist served that day:

```json
"require": {
    "composer/installers": ">=1.0.1",
    "mustangostang/spyc": "^0.6.3"
}
```

Worth naming which one actually floats. spyc's newest release is 0.6.3, from September 2019, so `^0.6.3` resolves to exactly one version today. The unbounded `composer/installers: >=1.0.1` is the real one, currently landing on v2.3.0 and open to a future 3.0 without anyone deciding to take it.

## Following core instead of adding a lock

MediaWiki core ships no `composer.lock` either, but it does not drift, because it pins exactly: the only non-exact constraint in its entire `require` block is `"php": ">=8.3.0"`. That is the house answer to this problem, so this follows it rather than introducing a repo-owned lock that would have to be regenerated against an upstream manifest that lives outside this repository.

The pins go in as temporary constraints, so Translate's own manifest is never rewritten, on disk or in the image:

```dockerfile
composer update --no-dev --no-interaction --working-dir="$ext/Translate" \
  --with "mustangostang/spyc:$SPYC_VERSION" \
  --with "composer/installers:$COMPOSER_INSTALLERS_VERSION"
```

`install` becomes `update` because `--with` is an update option, and because without a lock present `install` was resolving rather than installing anyway. A side benefit: `update` writes a `composer.lock` inside the image, so a built image records exactly what went in, without this repository owning the file.

## The guard

Exact pins on their own drift silently, and `TRANSLATE_VERSION` tracks a moving branch (#371), so this is not hypothetical: the day upstream adds a third requirement, it would install unpinned and unnoticed, recreating #372 for just that package. The php check ahead of the update fails the build when Translate's runtime requirement set stops matching what the ARGs pin. Two independent reviews of this change flagged the same gap and proposed the same guard.

## Verified

- Built the image. `composer show` inside it reports exactly `composer/installers 2.3.0` and `mustangostang/spyc 0.6.3`, and Translate's `composer.json` is byte-identical to upstream's.
- Ran the guard in the built image against a deliberately wrong expected set: exits 1 with `Translate requires composer/installers mustangostang/spyc, pinned composer/installers`.
- Ran the new updatecli manifest through `updatecli diff` (v0.120.1, the version the workflow pins). Both sources resolve, `v2.3.0` and `0.6.3`, and both `ARG` matchers hit the right lines.

One note on `--no-dev`: it does not stop Composer resolving `require-dev`, which is why the existing `policy.advisories.block false` line is still needed. That behaviour is unchanged by this pull request, `install` had the same property.

## Not addressed

`.yaml` versus `.yml` for the new manifest. The repository's policy is `.yml` for internal YAML, but `updatecli/updatecli.d/` is already all `.yaml`, so this matches its siblings rather than splitting the directory. Worth a separate cleanup if the policy should win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPZHQvVJbkaP7bjZAxAUec