### PR TITLE
feat: keep Vector's appearance menu, which works statically

### DIFF
--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -76,7 +76,7 @@ The <code>run</code> script:
 ; <code>buildScripts</code>
 : Dumps the JavaScript the pages need into two files: <code>startup-static.js</code> (the loader manifest, with its network auto-load removed) and <code>modules-static.js</code> (the full dependency closure, so every module self-executes). It seeds the <code>site</code> module (<code>MediaWiki:Common.js</code> and the skin's JS) and any default [[<tvar name="1">Special:MyLanguage/JavaScript</tvar>|gadgets]], which a live wiki pulls in implicitly.
 ; <code>rewriteScripts</code>
-: Rewrites the cached HTML to load the local bundle instead of <code>load.php</code>: it swaps the async startup tag for the static files plus an explicit <code>mw.loader.load()</code>, links the site styles last so they win the cascade, and removes the appearance menu (and the search box, unless [[<tvar name="2">Special:MyLanguage/Searching</tvar>|SifterSearch]] is providing a static index), which need a live API.
+: Rewrites the cached HTML to load the local bundle instead of <code>load.php</code>: it swaps the async startup tag for the static files plus an explicit <code>mw.loader.load()</code>, links the site styles last so they win the cascade, and removes the search box, which needs a live API, unless [[<tvar name="2">Special:MyLanguage/Searching</tvar>|SifterSearch]] is providing a static index.
 ; <code>storeImages</code>
 : Copies every referenced image (from Wikimedia Commons via InstantCommons, or from local uploads) to a content-hashed local file and rewrites the URLs, so nothing is fetched over the network at view time.
 ; <code>rename</code>

--- a/docs/Development/ko.wikitext
+++ b/docs/Development/ko.wikitext
@@ -44,7 +44,7 @@
 <!--T:12 @4f9fb5e1-->
 <code>maintenance/build.php</code>는 단계마다 부트스트랩 비용을 치르는 대신 MediaWiki를 '''한 번'''만 부팅하고 모든 단계를 자식 관리 스크립트로 실행합니다. 순서대로:
 
-<!--T:13 @3fd6dc99-->
+<!--T:13 @b44d8247-->
 ; <code>setMainPage</code>
 : <code>MediaWiki:Mainpage</code>를 가져온 <code>index</code> 문서로 지정하여, 사이트 루트가 <code>index.html</code>로 해석되도록 합니다.
 ; <code>importImages</code>
@@ -60,7 +60,7 @@
 ; <code>buildScripts</code>
 : 문서에 필요한 JavaScript를 두 파일로 덤프합니다. <code>startup-static.js</code>(네트워크 자동 로드를 제거한 로더 매니페스트)와 <code>modules-static.js</code>(전체 의존성 폐포로, 모든 모듈이 스스로 실행됨)입니다. <code>site</code> 모듈(<code>MediaWiki:Common.js</code>와 스킨의 JS)과, 실제 위키가 암묵적으로 끌어오는 기본 [[$1|소도구]]를 심어 둡니다.
 ; <code>rewriteScripts</code>
-: 캐시된 HTML이 <code>load.php</code> 대신 로컬 번들을 불러오도록 다시 씁니다. 비동기 startup 태그를 정적 파일과 명시적인 <code>mw.loader.load()</code>로 바꾸고, 사이트 스타일을 마지막에 링크해 캐스케이드에서 이기게 하며, 실제 API가 필요한 외관 메뉴(그리고 [[$2|SifterSearch]]가 정적 색인을 제공하지 않는 한 검색 상자)를 제거합니다.
+: 캐시된 HTML이 <code>load.php</code> 대신 로컬 번들을 불러오도록 다시 씁니다. 비동기 startup 태그를 정적 파일과 명시적인 <code>mw.loader.load()</code>로 바꾸고, 사이트 스타일을 마지막에 링크해 캐스케이드에서 이기게 하며, [[$2|SifterSearch]]가 정적 색인을 제공하지 않는 한 실제 API가 필요한 검색 상자를 제거합니다.
 ; <code>storeImages</code>
 : 참조된 모든 이미지(InstantCommons를 통한 위키미디어 공용, 또는 로컬 업로드)를 콘텐츠 해시된 로컬 파일로 복사하고 URL을 다시 써서, 열람 시점에 네트워크로 아무것도 가져오지 않도록 합니다.
 ; <code>rename</code>

--- a/extension.json
+++ b/extension.json
@@ -28,11 +28,6 @@
 			"messages": ["wikven-skin", "wikven-skin-description"]
 		}
 	},
-	"ResourceModuleSkinStyles": {
-		"vector": {
-			"+skins.vector.styles": "skins.vector.styles.less"
-		}
-	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "resources",
 		"remoteExtPath": "Wikven/resources"

--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -93,9 +93,12 @@ class AssetLocalizer {
 	 *
 	 * CSSMin percent-encodes printable text (an SVG, typically) instead of base64-encoding it, which
 	 * is what ResourceLoader itself does for the same images when it inlines them into a CSS bundle.
+	 * It leaves the spaces bare though, because it quotes the url() it builds; here the URI goes in
+	 * unquoted (a quote inside a JS bundle's CSS string would have to be escaped), and a bare space
+	 * makes the whole declaration invalid, so put those back. Base64 output has none to put back.
 	 */
 	private static function dataUri(string $bytes, string $mime): string {
-		return CSSMin::encodeStringAsDataURI($bytes, $mime);
+		return str_replace(' ', '%20', CSSMin::encodeStringAsDataURI($bytes, $mime));
 	}
 
 	/**

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -139,11 +139,6 @@ class RewriteScripts extends Maintenance {
 				$html = $this->citizenSearch($html, $citizenSearchWorks);
 			}
 
-			// Remove the appearance menu: its widgets pull codex+vue from load.php, which 404s statically.
-			$html = HtmlElementRemover::remove($html, static function ($unusedName, array $attrs) {
-				return ( $attrs['id'] ?? null ) === 'vector-appearance';
-			});
-
 			file_put_contents($file, $html, LOCK_EX);
 		}
 	}

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -14,10 +14,9 @@
   display: none;
 }
 
-// Wiki chrome that is meaningless on a static, read-only, single-language site:
-// the personal/preferences menu, the language switcher, and the watch action.
-.vector-user-links,
-#p-vector-user-menu-preferences,
+// Wiki chrome that is meaningless on a static, read-only, single-language site: the personal
+// menu, the language switcher, and the watch action. Vector's personal menu is a rule of its
+// own below, having to spare the appearance menu.
 // Citizen's, which also carries the language trigger the .mw-portlet-lang rule hides elsewhere.
 .citizen-userMenu,
 #p-lang-btn,
@@ -25,6 +24,15 @@
 .mw-watchlink,
 #ca-watch,
 #ca-unwatch {
+  display: none;
+}
+
+// Vector's user links are account chrome, with one exception: unpinning the appearance
+// menu ("hide") moves it into this nav, behind its dropdown button. Hiding the nav would
+// take the menu and its opener with it, leaving no way to get the menu back, so hide the
+// siblings instead.
+.vector-user-links > *:not(.vector-user-links-main),
+.vector-user-links-main > *:not(.vector-appearance-landmark) {
   display: none;
 }
 

--- a/resources/skins.vector.styles.less
+++ b/resources/skins.vector.styles.less
@@ -1,3 +1,0 @@
-.vector-user-links {
-  display: none;
-}

--- a/tests/e2e/appearance.spec.js
+++ b/tests/e2e/appearance.spec.js
@@ -1,0 +1,85 @@
+// Vector's appearance menu is the one piece of skin chrome a static export can still drive itself:
+// for the anonymous reader every option is a client preference, so Vector writes a cookie and swaps
+// an <html> class rather than calling the options API. The menu is empty in the served HTML and
+// filled by skins.vector.clientPreferences, so only a rendered page shows whether it arrived.
+
+const { test, expect } = require("@playwright/test");
+
+// URLs that only a live MediaWiki answers; a static export must request none.
+const BACKEND = /\/load\.php|\/api\.php|\/rest\.php\/|index\.php\?/;
+
+const clientPrefClasses = (page) =>
+	page.evaluate(() =>
+		[...document.documentElement.classList].filter((name) =>
+			name.includes("-clientpref-"),
+		),
+	);
+
+test("the appearance menu is filled in, and asks no backend to do it", async ({
+	page,
+}) => {
+	const errors = [];
+	const backend = [];
+	page.on("pageerror", (error) => errors.push(error.message));
+	page.on("request", (request) => {
+		if (BACKEND.test(request.url())) {
+			backend.push(request.url());
+		}
+	});
+
+	await page.goto("index.html", { waitUntil: "networkidle" });
+
+	// One radio per option of the three preferences Vector offers: text size, width, colour.
+	const radios = page.locator("#vector-appearance input[type=radio]");
+	await expect(radios).toHaveCount(8);
+	await expect(
+		page.locator("#skin-client-pref-skin-theme-value-night"),
+	).toBeAttached();
+
+	expect(backend, backend.join("; ")).toEqual([]);
+	expect(errors, errors.join("; ")).toEqual([]);
+});
+
+test("picking dark repaints the page and outlives a reload", async ({
+	page,
+}) => {
+	await page.goto("index.html");
+	await page.locator("#skin-client-pref-skin-theme-value-night").click();
+
+	await expect
+		.poll(() => clientPrefClasses(page))
+		.toContain("skin-theme-clientpref-night");
+	const dark = await page.evaluate(
+		() => getComputedStyle(document.body).backgroundColor,
+	);
+	expect(dark).not.toBe("rgb(255, 255, 255)");
+
+	// The inline <head> script restores the choice from the cookie, before any of the bundle runs.
+	await page.reload();
+	await expect
+		.poll(() => clientPrefClasses(page))
+		.toContain("skin-theme-clientpref-night");
+	await expect
+		.poll(() =>
+			page.evaluate(() => getComputedStyle(document.body).backgroundColor),
+		)
+		.toBe(dark);
+});
+
+test("width and text size are applied as chosen", async ({ page }) => {
+	await page.goto("index.html");
+
+	await page
+		.locator("#skin-client-pref-vector-feature-limited-width-value-0")
+		.click();
+	await expect
+		.poll(() => clientPrefClasses(page))
+		.toContain("vector-feature-limited-width-clientpref-0");
+
+	await page
+		.locator("#skin-client-pref-vector-feature-custom-font-size-value-2")
+		.click();
+	await expect
+		.poll(() => clientPrefClasses(page))
+		.toContain("vector-feature-custom-font-size-clientpref-2");
+});

--- a/tests/e2e/appearance.spec.js
+++ b/tests/e2e/appearance.spec.js
@@ -83,3 +83,43 @@ test("width and text size are applied as chosen", async ({ page }) => {
 		.poll(() => clientPrefClasses(page))
 		.toContain("vector-feature-custom-font-size-clientpref-2");
 });
+
+test("hiding the menu leaves it reachable, and it can be put back", async ({
+	page,
+}) => {
+	await page.goto("index.html");
+	await page
+		.locator("#vector-appearance .vector-pinnable-header-unpin-button")
+		.click();
+
+	// Unpinning is itself a client preference, so the reader arrives at the next page with the
+	// menu already moved into the header dropdown -- the state this has to keep working in.
+	await page.reload();
+
+	// Vector lays a transparent checkbox over the dropdown's own label, so the click goes there.
+	await page.locator("#vector-appearance-dropdown-checkbox").click();
+	const menu = page.locator(
+		"#vector-appearance-unpinned-container #vector-appearance",
+	);
+	await expect(menu).toBeVisible();
+	await expect(menu.locator("input[type=radio]")).toHaveCount(8);
+
+	await page
+		.locator("#vector-appearance .vector-pinnable-header-pin-button")
+		.click();
+	await expect(
+		page.locator("#vector-appearance-pinned-container #vector-appearance"),
+	).toBeVisible();
+});
+
+test("the icons the JS bundle carries render", async ({ page }) => {
+	await page.goto("index.html");
+
+	// The bundle injects its own CSS, so its images are inlined as data: URIs rather than written
+	// out as files. A URI that lands in the unquoted url() malformed leaves a valid-looking button
+	// with a blank icon, which no layout or visibility assertion would catch.
+	const mask = await page
+		.locator("#vector-appearance-dropdown-label .vector-icon")
+		.evaluate((element) => getComputedStyle(element).maskImage);
+	expect(mask).toContain("data:image/svg+xml");
+});

--- a/tests/phpunit/integration/AssetLocalizerTest.php
+++ b/tests/phpunit/integration/AssetLocalizerTest.php
@@ -119,4 +119,37 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 			'left alone rather than inlined into the bundle'
 		);
 	}
+
+	/**
+	 * A real icon SVG carries attributes, so the inlined URI has spaces between them. CSSMin leaves
+	 * those bare because it quotes the url() it builds itself; the one emitted here is unquoted (a
+	 * quote inside a JS bundle's CSS string would need escaping), and a bare space makes the whole
+	 * declaration invalid -- the browser drops it and the icon renders blank.
+	 */
+	public function testLocalizeAssetsEncodesSpacesInInlinedAssets() {
+		$mwRoot = $this->getNewTempDirectory();
+		mkdir("$mwRoot/skins/Vector/images", 0777, true);
+		file_put_contents("$mwRoot/skins/Vector/images/icon.svg", '<svg width="20" height="20"/>');
+		$this->setMwGlobals('IP', $mwRoot);
+
+		$dir = $this->getNewTempDirectory();
+		$js = "$dir/modules-static.js";
+		file_put_contents($js, '.a{mask-image:url(/skins/Vector/images/icon.svg)}' . "\n");
+
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		AssetLocalizer::localizeAssets($rl, $dir, [$js], 'en', 'vector', true);
+
+		$out = file_get_contents($js);
+		$this->assertSame(
+			1,
+			preg_match('~url\((data:[^)]*)\)~', $out, $m),
+			'the reference is still a single url()'
+		);
+		$this->assertStringNotContainsString(' ', $m[1], 'no bare space inside the url()');
+		$this->assertSame(
+			'<svg width="20" height="20"/>',
+			rawurldecode(substr($m[1], strlen('data:image/svg+xml,'))),
+			'and it still decodes back to the asset'
+		);
+	}
 }

--- a/tests/phpunit/integration/AssetLocalizerTest.php
+++ b/tests/phpunit/integration/AssetLocalizerTest.php
@@ -3,12 +3,27 @@
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
 use MediaWiki\Extension\Wikven\AssetLocalizer;
+use MediaWiki\ResourceLoader\ResourceLoader;
 use MediaWikiIntegrationTestCase;
 
 /**
  * @covers \MediaWiki\Extension\Wikven\AssetLocalizer
  */
 class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * The ResourceLoader service, with $GLOBALS['IP'] then pointed at a fixture install root.
+	 *
+	 * AssetLocalizer resolves a direct asset path against $IP, so these tests have to move it. The
+	 * service container reads the real install the first time it builds the ResourceLoader, to
+	 * register core's own modules, and errors out on a fixture root that has none of them -- so
+	 * build it first, while $IP is still the real one.
+	 */
+	private function resourceLoaderRootedAt(string $mwRoot): ResourceLoader {
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		$this->setMwGlobals('IP', $mwRoot);
+		return $rl;
+	}
+
 	/**
 	 * Direct skin/resource/extension asset url()s in dumped CSS are the most
 	 * regex-fragile part of the static export: if they stop matching, the output
@@ -21,8 +36,7 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 		$mwRoot = $this->getNewTempDirectory();
 		mkdir("$mwRoot/skins/Vector/images", 0777, true);
 		file_put_contents("$mwRoot/skins/Vector/images/arrow.svg", '<svg>arrow</svg>');
-		// AssetLocalizer reads the install root from $GLOBALS['IP'].
-		$this->setMwGlobals('IP', $mwRoot);
+		$rl = $this->resourceLoaderRootedAt($mwRoot);
 
 		$dir = $this->getNewTempDirectory();
 		$css = "$dir/styles.css";
@@ -38,7 +52,6 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 		])
 			. "\n");
 
-		$rl = $this->getServiceContainer()->getResourceLoader();
 		AssetLocalizer::localizeAssets($rl, $dir, [$css], 'en', 'vector');
 
 		$out = file_get_contents($css);
@@ -67,13 +80,12 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 		$mwRoot = $this->getNewTempDirectory();
 		mkdir("$mwRoot/skins/Vector/images", 0777, true);
 		file_put_contents("$mwRoot/skins/Vector/images/arrow.svg", '<svg>arrow</svg>');
-		$this->setMwGlobals('IP', $mwRoot);
+		$rl = $this->resourceLoaderRootedAt($mwRoot);
 
 		$dir = $this->getNewTempDirectory();
 		$js = "$dir/modules-static.js";
 		file_put_contents($js, '.a{background:url(/skins/Vector/images/arrow.svg)}' . "\n");
 
-		$rl = $this->getServiceContainer()->getResourceLoader();
 		AssetLocalizer::localizeAssets($rl, $dir, [$js], 'en', 'vector', true);
 
 		$out = file_get_contents($js);
@@ -94,10 +106,9 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 		$mwRoot = $this->getNewTempDirectory();
 		mkdir("$mwRoot/skins/Citizen/resources/fonts", 0777, true);
 		file_put_contents("$mwRoot/skins/Citizen/resources/fonts/Roboto.woff2", 'wOF2fake');
-		$this->setMwGlobals('IP', $mwRoot);
+		$rl = $this->resourceLoaderRootedAt($mwRoot);
 
 		$rule = '@font-face{src:url(/skins/Citizen/resources/fonts/Roboto.woff2) format("woff2")}';
-		$rl = $this->getServiceContainer()->getResourceLoader();
 
 		$cssDir = $this->getNewTempDirectory();
 		file_put_contents("$cssDir/styles.css", $rule . "\n");
@@ -130,13 +141,12 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 		$mwRoot = $this->getNewTempDirectory();
 		mkdir("$mwRoot/skins/Vector/images", 0777, true);
 		file_put_contents("$mwRoot/skins/Vector/images/icon.svg", '<svg width="20" height="20"/>');
-		$this->setMwGlobals('IP', $mwRoot);
+		$rl = $this->resourceLoaderRootedAt($mwRoot);
 
 		$dir = $this->getNewTempDirectory();
 		$js = "$dir/modules-static.js";
 		file_put_contents($js, '.a{mask-image:url(/skins/Vector/images/icon.svg)}' . "\n");
 
-		$rl = $this->getServiceContainer()->getResourceLoader();
 		AssetLocalizer::localizeAssets($rl, $dir, [$js], 'en', 'vector', true);
 
 		$out = file_get_contents($js);

--- a/tests/phpunit/unit/HtmlElementRemoverTest.php
+++ b/tests/phpunit/unit/HtmlElementRemoverTest.php
@@ -11,12 +11,12 @@ use MediaWikiUnitTestCase;
 class HtmlElementRemoverTest extends MediaWikiUnitTestCase {
 	private function byId(): callable {
 		return static function ($name, array $attrs) {
-			return ( $attrs['id'] ?? null ) === 'vector-appearance';
+			return ( $attrs['id'] ?? null ) === 'removable';
 		};
 	}
 
 	public function testRemovesAMatchedElementAndItsSubtree() {
-		$html = '<body><div id="vector-appearance"><div>nested</div>text</div><p>keep</p></body>';
+		$html = '<body><div id="removable"><div>nested</div>text</div><p>keep</p></body>';
 		$this->assertSame(
 			'<body><p>keep</p></body>',
 			HtmlElementRemover::remove($html, $this->byId())
@@ -26,7 +26,7 @@ class HtmlElementRemoverTest extends MediaWikiUnitTestCase {
 	public function testMatchesRegardlessOfTagName() {
 		// Vector may render the targeted chrome as <nav>, <aside>, or <form> instead of <div>; a
 		// matcher hardcoded to "<div" would silently leave it in place.
-		$html = '<body><nav id="vector-appearance"><span>x</span></nav><p>keep</p></body>';
+		$html = '<body><nav id="removable"><span>x</span></nav><p>keep</p></body>';
 		$this->assertSame(
 			'<body><p>keep</p></body>',
 			HtmlElementRemover::remove($html, $this->byId())
@@ -34,7 +34,7 @@ class HtmlElementRemoverTest extends MediaWikiUnitTestCase {
 	}
 
 	public function testAGreaterThanInsideAnAttributeValueIsNotTheTagEnd() {
-		$html = '<body><div id="vector-appearance" data-note="a > b">x</div><p>keep</p></body>';
+		$html = '<body><div id="removable" data-note="a > b">x</div><p>keep</p></body>';
 		$this->assertSame(
 			'<body><p>keep</p></body>',
 			HtmlElementRemover::remove($html, $this->byId())
@@ -42,9 +42,7 @@ class HtmlElementRemoverTest extends MediaWikiUnitTestCase {
 	}
 
 	public function testAVoidOrSelfClosedElementInsideTheSubtreeDoesNotDesyncDepth() {
-		$html =
-			'<body><div id="vector-appearance"><input type="search"><svg><path d="M0 0"/></svg></div>'
-			. '<p>keep</p></body>';
+		$html = '<body><div id="removable"><input type="search"><svg><path d="M0 0"/></svg></div><p>keep</p></body>';
 		$this->assertSame(
 			'<body><p>keep</p></body>',
 			HtmlElementRemover::remove($html, $this->byId())
@@ -66,7 +64,7 @@ class HtmlElementRemoverTest extends MediaWikiUnitTestCase {
 	}
 
 	public function testTwoSiblingMatchesAreBothRemoved() {
-		$html = '<body><div id="vector-appearance">a</div><p>mid</p><div id="vector-appearance">b</div></body>';
+		$html = '<body><div id="removable">a</div><p>mid</p><div id="removable">b</div></body>';
 		$this->assertSame(
 			'<body><p>mid</p></body>',
 			HtmlElementRemover::remove($html, $this->byId())


### PR DESCRIPTION
The static export stripped `#vector-appearance` from every page, on the grounds that its widgets "share the codex/vue bundle" with the search box and would 404 against `load.php`. That premise was wrong, and the menu works statically once it is left in place: readers get text size, width and colour (light/dark/automatic) back.

`skins.vector.clientPreferences` depends only on `mediawiki.api` and `mediawiki.user`, and it is already in `modules-static.js`. `skin.js` also waits on `skins.vector.search.codex.styles` before rendering the menu, but Vector lists that module unconditionally among `vector-2022`s page styles, so the export already emits its CSS and `RLSTATE` marks it `ready` — the `mw.loader.using()` resolves locally, with or without SifterSearch.

Nothing else was missing. A static export is anonymous, so `mw.user.isNamed()` is false and every option takes the `mw.user.clientPrefs` path: a cookie plus an `<html>` class, no API call, restored on the next page load by the inline `<head>` script Vector already emits. The night-mode, width and font-size rules are in the dumped `skins.vector.styles`.

## Keeping it reachable after "hide"

Unpinning moves `#vector-appearance` into `#vector-appearance-unpinned-container`, which lives inside `.vector-user-links` — the nav wikven hid wholesale as account chrome. So "hide" took the menu and its dropdown button with it, and the unpinned state is a cookie, so it stayed gone on every later page. Hide the siblings inside that nav instead, sparing the appearance landmark.

The rule that hid it lived in `ext.Wikven.styles.less`. The skin-style copy in `skins.vector.styles.less` never applied: its `ResourceModuleSkinStyles` key is `vector`, and the skin here is `vector-2022`. That dead file is dropped rather than left looking like a second place that governs this.

## Icons the JS bundle carries

Exposing the dropdown button exposed a second, older bug. `AssetLocalizer` inlines a bundle images as `data:` URIs, but `CSSMin::encodeStringAsDataURI` leaves the spaces in a percent-encoded SVG bare, since it quotes the `url()` it builds itself. Ours is unquoted (a quote inside a JS bundle CSS string would have to be escaped), so every such declaration was invalid and dropped, and the browser fell back to `.vector-icon`s 1×1 transparent PNG. The appearance button rendered as a blank square, as did the rest of `skins.vector.icons.js` — unnoticed so far because those icons sit on chrome the export hides. Put the spaces back.

## Test ordering

`AssetLocalizerTest` moved `$GLOBALS[IP]` to a fixture directory and asked for the ResourceLoader after, so the service container built it against the fixture root and threw looking for core own module directories. All four tests errored under the coverage stage, leaving `includes/AssetLocalizer.php` at 0% and every diff to it below the patch target. Take the service first; the file is now at 60%.

## Verification

Built `docs/` with the image and ran the suite against it:

- New `tests/e2e/appearance.spec.js`: the menu is filled in (8 radios across the three preferences); picking Dark repaints the page and survives a reload; width and text size apply as chosen; hiding it leaves it reachable from the header dropdown and "move to sidebar" puts it back; the icon mask really is the inlined SVG (a blank icon passes every layout and visibility assertion).
- The first test also asserts no `load.php`/`api.php`/`rest.php` request and no page error, so the 404 the removal was guarding against would fail the build.
- Full e2e suite: 30 passed, including the Citizen specs that landed on main meanwhile.
- `biome ci`, `mago format --check`, `mago lint`, `composer phpcs`, `translate check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2BfygzeJeiH3WG5r4hB3c