### PR TITLE
feat: gate translation checks on broken source pages, not on stale translations

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -45,4 +45,6 @@ jobs:
           source: docs
           image: wikven
           cache: false  # the image was just built locally; nothing to cache or pull
-          gate: false  # translating is not the job of whoever edits the English source
+          # A broken source page fails here; staleness only annotates, since translating is not the
+          # job of whoever edits the English source.
+          gate: true

--- a/actions/check-translations/action.yml
+++ b/actions/check-translations/action.yml
@@ -1,6 +1,6 @@
 ---
 name: Check wikven translations
-description: Report (and optionally gate on) out-of-date or missing translations in a wikven source tree.
+description: Report broken source pages, and out-of-date or missing translations, in a wikven source tree.
 branding:
   icon: globe
   color: blue
@@ -16,8 +16,10 @@ inputs:
     default: ghcr.io/chaotic-ground/wikven:0.1.0  # x-release-please-version
   gate:
     description: >-
-      Fail the step (non-zero exit) when any translation is stale or missing.
-      Set to "false" to only report, never fail.
+      Fail the step (non-zero exit) when a source page is broken: one Translate
+      cannot parse, or one the two readings disagree on. A translation that is
+      stale or missing is always reported and never fails the step. Set to
+      "false" to report even a broken page without failing.
     default: "true"
   cache:
     description: >-

--- a/docs/Translating.wikitext
+++ b/docs/Translating.wikitext
@@ -150,7 +150,7 @@ When you change a source unit, its translations no longer match their stamp and 
 
 <!--T:20-->
 * In the built site, an out-of-date unit is marked as an outdated translation, exactly as it would be on a wiki running Translate.
-* <code>translate check</code> reports every out-of-date or missing translation, and with <code>--gate</code> exits non-zero so continuous integration can fail the build:
+* <code>translate check</code> reports every out-of-date or missing translation as a warning, and every broken source page as an error. With <code>--gate</code> it exits non-zero on the errors alone, so continuous integration fails on a page nobody can translate but not on a translation that is merely behind:
 </translate>
 
 <tabber>
@@ -158,17 +158,21 @@ When you change a source unit, its translations no longer match their stamp and 
 <syntaxhighlight lang="console">
 $ wikven translate check --gate
 ::warning file=src/Intro/ko.wikitext::Stale translation unit T:2 (ko)
+
+1 translation(s) out of date or missing.
 </syntaxhighlight>
 |-|Docker=
 <syntaxhighlight lang="console">
 $ docker run --rm -v "$PWD/src:/workspace/src" ghcr.io/chaotic-ground/wikven translate check --gate
 ::warning file=src/Intro/ko.wikitext::Stale translation unit T:2 (ko)
+
+1 translation(s) out of date or missing.
 </syntaxhighlight>
 </tabber>
 
 <translate>
 <!--T:21-->
-The [https://github.com/chaotic-ground/wikven/tree/main/actions/check-translations check-translations action] runs the same check on pull requests, reporting each one as an annotation on the file it belongs to. It only reports; pass <code>gate: true</code> to fail the build instead. This documentation site is checked this way. To bring a translation back up to date, edit it to match the new source, then <code>translate stamp</code> it again.
+The [https://github.com/chaotic-ground/wikven/tree/main/actions/check-translations check-translations action] runs the same check on pull requests, reporting each one as an annotation on the file it belongs to. It fails the build on a broken source page and never on a translation that is behind; pass <code>gate: false</code> to report even a broken page without failing. This documentation site is checked this way. To bring a translation back up to date, edit it to match the new source, then <code>translate stamp</code> it again.
 </translate>
 
 {{prevnext|Searching|Deploying}}

--- a/maintenance/checkTranslations.php
+++ b/maintenance/checkTranslations.php
@@ -23,18 +23,18 @@ $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 
 require_once "$IP/maintenance/Maintenance.php";
 
-/** Report (and optionally gate on) out-of-date or missing translations in the source tree. */
+/** Report broken source pages, and out-of-date or missing translations, in the source tree. */
 class CheckTranslations extends Maintenance {
 	public function __construct() {
 		parent::__construct();
-		$this->addDescription('Report translations that are out of date or missing.');
+		$this->addDescription('Report broken source pages, and translations that are out of date or missing.');
 		$this->addOption('source', 'Source directory to check (default: $wgWikvenSourceDirectory).', false, true);
 		$this->addOption('path-prefix', 'Prefix for reported file names, making them repo-relative.', false, true);
-		$this->addOption('gate', 'Exit non-zero when any translation is stale or missing.');
+		$this->addOption('gate', 'Exit non-zero when a source page has an error. Staleness never gates.');
 	}
 
 	/**
-	 * @return bool Whether the run itself succeeded (staleness is reported, and gated, separately).
+	 * @return bool Whether the run itself succeeded (what it found is reported, and gated, separately).
 	 */
 	public function execute() {
 		if (!ExtensionRegistry::getInstance()->isLoaded('Translate')) {
@@ -50,14 +50,17 @@ class CheckTranslations extends Maintenance {
 		$prefix = $prefix === '' ? '' : rtrim($prefix, '/') . '/';
 		$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
 
-		$problems = 0;
+		// Counted apart because only one of them gates: a broken source page is the author's to fix
+		// before it bakes wrong, while a translation falling behind is the translation system working.
+		$errors = 0;
+		$stale = 0;
 		foreach (TranslationSource::baseFiles($source) as $baseFile) {
 			$sourceText = (string)file_get_contents($baseFile);
 			// A source page that marks a unit <!--T:title--> collides with the page-title unit, which
 			// sourceUnits() refuses outright. Report the source file here rather than let every
 			// translation of it fail, since the page is what has to be fixed.
 			if (StalenessComputer::usesReservedId($sourceText)) {
-				$problems++;
+				$errors++;
 				$reportSource = $prefix . substr($baseFile, strlen($source) + 1);
 				$reserved = StalenessComputer::TITLE_UNIT_ID;
 				$this->output(
@@ -66,7 +69,7 @@ class CheckTranslations extends Maintenance {
 				);
 				continue;
 			}
-			$problems += $this->checkSourcePage($prefix . substr($baseFile, strlen($source) + 1), $sourceText);
+			$errors += $this->checkSourcePage($prefix . substr($baseFile, strlen($source) + 1), $sourceText);
 			$pageTitle = TranslationSource::translatableTitle($baseFile, $source, $sourceText);
 			foreach (TranslationSource::translationLanguages($baseFile, $isKnownLanguage) as $lang) {
 				$translationFile = TranslationSource::translationPath($baseFile, $lang);
@@ -77,7 +80,7 @@ class CheckTranslations extends Maintenance {
 					if ($unit['status'] === StalenessComputer::OK) {
 						continue;
 					}
-					$problems++;
+					$stale++;
 					// GitHub Actions annotation; a harmless plain line in any other console.
 					$this->output(
 						"::warning file=$reportFile::"
@@ -88,14 +91,21 @@ class CheckTranslations extends Maintenance {
 			}
 		}
 
-		if ($problems === 0) {
+		if ($errors === 0 && $stale === 0) {
 			$this->output("All translations are up to date.\n");
 			return true;
 		}
 
-		$this->output("\n$problems translation issue(s) found.\n");
-		if ($this->hasOption('gate')) {
-			$this->fatalError('Wikven: translations are out of date or missing (see annotations above).');
+		$summary = [];
+		if ($errors > 0) {
+			$summary[] = "$errors source page error(s)";
+		}
+		if ($stale > 0) {
+			$summary[] = "$stale translation(s) out of date or missing";
+		}
+		$this->output("\n" . implode(', ', $summary) . ".\n");
+		if ($errors > 0 && $this->hasOption('gate')) {
+			$this->fatalError('Wikven: source pages have errors (see annotations above).');
 		}
 		return true;
 	}
@@ -104,7 +114,7 @@ class CheckTranslations extends Maintenance {
 	 * Read a source page with Translate's own parser and report where wikven would read it
 	 * differently, so the author hears it here rather than from a page that bakes wrong.
 	 *
-	 * @return int Problems found.
+	 * @return int Errors found.
 	 */
 	private function checkSourcePage(string $reportFile, string $sourceText): int {
 		try {
@@ -133,16 +143,16 @@ class CheckTranslations extends Maintenance {
 			$wikven[(string)$id] = StalenessComputer::hashUnit($unit['text']);
 		}
 
-		$problems = 0;
+		$errors = 0;
 		if ($unmarked > 0) {
-			$problems++;
+			$errors++;
 			$this->output(
 				"::error file=$reportFile::$unmarked translation unit(s) have no <!--T:n--> marker;"
 				. " run translate mark\n"
 			);
 		}
 		if (array_keys($wikven) !== array_keys($translate)) {
-			$problems++;
+			$errors++;
 			$this->output(
 				"::error file=$reportFile::Translate reads units "
 				. $this->unitList(array_keys($translate))
@@ -151,14 +161,14 @@ class CheckTranslations extends Maintenance {
 				. "\n"
 			);
 		} elseif ($wikven !== $translate) {
-			$problems++;
+			$errors++;
 			$this->output(
 				"::error file=$reportFile::Translate and wikven read different text for unit(s) "
 				. $this->unitList(array_keys(array_diff_assoc($wikven, $translate)))
 				. "\n"
 			);
 		}
-		return $problems;
+		return $errors;
 	}
 
 	/**


### PR DESCRIPTION
`translate check` counted two unlike things into one total: a source page Translate cannot read, and a translation that has fallen behind its source. `--gate` then failed on both or on neither.

Failing on both contradicts the standing rule that whoever edits the English source owes nothing to the other languages, so this repo ran the action with `gate: false`. That left the other half unguarded. Since #358, a page Translate cannot parse is skipped rather than aborting the bake, on the reasoning that the check reports it. It did report it, as an annotation nobody had to act on, and the page baked untranslated with a green build.

Counting them apart resolves it. `--gate` fails on the errors:

- a page Translate cannot parse
- a page the two readings disagree on, by unit id or by unit text (#379)
- units with no `<!--T:n-->` marker
- the reserved `T:title` id used on a source page

Staleness stays a warning and never fails. `translations.yml` turns the gate on.

The summary line now names both, so a run says what it found:

```
2 source page error(s), 3 translation(s) out of date or missing.
```

This PR's own check demonstrates it: editing the English text of T:20 and T:21 in `Translating` stales their Korean translations, which annotate and stay green. The Korean follows in a separate PR, as usual.

## Behaviour change for downstream users

`gate: true` used to fail on a stale translation and now does not. Anyone relying on that loses it. Say the word and I will add a separate input for the strict behaviour, but nothing in the issue asked for one and the rule above argues against making it the default.

Fixes #374

---
_Generated by [Claude Code](https://claude.com/claude-code)_