### PR TITLE
fix: read a source page the way Translate segments it

### DIFF
--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -57,6 +57,20 @@ class StalenessComputer {
 	/** What TranslatablePageParser::armourNowiki() hides: exactly this, no attributes, no other tag. */
 	private const ARMOURED_NOWIKI = '#<nowiki>.*?</nowiki>#s';
 
+	/** A unit marker, with the source-unit hash a translation's marker also carries. */
+	private const MARKER = '/<!--T:(?<id>[A-Za-z0-9]+)(?:\s+@(?<hash>[0-9a-f]{' . self::HASH_LENGTH . '}))?\s*-->/';
+
+	/** How TranslatablePageParser::parseSection() cuts a block's contents into units. */
+	private const SEGMENT = '~(^\s*|\s*\n\n\s*|\s*$)~';
+
+	/**
+	 * The two marker positions parseUnit() strips, and so the two it accepts: at the very start of a
+	 * unit, or at the end of any line in one. Anything else is pt-shake-position, which the check
+	 * reports as a page Translate cannot parse.
+	 */
+	private const MARKER_AT_START = '/^<!--T:.*?-->( |\n)/';
+	private const MARKER_AT_LINE_END = '/\s*<!--T:.*?-->$/m';
+
 	/** Short content hash of a source unit; the value carried as @<hash> in a translation marker. */
 	public static function hashUnit(string $unitText): string {
 		return substr(hash('sha256', self::normalize($unitText)), 0, self::HASH_LENGTH);
@@ -95,10 +109,10 @@ class StalenessComputer {
 
 	/** Number the still-unmarked units of one <translate> block's contents, continuing from $next. */
 	private static function markBlock(string $contents, int &$next): string {
-		// The two newlines must be adjacent, matching Translate's own sectioniser
-		// ('~(^\s*|\s*\n\n\s*|\s*$)~'): a line of spaces or tabs between them is still the same unit to
-		// Translate, and marking it as two would put a <!--T:n--> mid-unit, which Translate rejects
-		// (pt-shake-position).
+		// The two newlines must be adjacent, as they must for self::SEGMENT: a line of spaces or tabs
+		// between them is still the same unit to Translate, and marking it as two would put a
+		// <!--T:n--> mid-unit, which Translate rejects (pt-shake-position). Split here keeps the
+		// separators, which SEGMENT drops, because this rebuilds the page.
 		$units = preg_split('/(\n\n)/', $contents, -1, PREG_SPLIT_DELIM_CAPTURE);
 		$marked = '';
 		foreach ($units as $index => $segment) {
@@ -119,49 +133,16 @@ class StalenessComputer {
 	 * @return array<string,array{hash:?string,text:string}> id => [synced-source hash, unit text]
 	 */
 	public static function translationUnits(string $text): array {
-		$verbatim = self::verbatimRanges($text);
-		$length = strlen($text);
-		return self::unitsAt($text, static function (int $offset) use ($verbatim, $length): ?int {
-			return self::insideVerbatim($offset, $verbatim) ? null : $length;
-		});
-	}
-
-	/**
-	 * Split a source page into units keyed by their <!--T:n--> marker id.
-	 *
-	 * @return array<string,array{hash:?string,text:string}> id => [null, unit text]
-	 */
-	private static function sourcePageUnits(string $text): array {
-		$blocks = self::blockRanges($text);
-		// Translate segments each block's contents on their own, so no unit outlives its block.
-		return self::unitsAt($text, static function (int $offset) use ($blocks): ?int {
-			$block = self::containingRange($offset, $blocks);
-			return $block === null ? null : $block[1];
-		});
-	}
-
-	/**
-	 * Units keyed by marker id. $bound says both which markers count and how far each one's body may
-	 * run: null skips the marker, leaving the surrounding unit whole. A body otherwise runs to the
-	 * next counted marker.
-	 *
-	 * @param string $text
-	 * @param callable(int):(?int) $bound
-	 * @return array<string,array{hash:?string,text:string}>
-	 */
-	private static function unitsAt(string $text, callable $bound): array {
-		$pattern = '/<!--T:(?<id>[A-Za-z0-9]+)(?:\s+@(?<hash>[0-9a-f]{' . self::HASH_LENGTH . '}))?\s*-->/';
-		if (!preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
+		// A translation is wikven's own format: bare markers, no blocks to segment, so a unit simply
+		// runs from its marker to the next one.
+		if (!preg_match_all(self::MARKER, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
 			return [];
 		}
-
+		$verbatim = self::verbatimRanges($text);
 		$markers = [];
-		$limits = [];
 		foreach ($matches as $marker) {
-			$limit = $bound($marker[0][1]);
-			if ($limit !== null) {
+			if (!self::insideVerbatim($marker[0][1], $verbatim)) {
 				$markers[] = $marker;
-				$limits[] = $limit;
 			}
 		}
 
@@ -170,13 +151,38 @@ class StalenessComputer {
 		for ($i = 0; $i < $count; $i++) {
 			$marker = $markers[$i];
 			$bodyStart = $marker[0][1] + strlen($marker[0][0]);
-			$bodyEnd = min($limits[$i], ( $i + 1 ) < $count ? $markers[$i + 1][0][1] : strlen($text));
-			// An unstamped marker (source page, or a not-yet-stamped translation) has no hash group.
+			$bodyEnd = ( $i + 1 ) < $count ? $markers[$i + 1][0][1] : strlen($text);
+			// A not-yet-stamped marker has no hash group.
 			$stamped = isset($marker['hash']) && $marker['hash'][1] !== -1;
 			$units[$marker['id'][0]] = [
 				'hash' => $stamped ? $marker['hash'][0] : null,
 				'text' => substr($text, $bodyStart, $bodyEnd - $bodyStart)
 			];
+		}
+		return $units;
+	}
+
+	/**
+	 * Split a source page into units keyed by their <!--T:n--> marker id.
+	 *
+	 * A source page is Translate's format, so it is read Translate's way round: cut each <translate>
+	 * block into units first, then find the marker inside one. Scanning for markers first and cutting
+	 * between them would put the marker at a unit's edge, which is only where parseUnit() finds it
+	 * when the unit is written in the ordinary form.
+	 *
+	 * @return array<string,array{hash:?string,text:string}> id => [null, unit text]
+	 */
+	private static function sourcePageUnits(string $text): array {
+		$units = [];
+		foreach (self::blockRanges($text) as [$start, $end]) {
+			$contents = substr($text, $start, $end - $start);
+			foreach (preg_split(self::SEGMENT, $contents, -1, PREG_SPLIT_NO_EMPTY) as $segment) {
+				if (!preg_match(self::MARKER, $segment, $marker)) {
+					continue;
+				}
+				$body = preg_replace(self::MARKER_AT_START, '', $segment);
+				$units[$marker['id']] = ['hash' => null, 'text' => preg_replace(self::MARKER_AT_LINE_END, '', $body)];
+			}
 		}
 		return $units;
 	}

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -221,10 +221,13 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 
 	public function testNowikiInsideABlockHidesNothing() {
 		// parse() unarmours a block's contents before segmenting them, so <nowiki> shelters a marker
-		// from the block scan but not from the unit scan. Translate rejects the page; wikven must see
-		// the same two units for the check to be able to say so.
+		// from the block scan but not from the unit it lands in. One segment is one unit however many
+		// markers it holds, and Translate refuses this one outright (pt-shake-multiple), which the
+		// check reports on its own.
 		$text = "<translate>\n<!--T:1-->\nUse <nowiki><!--T:9--></nowiki> here.\n</translate>";
-		$this->assertSame([1, 9], array_keys(StalenessComputer::sourceUnits($text)));
+		$units = StalenessComputer::sourceUnits($text);
+		$this->assertSame([1], array_keys($units));
+		$this->assertSame('Use <nowiki><!--T:9--></nowiki> here.', $units[1]['text']);
 	}
 
 	public function testAWholeBlockArmouredByNowikiIsInvisible() {
@@ -235,7 +238,7 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 			. "<nowiki><translate>\n<!--T:1-->\nShown.\n</translate></nowiki>";
 		$units = StalenessComputer::sourceUnits($text);
 		$this->assertSame([1], array_keys($units));
-		$this->assertStringStartsWith("\nReal.\n", $units[1]['text']);
+		$this->assertSame('Real.', $units[1]['text']);
 	}
 
 	public function testMarkNumbersABlockShownInACodeExample() {
@@ -287,8 +290,18 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 			. "{{DISPLAYTITLE:Wikven}}\n"
 			. "<translate>\n<!--T:2-->\nTwo.\n</translate>\n[[Category:Docs]]";
 		$units = StalenessComputer::sourceUnits($text);
-		$this->assertSame("\nOne.\n", $units[1]['text']);
-		$this->assertSame("\nTwo.\n", $units[2]['text']);
+		$this->assertSame('One.', $units[1]['text']);
+		$this->assertSame('Two.', $units[2]['text']);
+	}
+
+	public function testASourceMarkerAtTheEndOfALineBelongsToTheLineBeforeIt() {
+		// parseUnit() strips a marker at the end of any line, not only a heading's, and keeps the text
+		// on both sides of it. Reading the unit as starting after the marker would lose everything
+		// before it.
+		$text = "<translate>\nfoo\n<!--T:1-->\nbar\n\n== Heading == <!--T:2-->\n</translate>";
+		$units = StalenessComputer::sourceUnits($text);
+		$this->assertSame("foo\nbar", $units[1]['text']);
+		$this->assertSame('== Heading ==', $units[2]['text']);
 	}
 
 	public function testEditingOutsideEveryBlockStalesNothing() {


### PR DESCRIPTION
wikven scanned a page for `<!--T:n-->` markers and cut the text between them, so a unit always began right after its marker. Translate works the other way round: `parseSection()` cuts each `<translate>` block into units on blank lines, and only then does `parseUnit()` strip the marker out of one. It strips two positions:

```
rer1: ~^<!--T:(.*?)-->( |\n)~  // at the very start of the unit
rer2: ~\s*<!--T:(.*?)-->$~m    // at the end of any line in it
```

`rer2` is named for the heading case, but `$` under `/m` is the end of **any** line. Everything before such a marker still belongs to the unit, and wikven threw it away:

```wikitext
<translate>
foo
<!--T:1-->
bar
</translate>
```

Translate reads T:1 as `foo\nbar`. wikven read `bar`.

So this stops imitating the result and copies the shape: segment the block first, find the marker inside the segment, strip it the two ways `parseUnit()` does. The heading form (`== X == <!--T:3-->`) falls out for free, having never worked before.

A translation file keeps the old marker scan. It carries bare markers and no blocks, so it is wikven's own format with nothing to segment, and `translationUnits()` is unchanged.

## No restamp

Every docs unit keeps its id and its hash: `hashUnit()` trims, and for a marker in the ordinary form the segment and the old between-markers slice trim to the same string. Verified unit by unit across all 47 source pages against `main`: **0 id changes, 0 hashes moved.**

## Consequences worth naming

- A segment holding two markers is now one unit, not two, and its id is the first marker's. Translate refuses such a page outright (`pt-shake-multiple`), which `translate check` reports on its own, so nothing goes unseen. `testNowikiInsideABlockHidesNothing` is updated to say this.
- An unmarked paragraph is no longer absorbed into the preceding unit's body, so it can no longer move that unit's hash. `translate check` already errors on unmarked units.

Fixes #383

---
_Generated by [Claude Code](https://claude.com/claude-code)_