### PR TITLE
build: pin quibble-action to v2.0.2, which fails on a failing suite

### DIFF
--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: femiwiki/quibble-action@d799e5bb348756ea1588f2b5f2ca7fc09fdbdac9  # v2.0.1
+      - uses: femiwiki/quibble-action@3ce3d15fc42e28f2b4a01da22957f263286b4361  # v2.0.2
         with:
           stage: phan
           mediawiki-version: ${{ matrix.mediawiki-version }}
@@ -42,7 +42,7 @@ jobs:
         with:
           persist-credentials: false
       - id: quibble
-        uses: femiwiki/quibble-action@d799e5bb348756ea1588f2b5f2ca7fc09fdbdac9  # v2.0.1
+        uses: femiwiki/quibble-action@3ce3d15fc42e28f2b4a01da22957f263286b4361  # v2.0.2
         with:
           stage: coverage
           # Coverage tooling lives only on MediaWiki master.


### PR DESCRIPTION
Closes #392.

The `coverage` job has concluded `success` over an erroring PHPUnit run for as long as it has existed. femiwiki/quibble-action v2.0.2 reads the JUnit report the run leaves behind and exits non-zero on any failure, any error, a report it cannot read, or a run that collected no tests at all.

The report is still written before that check, so `steps.quibble.outputs.coverage` is unaffected and the Codecov upload keeps working exactly as it did. What changes is that the upload no longer runs when the suite failed, which is the point: publishing coverage from a broken run is how `includes/AssetLocalizer.php` came to sit at 0/85 lines on both the head and the base commit without anything turning red.

Together with #403, which restores the gate by installing with `--with-developmentsettings`, both halves of #392 are now covered: the `phpunit` jobs run these tests under the settings that expose them, and the coverage job can no longer hide a failure if they ever diverge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nbsp5JSS7UFVNiD9hi9UVU