### PR TITLE
docs: say which Minerva settings a build actually reads

### DIFF
--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -40,6 +40,18 @@ config:
 <!--T:14-->
 Wikven renders Minerva without it as well: the entries it offers that a static host cannot serve are dropped either way.
 
+<!--T:15-->
+=== Minerva settings ===
+
+<!--T:16-->
+Most of the <code>$wgMinerva*</code> settings do nothing in a build, whether or not MobileFrontend is installed. Ten of the sixteen the skin declares are registered as MobileFrontend features and read back in <code>SkinOptions::setMinervaSkinOptions()</code>, which runs from the <code>RequestContextCreateSkinMobile</code> hook — and MobileFrontend fires that only once it has decided to serve a mobile view, which takes a mobile domain, a mobile device, or <code>useformat=mobile</code>. A bake is none of those, so the skin options keep the defaults compiled into them and these settings are inert: <code>MinervaShowCategories</code>, <code>MinervaPageIssuesNewTreatment</code>, <code>MinervaTalkAtTop</code>, <code>MinervaDonateLink</code>, <code>MinervaDonateBanner</code>, <code>MinervaHistoryInPageActions</code>, <code>MinervaOverflowInPageActions</code>, <code>MinervaAdvancedMainMenu</code>, <code>MinervaPersonalMenu</code> and <code>MinervaNightMode</code>.
+
+<!--T:17-->
+The other six the skin reads off the configuration itself, so they behave as documented: <code>MinervaEnableSiteNotice</code>, <code>MinervaAlwaysShowLanguageButton</code>, <code>MinervaDownloadNamespaces</code>, <code>MinervaNightModeOptions</code>, <code>MinervaTypeahead</code> and <code>MinervaABSamplingRate</code>. The last two have little to act on here: the typeahead calls a search API a static host does not have, and there is no A/B bucketing to sample. The language button is hidden either way, its overlay being MobileFrontend's.
+
+<!--T:18-->
+What the inert ones would have configured, {{SITENAME}} supplies its own way where it can: the colour theme is on the <code>Settings</code> page the build writes in place of <code>Special:MobileOptions</code>, and the site's own navigation is written into the main menu of every rendered page.
+
 <!--T:5-->
 == Configuring the skin ==
 
@@ -82,5 +94,10 @@ Use the <code>config</code> map.
 config:
   VectorResponsive: false
 </syntaxhighlight>
+
+<translate>
+<!--T:19-->
+A setting reaches the skin the same way any other does, but it only does something if the skin still reads it in a build. Minerva is the one place where most do not; see [[<tvar name="1">Special:MyLanguage/Skins#Minerva settings</tvar>|Minerva settings]] above before reaching for one.
+</translate>
 
 {{prevnext|Images|JavaScript}}


### PR DESCRIPTION
Part of #357. #366 closed the main-menu half of that issue; this closes the half the issue calls "worth knowing before anyone reaches for a config setting that looks like it should work."

## What is inert, and why

`SkinOptions::setMinervaSkinOptions()` is reachable from two places, both MobileFrontend's: `MobileFrontendHooks::onRequestContextCreateSkinMobile()` and `Hooks::onUserLogoutComplete()`. MobileFrontend fires `RequestContextCreateSkinMobile` from `onRequestContextCreateSkin`, which returns early unless `MobileContext::shouldDisplayMobileView()` is true — a mobile domain, a mobile device, `useformat=mobile`, or the `mf_useformat` cookie, falling back to false. A bake is none of those, so the skin options keep the defaults compiled into `SkinOptions`, whether or not MobileFrontend is installed.

Ten of the sixteen `$wgMinerva*` variables `skin.json` declares are only ever read into that path, as MobileFrontend features registered in MinervaNeue's own `MobileFrontendHooks`:

`MinervaShowCategories`, `MinervaPageIssuesNewTreatment`, `MinervaTalkAtTop`, `MinervaDonateLink`, `MinervaDonateBanner`, `MinervaHistoryInPageActions`, `MinervaOverflowInPageActions`, `MinervaAdvancedMainMenu`, `MinervaPersonalMenu`, `MinervaNightMode`.

The issue says "every `$wgMinerva*` variable in `skin.json` is inert", which is one step too far: the remaining six the skin reads straight off the configuration and they behave as documented — `MinervaEnableSiteNotice` (`SkinMinerva.php:837`), `MinervaAlwaysShowLanguageButton` (`MinervaPagePermissions.php:160`), `MinervaDownloadNamespaces` (`SkinMinerva.php:945`), `MinervaNightModeOptions` (`SkinMinerva.php:603`), `MinervaABSamplingRate` (`Hooks.php:230`) and `MinervaTypeahead` (a `packageFiles` config on `skins.minerva.search`). Two of them have little to act on in a static site, which the page says beside them rather than leaving to be found.

## The change

`docs/Skins.wikitext` gains a `=== Minerva settings ===` subsection under the existing "Minerva and MobileFrontend" heading, listing both sets and pointing at what wikven supplies instead — the `Settings` page in place of `Special:MobileOptions`, and the main menu the build fills. "Skin-specific configuration" gains one sentence pointing back at it, since that is where a reader reaching for `MinervaNightMode` lands.

Documentation only; no behaviour change.

## Verification

- Read against a `REL1_46` checkout of MinervaNeue and MobileFrontend rather than from memory. Every claim above names the file and line it came from.
- Ran the repo's own `StalenessComputer::mark()` over the edited page: it returns the file unchanged, so the hand-written `<!--T:15-->`–`<!--T:19-->` markers are exactly the ones `translate mark` would assign.

## Left out

`docs/Skins/ko.wikitext` was already missing T:12–T:14 and now also misses T:15–T:19. `check-translations` reports a stale translation without failing the step, and translating the page is its own piece of work rather than part of this one.

## Still open on #357

The remaining rough edges in the issue are already handled in the tree — `Hider` empties `TOOLBOX` rather than unsetting it (with the fatal it avoids named in a comment), `Adder` leaves Minerva to `fillMinervaMenu.php` so no iconless overflow entry is built, and night mode reaches the reader through the baked `Settings` page. What is left is the question the issue closes on: whether Minerva is supported to Vector's standard or documented as best-effort.

---
_Generated by [Claude Code](https://claude.ai/code/session_016r1WfrdbMVS7ML7bQYg1gH)_