### PR TITLE
build: pin the bundled extensions to commits, not to a branch tip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # Base images are digest-pinned and version-tagged so Dependabot's bumps read as version numbers
-# rather than digests. Dependabot keeps them current. The pin fixes the base images alone: apk,
-# codeload and Packagist below are all read at build time, so the image is not reproducible.
+# rather than digests. Dependabot keeps them current. The pin fixes the base images alone: apk below
+# still resolves against the current Alpine index at build time, so the image is not reproducible.
 FROM composer:2.10.2@sha256:4d71c3c2109c61d5415544264b59ad4087e4c5b7244481723664138fd36d5040 AS composer
 
 # The alpine variant, because nothing here serves over HTTP: `build` runs a maintenance script and
 # `serve` runs PHP's own server, so the Apache the default variant carries is never started. Same
-# PHP extensions, 873MB against 1.5GB.
+# PHP extensions, 873MB against 1.5GB. A bump onto a new release branch has to take the bundled
+# extensions with it, and their branch is `branch` in updatecli/updatecli.d/mediawiki-extensions.yaml.
 FROM mediawiki:1.46.0-fpm-alpine@sha256:b0e9413c015268322cfb67908e5f92121372c7407f09f97a4ce8938a4351e4ad
 
 # composer to install third-party extensions/skins at bake time (git/tar/gzip/unzip present).
@@ -33,8 +34,11 @@ RUN arch="$TARGETARCH" \
 # image's MediaWiki branch. Translate pulls its runtime Composer deps (spyc) into its own vendor/,
 # which its load_composer_autoloader then loads.
 ENV COMPOSER_ALLOW_SUPERUSER=1
-ARG TRANSLATE_VERSION=REL1_46
-ARG ULS_VERSION=REL1_46
+# Commits, not the branch tip: REL1_46 takes translatewiki updates weekly, so a branch pin builds a
+# different Translate from the same wikven commit a week later. Bumped by updatecli, which reads the
+# branch these follow from its own manifest, so that branch moves there when this image's does.
+ARG TRANSLATE_VERSION=79db5ae621f57e043350b280ffceaaa7dec6d991
+ARG ULS_VERSION=ab91c5b52bc362c07c81a17dd7908a97ed27b9f1
 # Translate asks for its two runtime deps by range, so an unpinned install takes whatever Packagist
 # serves that day. Core's own answer to this is exact versions and no lock file, so: exact versions,
 # passed as temporary constraints rather than written into Translate's manifest. Bumped by updatecli.
@@ -52,9 +56,9 @@ ARG COMPOSER_INSTALLERS_VERSION=v2.3.0
 RUN composer config --global policy.advisories.block false \
  && ext=/var/www/html/extensions \
  && curl -fsSL -o /tmp/uls.tar.gz \
-      "https://codeload.github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector/tar.gz/refs/heads/$ULS_VERSION" \
+      "https://codeload.github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector/tar.gz/$ULS_VERSION" \
  && curl -fsSL -o /tmp/translate.tar.gz \
-      "https://codeload.github.com/wikimedia/mediawiki-extensions-Translate/tar.gz/refs/heads/$TRANSLATE_VERSION" \
+      "https://codeload.github.com/wikimedia/mediawiki-extensions-Translate/tar.gz/$TRANSLATE_VERSION" \
  && mkdir -p "$ext/UniversalLanguageSelector" "$ext/Translate" \
  && tar -xzf /tmp/uls.tar.gz --strip-components=1 -C "$ext/UniversalLanguageSelector" \
  && tar -xzf /tmp/translate.tar.gz --strip-components=1 -C "$ext/Translate" \

--- a/updatecli/updatecli.d/mediawiki-extensions.yaml
+++ b/updatecli/updatecli.d/mediawiki-extensions.yaml
@@ -1,0 +1,61 @@
+---
+name: "build(deps): bump the bundled MediaWiki extensions"
+pipelineid: mediawiki-extensions
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: chaotic-ground
+      repository: wikven
+      branch: main
+      user: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - dependencies
+
+# The Dockerfile pins both extensions to commits, so the branch they follow lives here rather than
+# there. It is the release branch of the image's MediaWiki, and moves when that base image does.
+sources:
+  translate:
+    name: Head of Translate's REL1_46
+    kind: gitcommit
+    spec:
+      url: https://github.com/wikimedia/mediawiki-extensions-Translate
+      branch: REL1_46
+      depth: 1
+  uls:
+    name: Head of UniversalLanguageSelector's REL1_46
+    kind: gitcommit
+    spec:
+      url: https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector
+      branch: REL1_46
+      depth: 1
+
+targets:
+  translate:
+    name: 'build(deps): bump Translate to {{ source "translate" }}'
+    kind: dockerfile
+    scmid: default
+    sourceid: translate
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: TRANSLATE_VERSION
+  uls:
+    name: 'build(deps): bump UniversalLanguageSelector to {{ source "uls" }}'
+    kind: dockerfile
+    scmid: default
+    sourceid: uls
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: ULS_VERSION


### PR DESCRIPTION
Closes #371.

codeload served both bundled extensions from a branch tip:

```dockerfile
ARG TRANSLATE_VERSION=REL1_46
curl -fsSL -o /tmp/translate.tar.gz \
  "https://codeload.github.com/wikimedia/mediawiki-extensions-Translate/tar.gz/refs/heads/$TRANSLATE_VERSION"
```

REL1_46 is a live maintenance branch, not a frozen tag, and it takes translatewiki's localisation updates weekly. So the same wikven commit built a week apart embedded a different Translate, with nothing in the image recording which one.

The ARGs now hold commit SHAs and the URLs drop the `refs/heads/` prefix, which codeload serves directly. Nothing else in the fetch changes: the tarball's top-level directory is simply named after the SHA instead of the branch, and `--strip-components=1` was already discarding that name.

## The source kind

#371 left this open: "that needs a source kind that resolves a branch to its head SHA; worth checking what updatecli v0.120.1 offers before committing to the approach." It offers two, and I measured both against the pinned v0.120.1 rather than picking from the docs.

**`gitcommit`** is purpose-built, and its spec says so: "Branch specifies the branch whose latest commit hash is returned." It clones, which is the cost. Both git-backed kinds (`gitcommit`, `gitbranch`) reach the branch by cloning and then force-fetching `refs/*:refs/*`, and updatecli's own code comments warn that mirroring every ref "can be very expensive on repositories with a large number of refs". Translate is exactly that repository: its GitHub mirror carries Gerrit's refs, 15,016 in total, of which 14,316 are `refs/changes/*`.

**`http`** would avoid the clone entirely, since `https://api.github.com/repos/OWNER/REPO/commits/BRANCH` returns the bare SHA as its body under `Accept: application/vnd.github.sha`, and the `http` source returns the response body verbatim.

Measured, cold, both extensions:

| | wall clock | downloaded |
| --- | --- | --- |
| `gitcommit` | 2m40s | ~190MB |
| `http` + GitHub API | 1.5s | a few bytes |

I took `gitcommit` anyway. This is a weekly cron job, so 2m40s buys nothing worth having, and the `http` form pays for its speed with two couplings the git one does not have: a GitHub API media type, and the unauthenticated 60/hour rate limit on the runner's IP. Reading refs over git has neither. The cost is real but bounded, and it is spent once a week.

`depth: 1` is on both sources: it does not avoid the full-ref fetch, but it does keep the history out.

## Where REL1_46 went

The visible cost of this change: the branch name leaves the Dockerfile, where it used to sit two lines under `FROM mediawiki:1.46.0-fpm-alpine`, and lives only in the manifest's `branch:`. So a bump onto 1.47 could silently keep bundling REL1_46 extensions against 1.47 core.

I looked for a build-time guard and could not find an honest one. Translate's `extension.json` declares `requires.MediaWiki` as a floor, not a branch, so a REL1_46 checkout satisfies 1.47 core and a check against it would pass while wrong. A codeload tarball fetched by SHA carries no branch identity at all. So instead the note goes where the mistake would actually be made, at the base image:

```dockerfile
# PHP extensions, 873MB against 1.5GB. A bump onto a new release branch has to take the bundled
# extensions with it, and their branch is `branch` in updatecli/updatecli.d/mediawiki-extensions.yaml.
```

Both extensions sit in one pipeline, so updatecli moves them in a single pull request rather than two, which is what #371 asked for. Dependabot's `mediawiki` group still owns the base image; the two tools cannot be grouped, and the comment above is what ties them.

## The header comment

`Dockerfile` opened by naming three inputs read live at build time: apk, codeload and Packagist. #378 pinned Packagist exactly and this pins codeload, so apk is the one that is left, and the comment now says so rather than overclaiming reproducibility.

## Verified

- `updatecli diff` against the worktree, on v0.120.1, the version the workflow pins. Both sources resolve, and both targets land on the right lines: `#39 ... TRANSLATE_VERSION` and `#40 ... ULS_VERSION`, each already correct.
- Both resolved SHAs match `git ls-remote refs/heads/REL1_46` exactly: `79db5ae6...` for Translate, `ab91c5b5...` for ULS.
- Ran the same manifest against a copy of the Dockerfile with a deliberately stale Translate pin. It reports the bump and rewrites line 39, so the loop closes in both directions, not just the no-op one.
- codeload serves `tar.gz/<sha>`: HTTP 200, 12,738,051 bytes for ULS. Extracted with the Dockerfile's own `--strip-components=1` and `extension.json` lands at the root, as it did with the branch name.
- Built the image. It gets the code the pins name, not merely code that downloads: `extension.json` inside the image hashes to `34041c5b...` for ULS and `9ca0fb79...` for Translate, and both match the upstream file at those exact commits byte for byte.
- `yamllint --strict .` clean.

## Not addressed

`.yaml` versus `.yml` for the new manifest, same as #378: repository policy is `.yml` for internal YAML, but `updatecli/updatecli.d/` is all `.yaml`, so this matches its siblings rather than splitting the directory three ways. A rename of all four belongs in its own change.
