### PR TITLE
build(deps): bump SifterSearch to v0.7.0, which reaches every skin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 ARG TARGETARCH
-ARG SIFTERSEARCH_VERSION=v0.6.1
+ARG SIFTERSEARCH_VERSION=v0.7.0
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \
  && curl -fsSL "https://github.com/chaotic-ground/SifterSearch/releases/download/${SIFTERSEARCH_VERSION}/SifterSearch-linux-${arch}.tar.gz" \

--- a/docs/.wikven.yml
+++ b/docs/.wikven.yml
@@ -22,8 +22,16 @@ config:
   # Translated pages may be in a script the reader's system has no font for.
   WikvenBundleWebfonts: true
   # Search results have no thumbnails, so drop the empty thumbnail column from
-  # the typeahead.
+  # the typeahead. Both skins that mount core's Codex typeahead need telling
+  # separately: each reads its own config var, and each is replaced wholesale
+  # rather than merged, so the API keys are restated at their own defaults.
   VectorTypeahead:
+    apiUrl: null
+    recommendationApiUrl: null
+    options:
+      showThumbnail: false
+      showDescription: true
+  MinervaTypeahead:
     apiUrl: null
     recommendationApiUrl: null
     options:

--- a/tests/e2e/citizen.spec.js
+++ b/tests/e2e/citizen.spec.js
@@ -51,14 +51,17 @@ test("Citizen's search box suggests pages as you type", async ({ page }) => {
 	await page.locator("#searchInput").click();
 	await page.keyboard.type("binary", { delay: 40 });
 
-	// Core's widget builds each suggestion's href from the search form, which SifterSearch has
-	// pointed at the results page, so a suggestion arrives there with its own title as the query
-	// rather than at the page itself. Matching on what the reader sees, not on that.
-	await expect(
-		page
-			.locator(".suggestions-results a", { hasText: "Standalone binary" })
-			.first(),
-	).toBeVisible({ timeout: 15000 });
+	// The row a reader sees, and where following it takes them. Core's widget builds every
+	// suggestion's href out of the search form, which ext.sifter.retarget has aimed at the results
+	// page, so left alone a suggestion arrived there carrying its own title as the query rather
+	// than at the page it names (#381). SifterSearch rewrites the title rows to the page Pagefind
+	// found, which is the hop Vector's typeahead never made. Asserted as a suffix, since the URL
+	// carries the path prefix the site is served under.
+	const suggestion = page
+		.locator(".suggestions-results a", { hasText: "Standalone binary" })
+		.first();
+	await expect(suggestion).toBeVisible({ timeout: 15000 });
+	await expect(suggestion).toHaveAttribute("href", /Standalone_binary\.html$/);
 
 	// The panel is core's jquery.suggestions, whose own colours are hardcoded light; restated in
 	// Citizen's custom properties, it has to follow the skin rather than stay white in the dark.

--- a/tests/e2e/minerva-search.spec.js
+++ b/tests/e2e/minerva-search.spec.js
@@ -44,10 +44,13 @@ test("Minerva's search suggests pages without asking a REST backend", async ({
 	await page.keyboard.type("binary", { delay: 40 });
 
 	// A title suggestion leading to the page it names, not to the results page carrying the title
-	// as a query. Matched as a suffix, since the URL carries the path prefix the site is served
-	// under.
+	// as a query. Matched on the file name alone, at both ends: the URL carries the path prefix the
+	// site is served under, and core's typeahead appends a wprov= tracking parameter to every
+	// result URL it renders (instrumentation.addWprovToSearchResultUrls), so neither end is the
+	// page's own. What distinguishes it from the row #381 reported is Standalone_binary.html rather
+	// than Search.html.
 	await expect(
-		page.locator('.cdx-menu-item a[href$="Standalone_binary.html"]').first(),
+		page.locator('.cdx-menu-item a[href*="Standalone_binary.html"]').first(),
 	).toBeVisible({ timeout: 15000 });
 
 	expect(rest, rest.join("; ")).toEqual([]);

--- a/tests/e2e/minerva-search.spec.js
+++ b/tests/e2e/minerva-search.spec.js
@@ -1,0 +1,80 @@
+// Minerva's search, which reached a backend that is not there until SifterSearch learned the
+// skin's name. MinervaNeue names its own search module (skins.minerva.search), and the
+// SkinPageReadyConfig handler that swaps a skin's typeahead for Pagefind knew only core's legacy
+// widget and Vector's, so Minerva kept its own: every keystroke asked /rest.php/v1/search/title
+// and every one of those 404d on a static export (#381). ext.sifter.minerva mounts Minerva's own
+// search app on Pagefind instead, the way ext.sifter.vector already did for Vector 2022.
+//
+// The skin is the one place none of this was watched, which is how the REST calls went unnoticed
+// while Citizen's box was being fixed, so what follows is a reader's path through it rather than
+// the markup: the box, what it suggests, and where a suggestion leads.
+
+const { test, expect } = require("@playwright/test");
+
+const PAGE = "minerva/Installation.html";
+
+test.beforeEach(async ({ request }) => {
+	const response = await request.get(PAGE).catch(() => null);
+	test.skip(!response?.ok(), "this export does not render Minerva");
+});
+
+test("Minerva's search suggests pages without asking a REST backend", async ({
+	page,
+}) => {
+	// Narrowed to rest.php rather than to any backend URL: focusing a text field also has
+	// UniversalLanguageSelector fetch its input methods (#398), which is older than this and not
+	// Minerva's. This is the request #381 reported, and the one the adapter exists to prevent.
+	const rest = [];
+	page.on("request", (request) => {
+		if (/\/rest\.php\//.test(request.url())) {
+			rest.push(request.url());
+		}
+	});
+
+	await page.goto(PAGE);
+
+	// The skin renders a plain input in its header and replaces it with the Codex app once the
+	// search module loads on focus, so the element typed into is not the one clicked. Waiting for
+	// the mounted input is what keeps keystrokes from being dropped mid-swap.
+	await page.locator("#searchInput").first().click();
+	await page
+		.locator(".cdx-text-input__input")
+		.first()
+		.waitFor({ state: "visible", timeout: 15000 });
+	await page.keyboard.type("binary", { delay: 40 });
+
+	// A title suggestion leading to the page it names, not to the results page carrying the title
+	// as a query. Matched as a suffix, since the URL carries the path prefix the site is served
+	// under.
+	await expect(
+		page.locator('.cdx-menu-item a[href$="Standalone_binary.html"]').first(),
+	).toBeVisible({ timeout: 15000 });
+
+	expect(rest, rest.join("; ")).toEqual([]);
+});
+
+test("Minerva's search offers the results page and reaches it", async ({
+	page,
+}) => {
+	await page.goto(PAGE);
+
+	await page.locator("#searchInput").first().click();
+	await page
+		.locator(".cdx-text-input__input")
+		.first()
+		.waitFor({ state: "visible", timeout: 15000 });
+	await page.keyboard.type("binary", { delay: 40 });
+
+	// The "search for pages containing" footer, which the app renders from the URL generator
+	// SifterSearch hands it: with no wiki search to answer one, a full-text search is the
+	// configured results page or nothing at all.
+	const containing = page
+		.locator('.cdx-menu-item a[href*="Search.html?search="]')
+		.first();
+	await expect(containing).toBeVisible({ timeout: 15000 });
+
+	await containing.click();
+	await expect(page.locator(".pagefind-ui__result").first()).toBeVisible({
+		timeout: 15000,
+	});
+});


### PR DESCRIPTION
Closes #381.

Both halves of #381 were, as the report said, one layer down in SifterSearch, and both are now released in [v0.7.0](https://github.com/chaotic-ground/SifterSearch/releases/tag/v0.7.0). This picks it up and covers it.

## What was wrong

| #381 | Fix |
| --- | --- |
| A suggestion did not go to its page: every row linked to the results page carrying its own title as the query | SifterSearch [#39](https://github.com/chaotic-ground/SifterSearch/pull/39) keeps each result's URL as the titles go out to the widget and rewrites the links to it, extending the observer that already repointed the "search for pages containing X" row. [#62](https://github.com/chaotic-ground/SifterSearch/pull/62) widened the condition: a configured results page is where a full-text search goes whether or not the wiki answers one, so a live wiki with a results page was affected too |
| Minerva queried `/rest.php/v1/search/title`, which an export has no backend for | SifterSearch [#40](https://github.com/chaotic-ground/SifterSearch/pull/40) adds `ext.sifter.minerva`. Minerva mounts the same core app as Vector 2022 and takes the same optional search client, so it is the Vector adapter pointed at `skins.minerva.search`; both are registered from `ResourceLoaderRegisterModules`, gated on their skin's own search module being present |

wikven itself carried no bug here — it was pinned to a release that predated the fix.

## Changes

- **`Dockerfile`** — `SIFTERSEARCH_VERSION` v0.6.1 → v0.7.0. (Updatecli would have opened this bump on its own schedule; doing it here keeps it with the coverage below.)
- **`docs/.wikven.yml`** — a `MinervaTypeahead` block beside the `VectorTypeahead` one. Now that Minerva mounts core's Codex typeahead it needs the same telling that Pagefind results have no thumbnails to show, or it renders an empty thumbnail column. Its config var is its own and is replaced wholesale rather than merged, so `apiUrl` and `recommendationApiUrl` are restated at their own defaults.
- **`tests/e2e/minerva-search.spec.js`** (new) — Minerva's search was the one path nothing watched, which is how the REST calls went unnoticed while Citizen's box was being fixed. Two tests: the box suggests pages and asks no `rest.php` (narrowed to that rather than to any backend URL, since focusing a field also has ULS fetch its input methods, #398), and the "search for pages containing" footer leads to the results page and returns results.
- **`tests/e2e/citizen.spec.js`** — the suggestion test described the old behaviour in a comment and deliberately matched on the row's visible text to avoid asserting the href. It now follows the link, as a suffix match so it is independent of the path prefix the site is served under.

## Testing

Lint is clean (`biome ci`, YAML parses). The behavioural claims are verified by Smoke, which bakes `docs/` with the real image and runs the e2e suite against it — that is what exercises the new pin, the Minerva spec, and the tightened Citizen assertion end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5PSPGAZdic9iEbnaS5W8k)_