### PR TITLE
ci: run the PHPUnit jobs with the settings CI actually tests under

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Install MediaWiki dependencies
         working-directory: mediawiki
         run: composer install --no-interaction --no-progress
+      # --with-developmentsettings loads what Quibble loads; it turns on $wgEnableJavaScriptTest, which #392 needed.
       - name: Install MediaWiki (SQLite)
         working-directory: mediawiki
         run: |
@@ -66,6 +67,7 @@ jobs:
             --dbtype=sqlite --dbpath="$RUNNER_TEMP/wikidb" \
             --scriptpath='' \
             --pass=adminpassword \
+            --with-developmentsettings \
             TestWiki Admin
       - name: Enable Wikven
         working-directory: mediawiki


### PR DESCRIPTION
The `phpunit` jobs install MediaWiki bare and append `wfLoadExtension( 'Wikven' );`, nothing more. Quibble's LocalSettings does `require_once "$IP/includes/DevelopmentSettings.php"`, which sets `$wgEnableJavaScriptTest = true`, and only under that flag does `ServiceWiring` call `ResourceLoader::registerTestModules()`. That method includes `tests/qunit/QUnitTestResources.php`, which walks `{$GLOBALS['IP']}/resources/src/mediawiki.language/languages` with a `DirectoryIterator`.

That is the whole of #392's blind spot. `AssetLocalizerTest` relocated `$IP` before the service container built the ResourceLoader, so the iterator ran against a temp directory and all four tests errored, but only where the flag was on. Our `phpunit` jobs never turned it on, so the coverage job was the only one running these tests into an error, and it was the one job that could not fail.

Install with `--with-developmentsettings`. `LocalSettingsGenerator` writes exactly that `require_once` into `LocalSettings.php` on both REL1_46 and master, so this is the installer's own way of asking for it rather than a line we append ourselves. These jobs then test what CI runs, on both branches, instead of a wiki configured differently from every other job.

To be clear about what this does and does not fix: the fixture itself was already corrected in #387, so nothing here reproduces today. What it buys is that the ordering bug is now caught by the job that runs on every PR, rather than only by a coverage job that could not report the failure.

Follow-up, separately: femiwiki/quibble-action#61 makes the coverage job itself stop reporting success over a failing suite. This PR restores the gate; that one stops the lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nbsp5JSS7UFVNiD9hi9UVU