### PR TITLE
fix: give Citizen's search shortcuts the search the export has

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -26,6 +26,9 @@
 		"ext.Wikven.citizenSkins": {
 			"scripts": ["citizen-skins.js"],
 			"messages": ["wikven-skin", "wikven-skin-description"]
+		},
+		"ext.Wikven.citizenSearchShortcuts": {
+			"scripts": ["citizen-search-shortcuts.js"]
 		}
 	},
 	"ResourceFileModulePaths": {

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -99,14 +99,20 @@ class Adder implements
 			$out->addModuleStyles('ext.Wikven.emptyToolbox');
 		}
 
-		// Citizen registers a service worker at "$wgScriptPath/load.php" whenever the client-side
-		// script path is the wiki root (""), which is what the build installs with, and the request
-		// 404s on every page. There is no script path in a static export -- no index.php, load.php
-		// or api.php -- so say so, and the registration returns early on its own guard. Citizen is
-		// the only thing that reads the value for a decision; what else reads it builds api.php and
-		// rest.php URLs, which are dead here whichever way it is set.
 		if (MW_ENTRY_POINT === 'cli' && $skin->getSkinName() === 'citizen') {
+			// Citizen registers a service worker at "$wgScriptPath/load.php" whenever the client-side
+			// script path is the wiki root (""), which is what the build installs with, and the request
+			// 404s on every page. There is no script path in a static export -- no index.php, load.php
+			// or api.php -- so say so, and the registration returns early on its own guard. Citizen is
+			// the only thing that reads the value for a decision; what else reads it builds api.php and
+			// rest.php URLs, which are dead here whichever way it is set.
 			$out->addJsConfigVars('wgScriptPath', null);
+
+			// The skin's search shortcuts outlive the command palette the bake leaves out: skin.js
+			// binds them whether or not the trigger they open is still there, so "/" and Ctrl+K reach
+			// for two modules the export does not ship. The module tells the loader as much, so the
+			// request is never built, and opens the search form the export does have instead.
+			$out->addModules('ext.Wikven.citizenSearchShortcuts');
 		}
 
 		// Citizen's preferences panel is where its readers change how a page looks, so the skin list

--- a/resources/citizen-search-shortcuts.js
+++ b/resources/citizen-search-shortcuts.js
@@ -1,0 +1,167 @@
+/**
+ * Give Citizen's search shortcuts something the export actually has to open.
+ *
+ * The skin's own search is a command palette backed by the REST API, so the bake leaves it out:
+ * maintenance/rewriteScripts.php drops the trigger's id and commandPalette.js returns early without
+ * it, which is what leaves the plain form underneath standing for SifterSearch to retarget. What
+ * the bake cannot drop is the shortcuts. skin.js calls search.init() on the line after
+ * commandPalette.init() has bailed, unconditionally, so "/", Ctrl+K and the access key still reach
+ * for a palette that is not there, and fetch two modules the export does not ship.
+ *
+ * Two separate things are wrong, and they are fixed separately.
+ *
+ * The 404s are closed in the loader rather than by racing the skin for the keystroke. Listener
+ * order cannot be relied on here: mw.loader executes modules from a requestIdleCallback that fires
+ * after DOMContentLoaded, so the skin registers its window listener when its own module runs, and
+ * whether that is before or after this one is not ours to decide. Marking the modules failed
+ * instead makes the outcome the same either way -- mw.loader.using() rejects out of enqueue()
+ * before it builds a request, so the skin's trigger runs its state machine and settles silently.
+ *
+ * The dead keystroke is fixed by binding the same shortcuts and opening the form. The chord tests
+ * mirror skins.citizen.scripts/keyboardLayout.js, which is module-private and cannot be required
+ * from here. Mirroring rather than simplifying is deliberate: this must claim exactly what the skin
+ * would have claimed, so no key is swallowed that the skin would have left to the browser.
+ */
+(() => {
+	// Per-skin bakes mean this only ships with Citizen, but the bundle self-executes every module it
+	// holds, so say what it is for rather than leaning on that.
+	if (mw.config.get("skin") !== "citizen") {
+		return;
+	}
+
+	const DETAILS_ID = "citizen-search-details";
+	const TRIGGER_ID = "citizen-search-summary";
+	const INPUT_ID = "searchInput";
+
+	// What a palette trigger asks for at run time: the palette, and the toast mw.notify lazy-loads
+	// to report that the palette did not come. Neither is queued by any page, so neither is in the
+	// bundle, and both are a 404 on a site with no load.php behind it.
+	const UNSHIPPED = ["skins.citizen.commandPalette", "mediawiki.notification"];
+
+	// modules-static.js has run by now -- it is a plain <script> in <head>, ahead of the load() that
+	// schedules this -- so everything the bundle carries is at least "loaded". Anything still merely
+	// registered came from the startup registry and has no code behind it here.
+	for (const name of UNSHIPPED) {
+		if (mw.loader.getState(name) === "registered") {
+			mw.loader.state({ [name]: "error" });
+		}
+	}
+
+	// Macs compose characters with Option where other platforms use AltGr, and use Control+Option
+	// where they use Alt+Shift. userAgentData is Chromium-only; platform is deprecated but universal.
+	const isMac = /mac|iphone|ipad/i.test(
+		navigator.userAgentData?.platform || navigator.platform || "",
+	);
+
+	// Match the letter typed rather than the key position, falling back to position where no Latin
+	// letter is produced at all: Cyrillic and Greek keycaps carry a Latin legend that follows the US
+	// positions, and macOS rewrites every Option chord into a glyph. ASCII-only, because full
+	// Unicode case folding maps U+017F and U+212A onto "s" and "k".
+	const isLetterPressed = (event, letter) =>
+		/^[a-z]$/i.test(event.key)
+			? event.key.toLowerCase() === letter
+			: event.code === `Key${letter.toUpperCase()}`;
+
+	// Whether the event is a character composed with AltGr rather than a chord. Windows delivers
+	// AltGr as Ctrl+Alt and a Mac composes the same characters with Option alone, neither of which
+	// the modifier flags tell apart from a chord; the single-character test is what keeps real
+	// chords (Ctrl+Alt+ArrowDown) out.
+	const isAltGraphChar = (event) => {
+		if (event.metaKey || !event.altKey || (event.key || "").length !== 1) {
+			return false;
+		}
+		if (event.key === " ") {
+			return false;
+		}
+		return (
+			event.getModifierState?.("AltGraph") === true || event.ctrlKey || isMac
+		);
+	};
+
+	// mediawiki.util resolves the access-key chord per platform. These are the two Citizen claims;
+	// it leaves the bare Alt and bare Ctrl fallbacks alone, because Alt+F is the Windows File menu
+	// and Ctrl+F is find-in-page.
+	const isAccessKeyChord = (event) => {
+		if (event.metaKey) {
+			return false;
+		}
+		if (event.altKey && event.shiftKey && !event.ctrlKey) {
+			return true;
+		}
+		return isMac && event.ctrlKey && event.altKey && !event.shiftKey;
+	};
+
+	const OPEN_SHORTCUTS = [
+		// "/". A bare Ctrl means a chord, but AltGr types "/" on some layouts.
+		(event) =>
+			event.key === "/" &&
+			!event.metaKey &&
+			(!event.ctrlKey || isAltGraphChar(event)),
+		// Ctrl+K, or Command+K on a Mac. A further modifier makes it someone else's chord.
+		(event) =>
+			(event.ctrlKey || event.metaKey) &&
+			!event.altKey &&
+			!event.shiftKey &&
+			isLetterPressed(event, "k"),
+		// "F" is the access key MediaWiki assigns to search.
+		(event) => isAccessKeyChord(event) && isLetterPressed(event, "f"),
+	];
+
+	// Typing "/" into a search field must reach the field, not reopen it. The skin gates its own
+	// shortcuts the same way, so a field keeps both of us out.
+	const isFormField = (element) => {
+		if (!(element instanceof HTMLElement)) {
+			return false;
+		}
+		const name = element.nodeName.toLowerCase();
+		const type = (element.getAttribute("type") || "").toLowerCase();
+		return (
+			name === "select" ||
+			name === "textarea" ||
+			(name === "input" &&
+				type !== "submit" &&
+				type !== "reset" &&
+				type !== "checkbox" &&
+				type !== "radio") ||
+			element.isContentEditable
+		);
+	};
+
+	// The card is revealed by the [open] attribute on the <details> (Search.less), and Citizen's own
+	// dropdown.js is listening for that toggle: opening it this way is what hands Escape and
+	// click-away dismissal back to the skin. Nothing to open where the export has no search at all,
+	// and the shortcut is still swallowed, because doing nothing is the honest answer there.
+	const openSearch = () => {
+		const details = document.getElementById(DETAILS_ID);
+		const input = document.getElementById(INPUT_ID);
+		if (!details || !input) {
+			return;
+		}
+		details.open = true;
+		input.focus();
+	};
+
+	window.addEventListener(
+		"keydown",
+		(event) => {
+			// Only where the palette has no trigger to open. With one present the skin is running its
+			// own search -- a wiki with a server behind it -- and this has no business in the way.
+			if (document.getElementById(TRIGGER_ID)) {
+				return;
+			}
+			if (
+				isFormField(event.target) ||
+				!OPEN_SHORTCUTS.some((matches) => matches(event))
+			) {
+				return;
+			}
+			// Firefox quickfind would otherwise take "/". Stopping the rest of the listeners on this
+			// target spares the skin's own a pointless round through a palette that cannot load; it is
+			// not what keeps the request from being made, and does nothing when the skin ran first.
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			openSearch();
+		},
+		true,
+	);
+})();

--- a/tests/e2e/citizen.spec.js
+++ b/tests/e2e/citizen.spec.js
@@ -77,10 +77,15 @@ test("Citizen's search shortcuts open the search the export has", async ({
 }) => {
 	// The skin binds "/" and Ctrl+K to its command palette in skin.js whether or not the trigger
 	// they open survived the bake, so left alone they fetch a module the export does not ship. What
-	// this asserts is both halves: the form opens, and nothing goes to a backend.
+	// this asserts is both halves: the form opens, and neither module is asked for.
+	//
+	// Narrowed to those two rather than to any backend request, because focusing a text field also
+	// has UniversalLanguageSelector fetch its input methods (#398), which is older than this and not
+	// Citizen's. "a Citizen page gets everything it asks for" below still holds the wider line.
+	const PALETTE = /skins\.citizen\.commandPalette|mediawiki\.notification/;
 	const backend = [];
 	page.on("request", (request) => {
-		if (BACKEND.test(request.url())) {
+		if (BACKEND.test(request.url()) && PALETTE.test(request.url())) {
 			backend.push(request.url());
 		}
 	});

--- a/tests/e2e/citizen.spec.js
+++ b/tests/e2e/citizen.spec.js
@@ -72,6 +72,53 @@ test("Citizen's search box suggests pages as you type", async ({ page }) => {
 	).not.toBe("rgb(255, 255, 255)");
 });
 
+test("Citizen's search shortcuts open the search the export has", async ({
+	page,
+}) => {
+	// The skin binds "/" and Ctrl+K to its command palette in skin.js whether or not the trigger
+	// they open survived the bake, so left alone they fetch a module the export does not ship. What
+	// this asserts is both halves: the form opens, and nothing goes to a backend.
+	const backend = [];
+	page.on("request", (request) => {
+		if (BACKEND.test(request.url())) {
+			backend.push(request.url());
+		}
+	});
+
+	await page.goto(PAGE);
+
+	// Which listener the keystroke reaches first is up to mw.loader, so what keeps the request from
+	// being made is the palette being marked failed rather than merely registered.
+	expect(
+		await page.evaluate(() =>
+			mw.loader.getState("skins.citizen.commandPalette"),
+		),
+	).toBe("error");
+
+	await page.keyboard.press("/");
+	await expect(page.locator("#citizen-search-details")).toHaveJSProperty(
+		"open",
+		true,
+	);
+	await expect(page.locator("#searchInput")).toBeFocused();
+
+	// Escape is the skin's own dismissal (dropdown.js), which opening the <details> rather than
+	// unclipping the card by hand is what buys.
+	await page.keyboard.press("Escape");
+	await expect(page.locator("#citizen-search-details")).toHaveJSProperty(
+		"open",
+		false,
+	);
+
+	// The shortcuts are inert while focus is in a field, in the export as in the skin, so the
+	// second one is only reachable once focus has left the search box.
+	await page.locator("#firstHeading").click();
+	await page.keyboard.press("ControlOrMeta+k");
+	await expect(page.locator("#searchInput")).toBeFocused();
+
+	expect(backend, backend.join("; ")).toEqual([]);
+});
+
 test("Citizen's preferences panel loads and switches the theme", async ({
 	page,
 }) => {

--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -105,6 +105,38 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
+	 * Citizen binds its search shortcuts whether or not the command palette they open survived the
+	 * bake, so the export takes them over. Only Citizen has them, so only Citizen gets the module.
+	 *
+	 * @dataProvider provideSearchShortcutSkins
+	 */
+	public function testSearchShortcutsAreTakenOverForCitizenOnly(string $skin, bool $expected) {
+		$this->overrideConfigValue('WikvenSkins', [$skin]);
+		$modules = [];
+		$out = $this->createMock(OutputPage::class);
+		$out->method('addModules')->willReturnCallback(static function ($name) use (&$modules) {
+			$modules[] = $name;
+		});
+		$skinMock = $this->createMock(Skin::class);
+		$skinMock->method('getSkinName')->willReturn($skin);
+
+		( new Adder() )->onBeforePageDisplay($out, $skinMock);
+
+		$this->assertSame(
+			$expected,
+			in_array('ext.Wikven.citizenSearchShortcuts', $modules, true)
+		);
+	}
+
+	public static function provideSearchShortcutSkins() {
+		return [
+			'citizen' => ['citizen', true],
+			'vector' => ['vector-2022', false],
+			'minerva' => ['minerva', false]
+		];
+	}
+
+	/**
 	 * The chooser that carries the skin list into Citizen's preferences panel is only worth
 	 * loading where there is a panel to put it in and more than one skin to choose between.
 	 *


### PR DESCRIPTION
Closes #384.

Citizen's search is a command palette backed by the REST API, so the bake leaves it out: `rewriteScripts.php` drops the trigger's id, `commandPalette.js` returns early without it, and the plain form underneath survives for SifterSearch to retarget. The shortcuts do not go with it. `skin.js` calls `search.init()` on the line after `commandPalette.init()` has bailed, unconditionally, so `/`, `Ctrl`+`K` and `Alt`+`Shift`+`F` still route to a palette that is not there: two 404s per press, and nothing on screen.

Two things are wrong here, and they are fixed separately.

## The 404s, in the loader rather than by winning a race

The obvious fix is to bind the same keys first and stop the event before the skin's listener sees it. Listener order cannot carry that weight. `mw.loader` executes modules from a `requestIdleCallback`, and that fires *after* `DOMContentLoaded` (measured in Chromium, 12 runs out of 12 on a page the size of ours), so the skin registers its `window` listener when its own module runs rather than at `DOMContentLoaded`, and whether that lands before or after this module is `mw.loader`'s business, not ours.

So the request is stopped where it is built instead. The module marks `skins.citizen.commandPalette` and `mediawiki.notification` (the toast `mw.notify` lazy-loads to report the first one missing) as failed, and `enqueue()` rejects out of `anyFailed()` before it builds a request. Each is marked only while still merely `registered`, which on a bundle that has already run every `mw.loader.impl()` it carries means the bundle does not have it, so an export that does ship one is left alone.

## The dead keystroke

The module binds the same three shortcuts and opens the search form, by setting `[open]` on the `<details>` the card hangs off. That is also what hands `Escape` and click-away dismissal back to the skin: `dropdown.js` is listening for that toggle.

The chord tests mirror `skins.citizen.scripts/keyboardLayout.js`, which is module-private and cannot be required from here. Mirroring rather than simplifying is deliberate: this has to claim exactly what the skin would have claimed, so no keystroke is swallowed that the skin would have left to the browser, AltGr layouts and the Mac's `Control`+`Option` access-key chord included.

Where the export has no search at all (no SifterSearch, or no results page for it), the shortcut is still swallowed and does nothing, which is the honest answer there. Where the trigger is present, a wiki with a server behind it, the module stands down and the skin keeps its own shortcuts.

## Not upstream

#384 originally asked Citizen for a `$wgCitizenEnableCommandPalette` switch or a seam for the palette's search client. That framing is gone from the issue: the skin is not at fault, since on a wiki with a server the trigger is always in the DOM and `load.php` answers. wikven is what takes the trigger away, so wikven is what fixes it.

## Testing

`tests/e2e/citizen.spec.js` presses `/` and `Ctrl`+`K` on a baked page and asserts the form opens, focus lands in it, and no request reaches a backend.

Beyond that, both listener orders were exercised in Chromium against the module file itself, with a stand-in for `skins.citizen.scripts` and a `mw.loader` that records what would have been fetched: 11 checks, and in both orders the form opens and nothing is requested.
