### PR TITLE
fix: rebase the printfooter link on a page exported into a subdirectory

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -86,6 +86,20 @@ jobs:
             exit 1
           fi
 
+          # Every printfooter "Retrieved from" link must resolve from the page that carries it
+          # (#394). Core builds it from the page's own URL and expands away the "./" wikven writes,
+          # so a page exported into a subdirectory needs the "../" per level rename.php adds; the
+          # link is print-only on screen, which is exactly why nothing else would catch it.
+          find dist -name '*.html' -print0 | while IFS= read -r -d '' page; do
+            href=$(sed -n 's/.*class="printfooter"[^<]*<a[^>]*href="\([^"]*\)".*/\1/p' "$page")
+            [ -n "$href" ] || continue
+            case "$href" in *'://'* | /* | '#'*) continue ;; esac
+            if [ ! -f "$(dirname "$page")/$href" ]; then
+              echo "::error::$page: printfooter link '$href' does not resolve"
+              exit 1
+            fi
+          done
+
           # Bundled webfonts. The Khmer translation is the fixture: without a page in a script ULS
           # has a font for, every assertion below passes vacuously on an empty stylesheet.
           test -s dist/webfonts.css

--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -18,6 +18,9 @@ class RelativeUrl {
 	 * which turns a documentation example's own "<a href=\"./intro\">" into "&lt;a href=\"./intro\"&gt;"
 	 * -- the quotes survive, but neither escaped angle bracket is a real "<" or ">", so nothing there
 	 * reads as a tag span and the example's href is correctly left alone.
+	 *
+	 * The printfooter's link arrives without the "./" it was written with, so it is rebased on its
+	 * own; see rebasePrintFooter() below.
 	 */
 	public static function reparent(string $html, int $depth): string {
 		if ($depth < 1) {
@@ -70,7 +73,7 @@ class RelativeUrl {
 		);
 
 		$styleContexts = array_merge(self::tagRanges($html), self::ranges($html, '#<style\b[^>]*>.*?</style>#is'));
-		return preg_replace_callback(
+		$html = preg_replace_callback(
 			'#url\((["\']?)(\.\.?)/#',
 			static function (array $m) use ($rebase, $styleContexts): string {
 				if (!self::insideAny($m[0][1], $styleContexts)) {
@@ -83,6 +86,63 @@ class RelativeUrl {
 			$count,
 			PREG_OFFSET_CAPTURE
 		);
+
+		return self::rebasePrintFooter($html, $up);
+	}
+
+	/**
+	 * Rebase the printfooter's "Retrieved from" link, the one reference that reaches a page having
+	 * lost the "./" the rest of this class goes by.
+	 *
+	 * Skin::printSource() builds it from Title::getCanonicalURL() and expands the result a second
+	 * time; each expansion runs UrlUtils' dot-segment removal over the URL, which drops the leading
+	 * "./" that Hooks\Main::onGetLocalURL wrote. What survives is still a path from the output root
+	 * -- it just no longer says so, so the passes above walk past it, and from a page exported into
+	 * a subdirectory it resolves inside that subdirectory and answers 404. A top-level page is
+	 * unaffected, its link being right from the root by accident.
+	 *
+	 * A bare relative href is exactly the shape that carries no marker telling a link of ours from
+	 * a path a page merely shows, which is why only core's printfooter div is rebased: everything
+	 * in there is the line core has just built out of this page's own URL.
+	 */
+	private static function rebasePrintFooter(string $html, string $up): string {
+		return preg_replace_callback(
+			'~<div[^>]*\bclass="printfooter"[^>]*>.*?</div>~s',
+			static function (array $footer) use ($up): string {
+				return preg_replace_callback(
+					'~(\shref=")([^"]*)"~',
+					static function (array $href) use ($up): string {
+						if (!self::isRootRelative($href[2])) {
+							return $href[0];
+						}
+						return $href[1] . $up . $href[2] . '"';
+					},
+					$footer[0]
+				);
+			},
+			$html
+		);
+	}
+
+	/**
+	 * Whether $href is a bare path from the output root -- what the printfooter's link is left as.
+	 *
+	 * Everything else names something the depth of the page cannot move: an absolute URL, a path
+	 * from the host root, a fragment or query on the page itself, or -- for a link that kept its
+	 * marker, and so was rebased by reparent() already -- a path the "./" prefix has spoken for.
+	 * A namespaced title such as "File:Oven.jpg.html" reads like a scheme and is not one, hence
+	 * the test for "://" rather than for a colon.
+	 */
+	private static function isRootRelative(string $href): bool {
+		if ($href === '') {
+			return false;
+		}
+		foreach (['/', '#', '?', './', '../'] as $prefix) {
+			if (str_starts_with($href, $prefix)) {
+				return false;
+			}
+		}
+		return !str_contains($href, '://');
 	}
 
 	/** Byte ranges of the raw "<tag ...>" spans in $html, each as [start, endExclusive]. */

--- a/tests/phpunit/unit/RelativeUrlTest.php
+++ b/tests/phpunit/unit/RelativeUrlTest.php
@@ -96,6 +96,63 @@ class RelativeUrlTest extends MediaWikiUnitTestCase {
 		$this->assertSame($html, RelativeUrl::reparent($html, 1));
 	}
 
+	/**
+	 * The printfooter's "Retrieved from" link reaches here as a bare path from the output root:
+	 * core expands the page's own URL, and dot-segment removal takes the "./" off it.
+	 */
+	public function testThePrintFooterLinkIsRebased() {
+		$this->assertSame(
+			'<div class="printfooter" data-nosnippet="">Retrieved from '
+			. '"<a dir="ltr" href="../Manual/Config.html">Manual/Config.html</a>"</div>',
+			RelativeUrl::reparent(
+				'<div class="printfooter" data-nosnippet="">Retrieved from '
+				. '"<a dir="ltr" href="Manual/Config.html">Manual/Config.html</a>"</div>',
+				1
+			)
+		);
+	}
+
+	public function testThePrintFooterLinkGainsOneLevelPerDepth() {
+		$this->assertSame(
+			'<div class="printfooter"><a href="../../A/B/C.html">A/B/C.html</a></div>',
+			RelativeUrl::reparent('<div class="printfooter"><a href="A/B/C.html">A/B/C.html</a></div>', 2)
+		);
+	}
+
+	/** A namespaced title reads like a URL scheme; only "://" marks one that really is. */
+	public function testThePrintFooterLinkToANamespacedPageIsRebased() {
+		$this->assertSame(
+			'<div class="printfooter"><a href="../File:Oven.jpg.html">File:Oven.jpg.html</a></div>',
+			RelativeUrl::reparent(
+				'<div class="printfooter"><a href="File:Oven.jpg.html">File:Oven.jpg.html</a></div>',
+				1
+			)
+		);
+	}
+
+	public function testAPrintFooterLinkThatKeptItsMarkerIsRebasedOnce() {
+		$this->assertSame(
+			'<div class="printfooter"><a href="../Intro.html">Intro.html</a></div>',
+			RelativeUrl::reparent('<div class="printfooter"><a href="./Intro.html">Intro.html</a></div>', 1)
+		);
+	}
+
+	public function testAnAbsolutePrintFooterLinkIsLeftAlone() {
+		$html = '<div class="printfooter"><a href="https://example.org/Intro">https://example.org/Intro</a></div>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
+	/** Outside the printfooter a bare relative href is indistinguishable from a path in prose. */
+	public function testABareRelativeHrefOutsideThePrintFooterIsLeftAlone() {
+		$html = '<a href="Manual/Config.html">Config</a>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
+	public function testAPrintFooterShownAsACodeExampleIsNotRewritten() {
+		$html = '<pre>&lt;div class="printfooter"&gt;&lt;a href="Intro.html"&gt;&lt;/a&gt;&lt;/div&gt;</pre>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
 	public function testMyLanguageResolvesToTheTranslationWhenItExists() {
 		$this->assertSame(
 			'href="./B/ko.html"',


### PR DESCRIPTION
Closes #394.

Every page the export writes into a subdirectory carried a dead "Retrieved from" link: `Editing_sidebar/ko.html`, read from `/wikven/Editing_sidebar/`, resolves to `/wikven/Editing_sidebar/Editing_sidebar/ko.html` and answers 404. A top-level page was right only by accident, its path from the output root being its path from its own directory too.

`Skin::printSource()` builds the link from `Title::getCanonicalURL()` and then expands the result a second time, and each expansion runs UrlUtils' dot-segment removal over the URL. That takes the leading `./` off what `Hooks\Main::onGetLocalURL` wrote, so what reaches the page is still a path from the output root but no longer says so -- and `RelativeUrl::reparent()` rebases only references that still carry `./` or `../`, that prefix being how it tells a link of ours from a path a page merely shows.

So the link is rebased on its own, inside core's printfooter div alone. Teaching `reparent()` about bare relative hrefs generally is the change the shape does not support: outside that div there is nothing to distinguish one from text a page displays. Inside it there is nothing else -- the whole of the div is the line core has just built out of this page's own URL -- and an href naming a protocol, a path from the host root, a fragment or a query is skipped anyway. A namespaced title such as `File:Oven.jpg.html` reads like a scheme without being one, so that test is for `://` rather than for a colon.

The link is print-only in MediaWiki's skinning styles, which is why no rendered page shows the breakage and why nothing but an audit had caught it. The smoke workflow now resolves every printfooter link against the page that carries it, so a regression fails on the site itself.

Found while auditing the exported links of a translated page in #382 and #391.


---
_Generated by [Claude Code](https://claude.ai/code/session_0169JNgce6WB6rQYAnuP4U5m)_