### PR TITLE
fix: link the search toggle to the results page, not to Special:Search

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -77,6 +77,15 @@ jobs:
             exit 1
           fi
 
+          # The export has no Special:Search, so a link to it answers 404 (#393). Vector writes one
+          # for the collapsed search box, on every page it renders, and the results page is where
+          # that belongs; the hidden "title" input naming the special page is left to SifterSearch,
+          # which repoints it, so this matches the link alone.
+          if grep -rIl --include='*.html' 'Special:Search\.html' dist; then
+            echo "::error::exported HTML links to Special:Search, which the export does not have"
+            exit 1
+          fi
+
           # Bundled webfonts. The Khmer translation is the fixture: without a page in a script ULS
           # has a font for, every assertion below passes vacuously on an empty stylesheet.
           test -s dist/webfonts.css

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -72,6 +72,16 @@ class Main implements
 			}
 		}
 
+		// Vector renders the collapsed search box as a link to Special:Search -- the page the "f"
+		// accesskey opens, and at a narrow viewport the whole of the search affordance -- and the
+		// export has no such page. Where search lands here is SifterSearch's results page, so send
+		// it there instead of at a 404. SifterSearch retargets the link itself once its script
+		// runs; writing the link out right is what makes the exported page correct on its own.
+		if ($title->isSpecial('Search')) {
+			$url = $this->searchUrl($query);
+			return;
+		}
+
 		$name = Title::makeName($title->getNamespace(), $title->getDBkey());
 		// Parse query to name=>value; substring-matching "action=" would also match "veaction=edit".
 		$params = wfCgiToArray($query);
@@ -89,6 +99,25 @@ class Main implements
 		} else {
 			$url = "./$name.html";
 		}
+	}
+
+	/**
+	 * Where a search goes in the export: the results page, carrying the term the link asks for
+	 * (SifterSearch's widget reads it from "?search="), or nowhere.
+	 *
+	 * With no results page named there is nowhere to land, so the link is left the button its own
+	 * script already treats it as: Vector's toggle prevents the navigation and opens the box, which
+	 * is the whole of what it is for, and a reader without scripts has no search here either way --
+	 * Pagefind answers in the browser. That beats a link to a page that answers 404.
+	 */
+	private function searchUrl(string $query): string {
+		$results = Search::resultsPage();
+		if (!$results) {
+			return '#';
+		}
+		$url = './' . Title::makeName($results->getNamespace(), $results->getDBkey()) . '.html';
+		$term = wfCgiToArray($query)['search'] ?? '';
+		return $term === '' ? $url : $url . '?' . wfArrayToCgi(['search' => $term]);
 	}
 
 	/**

--- a/includes/Search.php
+++ b/includes/Search.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Wikven;
 
 use MediaWiki\Registration\ExtensionRegistry;
+use MediaWiki\Title\Title;
 
 /** Whether SifterSearch provides a working static search box: loaded and indexing into a bundle. */
 class Search {
@@ -23,6 +24,24 @@ class Search {
 	}
 
 	/**
+	 * The page SifterSearch lists a query's matches on, or null where the site names none.
+	 *
+	 * Read as a title, because that is what SifterSearch does with the setting: a value that is not
+	 * one names no page, and its own handler gives up on it rather than wiring anything to it.
+	 *
+	 * Not gated on isActive(), unlike hasResultsPage() below: what this answers is where a search
+	 * link can land, and the page a site named is that place whether or not an index was built for
+	 * it. Where search is off entirely the box is hidden anyway, so nothing offers such a link.
+	 */
+	public static function resultsPage(): ?Title {
+		$page = (string)( $GLOBALS['wgSifterSearchResultsPage'] ?? '' );
+		if ($page === '') {
+			return null;
+		}
+		return Title::newFromText($page);
+	}
+
+	/**
 	 * Whether submitting a plain search form reaches results.
 	 *
 	 * SifterSearch retargets the skin's form at its results page, and only when one is configured
@@ -31,6 +50,6 @@ class Search {
 	 * but the form -- Citizen, whose own search is its command palette -- has only this path.
 	 */
 	public static function hasResultsPage(): bool {
-		return self::isActive() && (string)( $GLOBALS['wgSifterSearchResultsPage'] ?? '' ) !== '';
+		return self::isActive() && self::resultsPage() !== null;
 	}
 }

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -97,4 +97,33 @@ class MainTest extends MediaWikiIntegrationTestCase {
 		$this->main()->onGetLocalURL($title, $url, 'diff=');
 		$this->assertSame('./Getting_Started.html', $url);
 	}
+
+	/**
+	 * Vector renders the collapsed search box as a link to Special:Search, which the export does
+	 * not have, so it goes to the page SifterSearch lists a query's matches on instead.
+	 */
+	public function testSearchLinkGoesToTheResultsPage() {
+		$this->setMwGlobals('wgSifterSearchResultsPage', 'Search');
+		$url = '/index.php/Special:Search';
+		$this->main()->onGetLocalURL(Title::newFromText('Special:Search'), $url, '');
+		$this->assertSame('./Search.html', $url);
+	}
+
+	/** A link that asks for a term keeps it: the results widget reads "?search=" from the URL. */
+	public function testSearchLinkCarriesTheTerm() {
+		$this->setMwGlobals('wgSifterSearchResultsPage', 'Help:Search');
+		$url = '/x';
+		$this->main()->onGetLocalURL(Title::newFromText('Special:Search'), $url, 'search=oven');
+		$this->assertSame('./Help:Search.html?search=oven', $url);
+	}
+
+	/**
+	 * With no results page named there is nowhere for a search to land, so the toggle is left the
+	 * button its own script treats it as, rather than a link to a page that answers 404.
+	 */
+	public function testSearchLinkWithoutResultsPage() {
+		$url = '/x';
+		$this->main()->onGetLocalURL(Title::newFromText('Special:Search'), $url, '');
+		$this->assertSame('#', $url);
+	}
 }

--- a/tests/phpunit/integration/SearchTest.php
+++ b/tests/phpunit/integration/SearchTest.php
@@ -23,4 +23,27 @@ class SearchTest extends MediaWikiIntegrationTestCase {
 		$this->assertFalse(Search::isActive());
 		$this->assertFalse(Search::hasResultsPage(), 'a results page needs a search to reach it');
 	}
+
+	/**
+	 * The page itself is answered whatever the search around it is doing: it is where a search link
+	 * lands, and a site that named one named it for that.
+	 *
+	 * @dataProvider provideResultsPages
+	 */
+	public function testResultsPageIsTheConfiguredTitle(?string $configured, ?string $expected) {
+		$this->setMwGlobals('wgSifterSearchResultsPage', $configured);
+		$page = Search::resultsPage();
+		$this->assertSame($expected, $page?->getPrefixedText());
+	}
+
+	public static function provideResultsPages() {
+		return [
+			'a page' => ['Search', 'Search'],
+			'a page outside the main namespace' => ['Help:Search', 'Help:Search'],
+			'none named' => ['', null],
+			// SifterSearch reads the setting as a title too, and wires up nothing when it is not one.
+			'not a title' => ['<', null],
+			'no value, as on a wiki without SifterSearch' => [null, null]
+		];
+	}
 }


### PR DESCRIPTION
Closes #393.

Vector renders the collapsed state of its search box as a link to `Special:Search` — the target the `f` accesskey opens, and at a narrow viewport the whole of the search affordance — and the export has no such page: `Special:Search.html` answers 404. `Hooks\Main::onGetLocalURL` rewrote that title like any other, so the link named a file the bake never writes. The href comes from `VectorComponentSearchBox`, which builds it from core's `page-title` (`Special:Search`) through `Title::getLocalURL()`, so the header box and the sticky header's each carry one — both hits an audit of an exported page finds.

## Where it goes instead

SifterSearch's results page, which `docs/.wikven.yml` names and nothing in the markup pointed at, carrying the term the link asks for (`?search=`, which `ext.sifter.results` reads off the URL).

`ext.sifter.retarget` rewrites the link too, once its script runs, so this is not what makes the docs site's search work — it is what makes the page the export ships correct on its own, and correct at any depth: the href is relative, and `rename.php` reparents it per subdirectory, where the module carries one URL for the whole bundle. (That is its own upstream matter: `resultsPageUrl` is computed once into the bundle as `./Search.html`, so on a subpage such as `Deploying/ko.html` the script replaces a correct href with one that resolves a directory too deep. Not touched here.)

## With no results page

The default names none, so there is nowhere to land: the link becomes `#`, and the toggle is left the button its own script already treats it as — Vector's `searchToggle.js` prevents the navigation and opens the box. A reader without scripts has no search here either way, Pagefind answering in the browser, so a link to a page that 404s buys nothing.

## What is left alone

The form underneath the toggle still posts to the script path. That one is SifterSearch's: `ext.sifter.retarget` repoints its action and its hidden `title` input at the results page, and where there is none `ext.sifter.pagefind` takes the submit to the top match instead. Neither target is a link the export renders, so neither is ours to write.

## Also

`Search::resultsPage()` is where the setting is read now, as a title, which is what SifterSearch does with it: a value that is not one names no page, and `hasResultsPage()` now says so as well rather than counting any non-empty string.

## Testing

- `MainTest` covers the three answers (results page, results page with a term, no results page); `SearchTest` covers reading the setting as a title. Run against MediaWiki REL1_46 on SQLite: 255 tests, all pass, and the three `MainTest` cases fail without the hook change.
- `phpcs`, `mago format --check`, `mago lint`, `minus-x` and `yamllint` are clean.
- The smoke workflow now greps the bake for a link to `Special:Search.html`, so a regression fails on the site itself rather than on the next audit of one. It matches the link alone, not the hidden `title` input naming the special page, which SifterSearch repoints. (The bake could not be run here — no Docker daemon in this environment — so that assertion runs for the first time in CI.)

---
_Generated by [Claude Code](https://claude.ai/code/session_019dBoQc7RNwSThCroMUtRzK)_