### PR TITLE
ci: call updatecli through the pipeline subcommand

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           version: v0.120.1
 
-      - run: updatecli apply --config updatecli/updatecli.d
+      - run: updatecli pipeline apply --config updatecli/updatecli.d
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A manual run in SifterSearch, which copied this workflow, warned:

```
WARNING: Deprecated command, please instead use `updatecli pipeline apply`
```

It still works today, but it is on its way out. Same flags, same behaviour. Fixed there in chaotic-ground/SifterSearch#53.

Verified by dispatching this workflow from the branch ([run](https://github.com/chaotic-ground/wikven/actions/runs/31928457163)): the warning is gone, and all five pipelines still resolve and report as before, with `Succeeded: 5, Changed: 0, Failed: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JF2iBnkGd8HydwdrGj8CM