### PR TITLE
build: run phpcs from the commit hook

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -5,6 +5,8 @@ grumphp:
         # none are staged, and offer to re-run with fixes applied when they fail.
         mago_format: ~
         mago_lint: ~
+        phpcs:
+            standard: .phpcs.xml
         # No native task exists for these, so they run as they do in CI.
         shell:
             scripts:
@@ -13,4 +15,5 @@ grumphp:
                 - ["-c", "taplo fmt --check"]
                 - ["-c", "taplo check"]
                 - ["-c", "vendor/bin/minus-x check ."]
+                - ["-c", "composer validate --no-check-publish"]
             triggered_by: [php, json, css, less, js, ts, md, toml]


### PR DESCRIPTION
Closes #395.

`grumphp.yml` ran `mago_format`, `mago_lint`, and a shell task for biome, rumdl, taplo and minus-x. phpcs was not among them, so a commit phpcs rejects went out and came back as a red check minutes later, twice in #366.

GrumPHP's native `phpcs` task scopes to the staged PHP files and skips when none are staged, like the mago tasks beside it. `standard: .phpcs.xml` is the same ruleset `composer phpcs` and the `phpcs` CI job use.

Verified on the #366 case, an untyped parameter under a doc comment: the hook fails with `MediaWiki.Commenting.FunctionComment.MissingParamTag`, and skips entirely when nothing PHP is staged.

## Which phpcs the hook runs

The issue asked whether the hook should fail loudly when the installed sniffs do not satisfy `composer.json`. It should, because a hook that reports success against the wrong sniff set is worse than no hook, and `composer validate --no-check-publish` already says exactly that:

```
- The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.
- Required (in require-dev) package "mediawiki/mediawiki-codesniffer" is in the lock file as "v52.0.0" but that does not satisfy your constraint "53.0.0".
```

It is half a second, it covers grumphp, minus-x and phan-config on the same pin, and `--no-check-publish` is needed because an extension's `composer.json` has no `description`. It sits in the shell task rather than the native `composer` task, which only runs when `composer.json` itself is staged, the one case where the lock is least likely to be stale.

The gap it does not close: a checkout with no `composer.lock` at all validates clean, so a hand-emptied `vendor/` still goes unnoticed. Nothing short of resolving dependencies catches that, and it is not a state a contributor reaches by pulling.

## phan

Not approximated, and the hook stops here on purpose. phan resolves core symbols, which needs the full MediaWiki install only quibble provides; `quibble.yml` already carries that note. The unused-parameter finding from #366 stays a CI-only catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112wmu1kyrMUuap9j53CAy9
