### PR TITLE
fix: never read a translation file as a base page

### DIFF
--- a/includes/PageTranslation/TranslationSource.php
+++ b/includes/PageTranslation/TranslationSource.php
@@ -161,9 +161,15 @@ class TranslationSource {
 	/**
 	 * Every translatable base page under a source directory.
 	 *
+	 * A translation is never one, whatever it holds. A <translate> it quotes is real to Translate as
+	 * much as to wikven, so nothing downstream would object to "<Page>/<lang>" being marked as a page
+	 * in its own right; the naming convention is what says it is not.
+	 *
+	 * @param string $sourceDir
+	 * @param callable(string):bool $isKnownLanguage
 	 * @return string[] Absolute paths, sorted for a stable order.
 	 */
-	public static function baseFiles(string $sourceDir): array {
+	public static function baseFiles(string $sourceDir, callable $isKnownLanguage): array {
 		$iterator = new RecursiveIteratorIterator(
 			new RecursiveDirectoryIterator($sourceDir, FilesystemIterator::SKIP_DOTS)
 		);
@@ -173,6 +179,7 @@ class TranslationSource {
 			if (
 				$file->isFile()
 				&& str_ends_with($path, '.wikitext')
+				&& !self::isTranslationFile($path, $isKnownLanguage)
 				&& self::isTranslatable((string)file_get_contents($path))
 			) {
 				$files[] = $path;

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -66,7 +66,7 @@ class BuildTranslations extends Maintenance {
 		$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
 
 		$prepared = [];
-		foreach (TranslationSource::baseFiles($source) as $baseFile) {
+		foreach (TranslationSource::baseFiles($source, $isKnownLanguage) as $baseFile) {
 			$relative = substr($baseFile, strlen($source) + 1);
 			$title = Title::newFromText(SourceFile::filenameToTitle($relative));
 			if (!$title) {

--- a/maintenance/checkTranslations.php
+++ b/maintenance/checkTranslations.php
@@ -54,7 +54,7 @@ class CheckTranslations extends Maintenance {
 		// before it bakes wrong, while a translation falling behind is the translation system working.
 		$errors = 0;
 		$stale = 0;
-		foreach (TranslationSource::baseFiles($source) as $baseFile) {
+		foreach (TranslationSource::baseFiles($source, $isKnownLanguage) as $baseFile) {
 			$sourceText = (string)file_get_contents($baseFile);
 			// A source page that marks a unit <!--T:title--> collides with the page-title unit, which
 			// sourceUnits() refuses outright. Report the source file here rather than let every

--- a/maintenance/markTranslations.php
+++ b/maintenance/markTranslations.php
@@ -29,7 +29,8 @@ class MarkTranslations extends Maintenance {
 			if ($source === '' || !is_dir($source)) {
 				$this->fatalError("Wikven: source directory '$source' does not exist.");
 			}
-			foreach (TranslationSource::baseFiles($source) as $baseFile) {
+			$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
+			foreach (TranslationSource::baseFiles($source, $isKnownLanguage) as $baseFile) {
 				$this->markFile($baseFile);
 			}
 			return;

--- a/maintenance/retranslateChrome.php
+++ b/maintenance/retranslateChrome.php
@@ -43,7 +43,7 @@ class RetranslateChrome extends Maintenance {
 		$contentLang = $services->getContentLanguage()->getCode();
 		$isKnownLanguage = [$services->getLanguageNameUtils(), 'isKnownLanguageTag'];
 
-		foreach (TranslationSource::baseFiles($source) as $baseFile) {
+		foreach (TranslationSource::baseFiles($source, $isKnownLanguage) as $baseFile) {
 			$relative = substr($baseFile, strlen($source) + 1);
 			$baseTitle = SourceFile::filenameToTitle($relative);
 			foreach (TranslationSource::translationLanguages($baseFile, $isKnownLanguage) as $lang) {

--- a/maintenance/scaffoldTranslations.php
+++ b/maintenance/scaffoldTranslations.php
@@ -38,7 +38,8 @@ class ScaffoldTranslations extends Maintenance {
 			if ($source === '' || !is_dir($source)) {
 				$this->fatalError("Wikven: source directory '$source' does not exist.");
 			}
-			foreach (TranslationSource::baseFiles($source) as $baseFile) {
+			$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
+			foreach (TranslationSource::baseFiles($source, $isKnownLanguage) as $baseFile) {
 				$this->scaffoldFile($baseFile, $language, $source);
 			}
 			return;

--- a/maintenance/stampTranslations.php
+++ b/maintenance/stampTranslations.php
@@ -30,7 +30,7 @@ class StampTranslations extends Maintenance {
 				$this->fatalError("Wikven: source directory '$source' does not exist.");
 			}
 			$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
-			foreach (TranslationSource::baseFiles($source) as $baseFile) {
+			foreach (TranslationSource::baseFiles($source, $isKnownLanguage) as $baseFile) {
 				$sourceText = (string)file_get_contents($baseFile);
 				$pageTitle = TranslationSource::translatableTitle($baseFile, $source, $sourceText);
 				foreach (TranslationSource::translationLanguages($baseFile, $isKnownLanguage) as $lang) {

--- a/tests/phpunit/integration/TranslationSourceTest.php
+++ b/tests/phpunit/integration/TranslationSourceTest.php
@@ -65,6 +65,28 @@ class TranslationSourceTest extends MediaWikiIntegrationTestCase {
 		];
 	}
 
+	public function testBaseFilesLeaveOutATranslationThatQuotesATranslateTag() {
+		// A <translate> a translation quotes is as real to Translate as to wikven, so nothing
+		// downstream would object to "Intro/ko" being marked as a translatable page of its own.
+		$dir = sys_get_temp_dir() . '/wikven-base-files-' . uniqid();
+		$page = "<languages/>\n<translate>\n<!--T:1-->\nHi.\n</translate>";
+		mkdir("$dir/Intro", 0777, true);
+		file_put_contents("$dir/Intro.wikitext", $page);
+		file_put_contents("$dir/Intro/ko.wikitext", "<!--T:1-->\n안녕. 이렇게 씁니다: $page");
+		// A subpage whose name is not a language code is a page in its own right, not a translation.
+		file_put_contents("$dir/Intro/Details.wikitext", $page);
+
+		$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
+		$found = TranslationSource::baseFiles($dir, $isKnownLanguage);
+
+		array_map('unlink', glob("$dir/Intro/*") ?: []);
+		array_map('unlink', glob("$dir/*.wikitext") ?: []);
+		rmdir("$dir/Intro");
+		rmdir($dir);
+
+		$this->assertSame(["$dir/Intro.wikitext", "$dir/Intro/Details.wikitext"], $found);
+	}
+
 	/** @dataProvider provideTranslatableTitle */
 	public function testTranslatableTitle(string $baseFile, string $text, ?string $expected) {
 		$this->assertSame($expected, TranslationSource::translatableTitle($baseFile, '/src', $text));


### PR DESCRIPTION
`baseFiles()` decided what a source page is from `isTranslatable()` alone, so `docs/<Page>/<lang>.wikitext` holding a real-looking `<translate>` became a base page in its own right. The bake would then mark `<Page>/<lang>` as translatable, and `translate check` would raise nothing, because Translate reads that file exactly the way wikven does. The naming convention is the only thing that says it is a translation, and nothing was consulting it.

Not reachable in this repo today: every `<translate>` quoted in a translation file is `<nowiki>`-wrapped or entity-escaped. The route widened with #358, which correctly made a `<translate>` shown inside `<syntaxhighlight>` count, since that is what Translate does with one.

`isTranslationFile()` already answers the question but needs a language test, which is what keeps an ordinary subpage from being mistaken for a translation. So `baseFiles()` now takes the `$isKnownLanguage` callable. Four of its six callers had built one already; the other two get it from the container they were holding anyway.

The new test pins both halves: `Intro/ko.wikitext` is left out even while quoting a whole translatable page, and `Intro/Details.wikitext` is still a base page of its own because `Details` is not a language code.

Docs are unaffected: 17 base files before, 17 after, the same 17.

Fixes #375

---
_Generated by [Claude Code](https://claude.com/claude-code)_