### PR TITLE
build(deps): pin MobileFrontend to a commit

### DIFF
--- a/docs/.wikven.yml
+++ b/docs/.wikven.yml
@@ -48,6 +48,8 @@ config:
     # the skin skips initMobile.js entirely (see its setup.js). This site builds the pair so the
     # configuration wikven recommends for Minerva is the one CI renders. Mirrored from Gerrit,
     # which throttles Actions runners.
+    # Pinned to a commit rather than to REL1_46's tip, so a build of a given revision of this
+    # repository fetches the code that revision was tested against. updatecli moves the pin.
     MobileFrontend:
       repository: https://github.com/wikimedia/mediawiki-extensions-MobileFrontend.git
-      reference: REL1_46
+      commit: e00881d4d6f2e91f57026e8fa81a7dd8ad71cda4

--- a/updatecli/updatecli.d/mediawiki-extensions.yaml
+++ b/updatecli/updatecli.d/mediawiki-extensions.yaml
@@ -20,8 +20,10 @@ actions:
       labels:
         - dependencies
 
-# The Dockerfile pins both extensions to commits, so the branch they follow lives here rather than
-# there. It is the release branch of the image's MediaWiki, and moves when that base image does.
+# Every pin here is a commit, so the branch it follows lives here rather than beside it. It is the
+# release branch of the image's MediaWiki, and moves when that base image does. Two of the three are
+# bundled by the Dockerfile; MobileFrontend is fetched at build time by the docs site, which is the
+# only site that installs it.
 sources:
   translate:
     name: Head of Translate's REL1_46
@@ -35,6 +37,13 @@ sources:
     kind: gitcommit
     spec:
       url: https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector
+      branch: REL1_46
+      depth: 1
+  mobilefrontend:
+    name: Head of MobileFrontend's REL1_46
+    kind: gitcommit
+    spec:
+      url: https://github.com/wikimedia/mediawiki-extensions-MobileFrontend
       branch: REL1_46
       depth: 1
 
@@ -59,3 +68,11 @@ targets:
       instruction:
         keyword: ARG
         matcher: ULS_VERSION
+  mobilefrontend:
+    name: 'build(deps): bump MobileFrontend to {{ source "mobilefrontend" }}'
+    kind: yaml
+    scmid: default
+    sourceid: mobilefrontend
+    spec:
+      file: docs/.wikven.yml
+      key: $.config.WikvenRepositories.MobileFrontend.commit


### PR DESCRIPTION
The docs site fetches MobileFrontend at build time, and it was the one source still following a branch tip: a build of a given revision of this repository got whatever `REL1_46` held that day. Its neighbours in the same map are pinned to tags (`v4.0.0`, `v3.17.0`), and #396 pinned the Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)'s two extensions to commits for the same reason. MobileFrontend has no release tag on the mirror -- the last one is `REL1_42` -- so a commit is the only pin available.

The updatecli policy that walks Translate and UniversalLanguageSelector walks this one too, so the pin still follows the release branch of the image's MediaWiki; it just moves in a reviewable pull request rather than under a build.

That target writes YAML rather than a Dockerfile `ARG`, which is new here, so I checked what it does to a file this heavily commented: parsed and rewritten with goccy/go-yaml v1.19.2 (the library and version the pinned updatecli v0.120.1 uses, through the same FilterNode/ReplaceWithNode path), the change is the one line and nothing else -- comments, the document marker, and every other key survive.

Built and baked the docs site locally with the pin in place: the fetch by SHA works against the mirror (`git fetch --depth 1 origin <sha>`, which is the path `fetchExtensions.php` already had for `commit:`), and the Minerva output is unchanged.

The `reference: REL1_46` in `docs/Skins.wikitext` stays as it is: that snippet teaches a reader how to enable MobileFrontend, and a SHA copied out of documentation is a stale SHA. `Configuration.wikitext` already tells them which of the two is reproducible.