### PR TITLE
fix: stop ULS reaching for input methods the export cannot serve

### DIFF
--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -102,6 +102,7 @@ class Main implements
 	 */
 	public function onSetupAfterCache(): void {
 		$this->restoreCitizenSearchWiring();
+		$this->unbindUlsInputMethods();
 
 		$wikvenLogos = $this->config->get('WikvenLogos');
 		if (!is_array($wikvenLogos) || $wikvenLogos === []) {
@@ -153,6 +154,27 @@ class Main implements
 		MediaWikiServices::getInstance()
 			->getHookContainer()
 			->register('SkinPageReadyConfig', [$this, 'enableCitizenSearch']);
+	}
+
+	/**
+	 * Leave ULS's input methods with no field to attach to.
+	 *
+	 * ULSIMEEnabled, which WikvenSettings turns off, does not stop the request: ext.uls.interface
+	 * binds a focus handler to every text field whatever that flag says, and the flag is read
+	 * inside ext.uls.ime, which the handler has fetched from load.php by then. So the empty
+	 * selector list is what actually keeps the export quiet on the first click into a field.
+	 *
+	 * It has to be set here rather than in WikvenSettings.php, because an empty array is the one
+	 * value ExtensionRegistry does not keep: it reads as "not set", and the extension's own
+	 * default replaces it wholesale when the registry applies extension.json config.
+	 *
+	 * The global is the test for ULS: it exists because ULS's extension.json declares it.
+	 */
+	private function unbindUlsInputMethods(): void {
+		if (!isset($GLOBALS['wgULSImeSelectors'])) {
+			return;
+		}
+		$GLOBALS['wgULSImeSelectors'] = [];
 	}
 
 	/**

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -247,7 +247,9 @@ foreach ($config['extensions'] ?? [] as $extension) {
 // the same fonts into a static stylesheet (see includes/Webfonts/FontRepository.php).
 // Its input methods go the same way: focusing any text input -- the search box, most visibly --
 // has the browser fetch ext.uls.ime and jquery.ime from load.php. Nothing in an export takes
-// typed input anywhere, so there is nothing for a transliteration keyboard to type into.
+// typed input anywhere, so there is nothing for a transliteration keyboard to type into. The flag
+// below is not what stops that fetch: Main::onSetupAfterCache() empties the list of selectors the
+// handler binds to, and says there why that cannot be done from here.
 if (in_array('UniversalLanguageSelector', $config['extensions'], true)) {
 	$GLOBALS['wgULSWebfontsEnabled'] = false;
 	$GLOBALS['wgULSIMEEnabled'] = false;

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -36,6 +36,12 @@ test("a content page fetches nothing from a live backend", async ({ page }) => {
 	// the property under test here.
 	await page.goto("Installation.html", { waitUntil: "networkidle" });
 
+	// A page can be quiet on load and still reach for a backend on the first thing a reader does.
+	// ULS binds its input methods to text fields and fetches them on first focus, so the click is
+	// part of the claim rather than a separate one.
+	await page.locator("#searchInput").first().click();
+	await page.waitForLoadState("networkidle");
+
 	expect(backend, backend.join("; ")).toEqual([]);
 });
 

--- a/tests/phpunit/integration/MainSetupAfterCacheTest.php
+++ b/tests/phpunit/integration/MainSetupAfterCacheTest.php
@@ -113,4 +113,25 @@ class MainSetupAfterCacheTest extends MediaWikiIntegrationTestCase {
 			'another skin keeps its own answer' => ['vector-2022', false]
 		];
 	}
+
+	/**
+	 * ULS fetches its input methods from load.php the first time a reader focuses a text field, and
+	 * an export has no load.php. Emptying the selector list is what leaves the handler nothing to
+	 * bind to, and it belongs here: set at LocalSettings time, an empty array reads to
+	 * ExtensionRegistry as "not set" and ULS's own default replaces it.
+	 */
+	public function testUlsInputMethodsAreLeftWithNoFieldToBindTo() {
+		$this->setMwGlobals('wgULSImeSelectors', ['input[type=text]', 'textarea']);
+		$this->main()->onSetupAfterCache();
+		$this->assertSame([], $GLOBALS['wgULSImeSelectors']);
+	}
+
+	/** Without ULS there is no such config, and inventing one would be a global that means nothing. */
+	public function testTheUlsSelectorListIsNotInventedWithoutUls() {
+		if (array_key_exists('wgULSImeSelectors', $GLOBALS)) {
+			$this->markTestSkipped('ULS is loaded here, so there is no "without ULS" to assert');
+		}
+		$this->main()->onSetupAfterCache();
+		$this->assertArrayNotHasKey('wgULSImeSelectors', $GLOBALS);
+	}
 }


### PR DESCRIPTION
Closes #398.

Reproduced first, as a browser assertion rather than by reading the code, on a locally baked `docs/`:

```
Error: http://127.0.0.1:47249/load.php?lang=en&modules=ext.uls.ime%7Cjquery.ime&skin=vector-2022&version=4y7cr
```

## Why the flag already there does not do it

`WikvenSettings.php` has set `ULSIMEEnabled` to `false` since #369, with a comment naming this exact request. It does not stop it, and the reason is the order of the two things:

```js
// ext.uls.interface.js
function initIme() {
    const imeSelector = mw.config.get( 'wgULSImeSelectors' ).join( ', ' );
    $( document.body ).on( 'focus.imeinit', imeSelector, function () {
        ...
        mw.loader.using( 'ext.uls.ime', () => { ... } );
    } );
}
```

`init()` calls `initIme()` unconditionally, and the flag is read at `ext.uls.ime.js:110`, inside the module the handler has already fetched by then. The flag governs whether an input method is *applied*, never whether the module is *loaded*, so it can only take effect after the 404 it was meant to prevent.

## Emptying the selector list, and where that has to happen

`ULSImeSelectors` is ULS's own config for which elements get an input method, so emptying it is the honest statement: none of them. In jQuery 3.7.1, which is what core ships, the joined empty string is falsy, so `jQuery.event.add` takes the `else` branch at the `if ( selector )` on line 5011 and registers a direct handler on `document.body` rather than a delegate. `focus` does not bubble, so it never fires and nothing is fetched.

The interesting part is that this cannot go in `WikvenSettings.php` next to the flag, which is where I first put it and where it silently did nothing. `ExtensionRegistry` treats an empty array as absent:

```php
} elseif ( !$GLOBALS[$key] ) {
    // Performance optimization: When the target is an empty array, just set it
    $GLOBALS[$key] = $val;
    continue;
}
```

So an empty array set at LocalSettings time is replaced wholesale by ULS's default when the registry applies `extension.json` config. That is also why the two booleans beside it *do* work: a scalar hits the branch above, where an existing global overrides the default. It goes in `Main::onSetupAfterCache()` instead, which already exists for config that cannot be settled that early, and the comment in `WikvenSettings.php` now points at it rather than implying the flag is the fix.

The method keys off the global rather than `ExtensionRegistry::isLoaded()` so that what it does can be asserted where ULS is not installed, which is every environment CI runs PHPUnit in.

## The test that should have caught it

`smoke.spec.js` already claimed "a content page fetches nothing from a live backend", and that claim was true: this request does not fire on load. It fires on the first click into a field. So the test now clicks into the search box before asserting, which makes the claim the one worth making, and it fails on `main`.

## Not addressed

The issue also notes the path: the request goes to `/load.php` at the domain root while the site is served under `/wikven/`. This change removes the request rather than repointing it, and any `load.php` request is wrong at either path, so nothing here depends on that. Worth its own issue if some other module turns out to reach for one.

## Verified

- The new assertion fails on `main` with the URL above and passes with the change, against an image built and a `docs/` baked locally.
- `wgULSImeSelectors` in the baked bundle: `["input:not([type])","input[type=text]",...]` before, `[]` after.
- Full Playwright suite, 30 tests, green. The two specs that type into the search box (`smoke.spec.js`, `citizen.spec.js`) pass, so the typeahead is untouched by this.
- `composer test` clean.
