### PR TITLE
fix: move Vector's skin list into the appearance menu

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -30,6 +30,9 @@
 		"ext.Wikven.citizenSearchShortcuts": {
 			"scripts": ["citizen-search-shortcuts.js"]
 		},
+		"ext.Wikven.vectorSkins": {
+			"scripts": ["vector-skins.js"]
+		},
 		"ext.Wikven.appearance": {
 			"scripts": ["appearance.js"]
 		}

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -22,6 +22,10 @@ class Adder implements
 	 * skin list goes in the toolbox: Citizen splices the toolbox alone and Minerva reads no other
 	 * section, so a section of our own would leave their page-tools menus for the sidebar drawer,
 	 * or vanish.
+	 *
+	 * The page-tools menu is where the section is rendered, not where a reader is meant to find it:
+	 * ext.Wikven.vectorSkins moves it into the appearance menu, beside the other choices about how
+	 * a page looks. This stays as the fallback a reader without JavaScript is left with.
 	 */
 	private const OWN_SECTION_SKINS = ['vector-2022'];
 
@@ -106,6 +110,17 @@ class Adder implements
 			&& ( $GLOBALS['wgCitizenEnablePreferences'] ?? false )
 		) {
 			$out->addModules('ext.Wikven.citizenSkins');
+		}
+
+		// Vector's appearance menu is where its readers change how a page looks, so the skin list
+		// moves there from the page-tools menu its own section lands in. As in Citizen, the module
+		// moves the section the bake already rendered rather than building a second copy, so a
+		// reader without JavaScript keeps the plain list of links where it is.
+		if (
+			$skin->getSkinName() === 'vector-2022'
+			&& count($GLOBALS['wgWikvenSkins'] ?? []) > 1
+		) {
+			$out->addModules('ext.Wikven.vectorSkins');
 		}
 
 		// Minerva writes the night-mode class only when SkinOptions::NIGHT_MODE is on, which nothing

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -54,31 +54,28 @@
 .wikven-vector-skins-moved #vector-appearance .mw-portlet-wikven-skins {
   margin-top: @spacing-75;
 
+  // Blocks rather than a flex column. A column would do the stacking just as well, but the header
+  // dropdown the menu moves into when a reader hides it sets `align-items: center` on its lists:
+  // the entries would then be shrunk to their names and centred, which is not something aligning
+  // the text inside them can undo. Blocks have no such handle to be taken by.
   ul {
-    display: flex;
-    flex-direction: column;
+    display: block;
     margin: 0;
     padding: 0;
     list-style: none;
   }
 
-  // The header dropdown the menu moves into when a reader hides it centres its entries, which left
-  // the skin names strung down the middle of a section whose every choice is ranged left. Stated on
-  // the entry rather than on the list around it: the dropdown declares its centring on the entry,
-  // and a declaration beats a value inherited from an ancestor however specific that ancestor's
-  // selector is. `start` rather than `left`, so a right-to-left reading keeps its own edge.
   .mw-list-item {
     display: block;
     margin: 0;
-    text-align: start;
   }
 
   // The label is the anchor, except on the skin being read, where it is a span; both carry the row.
+  // Without a box of its own the label is only as tall as its text, and the rows crowd each other.
   .mw-list-item > a,
   .mw-list-item > span {
     display: block;
     padding: @spacing-25 0;
-    text-align: start;
   }
 }
 

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -43,10 +43,36 @@
 }
 
 // The skin list once ext.Wikven.vectorSkins has moved it into Vector's appearance menu. The menu
-// sets the type for the sections it draws itself, and the portlet arrives with the heading that
-// names this one, so what it needs here is room from the preferences above it rather than chrome.
+// reads as one choice to a row under a named heading, and the portlet arrives with the heading that
+// names this section, so what is left is the rows.
+//
+// The list cannot be left as it came: it is styled for the page-tools menu, which lays its entries
+// out along a line, and in a sidebar-width menu that runs the skin names together into one word.
+// So the column is stated here rather than inherited, and each entry is given the box its label
+// sits in -- without one the label is only as tall as the text, and the rows crowd each other.
+// Addressed through the id the menu carries, which is what outranks the skin's own list rules.
 .wikven-vector-skins-moved #vector-appearance .mw-portlet-wikven-skins {
   margin-top: @spacing-75;
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .mw-list-item {
+    display: block;
+    margin: 0;
+  }
+
+  // The label is the anchor, except on the skin being read, where it is a span; both carry the row.
+  .mw-list-item > a,
+  .mw-list-item > span {
+    display: block;
+    padding: @spacing-25 0;
+  }
 }
 
 // What is left in the page-tools menu once the list leaves is the toolbox Hider emptied. Core

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -42,6 +42,24 @@
   font-weight: @font-weight-bold;
 }
 
+// The skin list once ext.Wikven.vectorSkins has moved it into Vector's appearance menu. The menu
+// sets the type for the sections it draws itself, and the portlet arrives with the heading that
+// names this one, so what it needs here is room from the preferences above it rather than chrome.
+.wikven-vector-skins-moved #vector-appearance .mw-portlet-wikven-skins {
+  margin-top: @spacing-75;
+}
+
+// What is left in the page-tools menu once the list leaves is the toolbox Hider emptied. Core
+// hides the emptied portlet itself; this is the box Vector draws around it, as in
+// empty-toolbox.less -- and, as there, only above the width at which that box also carries the
+// page tabs. Gated on the class the module sets, because without JavaScript the list is still in
+// the box and hiding it would take the export's only switcher with it.
+@media ( min-width: @min-width-breakpoint-tablet ) {
+  .wikven-vector-skins-moved .vector-page-tools-landmark {
+    display: none;
+  }
+}
+
 // Citizen counts the wiki in its drawer. Pages and files are facts about the exported site; the
 // user count is the build's own admin account, and the edit count is how many revisions building
 // it happened to take. Neither says anything about the site a reader is looking at.

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -60,15 +60,17 @@
     margin: 0;
     padding: 0;
     list-style: none;
-    // The chrome this menu is drawn in centres its text, which leaves the skin names strung down
-    // the middle while every choice above them is ranged left. `start` rather than `left`, so a
-    // right-to-left reading keeps its own edge.
-    text-align: start;
   }
 
+  // The header dropdown the menu moves into when a reader hides it centres its entries, which left
+  // the skin names strung down the middle of a section whose every choice is ranged left. Stated on
+  // the entry rather than on the list around it: the dropdown declares its centring on the entry,
+  // and a declaration beats a value inherited from an ancestor however specific that ancestor's
+  // selector is. `start` rather than `left`, so a right-to-left reading keeps its own edge.
   .mw-list-item {
     display: block;
     margin: 0;
+    text-align: start;
   }
 
   // The label is the anchor, except on the skin being read, where it is a span; both carry the row.
@@ -76,6 +78,7 @@
   .mw-list-item > span {
     display: block;
     padding: @spacing-25 0;
+    text-align: start;
   }
 }
 

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -60,6 +60,10 @@
     margin: 0;
     padding: 0;
     list-style: none;
+    // The chrome this menu is drawn in centres its text, which leaves the skin names strung down
+    // the middle while every choice above them is ranged left. `start` rather than `left`, so a
+    // right-to-left reading keeps its own edge.
+    text-align: start;
   }
 
   .mw-list-item {

--- a/resources/vector-skins.js
+++ b/resources/vector-skins.js
@@ -1,0 +1,93 @@
+/**
+ * Offer the export's other skins in Vector's appearance menu.
+ *
+ * Which skin to read in is a choice about how the page looks, so it belongs beside the theme, the
+ * text size and the content width rather than under "Tools" among the page actions. Vector lands it
+ * in Tools as a direct consequence of how the list is rendered: Hooks\Adder gives it a sidebar
+ * section of its own (OWN_SECTION_SKINS) and SkinVector22::extractPageToolsFromSidebar() splices
+ * every section from the toolbox onward into the page-tools menu.
+ *
+ * Vector offers no server-side route to the appearance menu. The menu is empty in the served HTML
+ * -- VectorComponentAppearance renders a pinnable element, a container and a header and nothing
+ * else -- and its contents are built on the client out of skins.vector.js/clientPreferences.json.
+ * That framework stores an enum as a class on <html>, which a link into another directory is not,
+ * and there is no hook to add an entry with. So the section the bake already rendered is moved,
+ * whole, into the menu.
+ *
+ * Moving rather than rebuilding is what leaves a reader with no JavaScript the plain list of links
+ * where the bake wrote it, and it keeps the entries' hrefs, which the bake has already reparented
+ * for the page's own depth -- so this file needs no notion of where in the export it is running,
+ * and there is no URL arithmetic to keep correct. It also keeps the t-wikven-skin-* ids in the
+ * document, which is where the generated settings page reads its own copy of the list from
+ * (appearance.js).
+ *
+ * The menu is a pinnable element: "hide" moves #vector-appearance itself between
+ * vector-appearance-pinned-container and vector-appearance-unpinned-container. Putting the section
+ * inside the menu, rather than beside it in whichever container holds it, is what takes the list
+ * along when the reader moves it.
+ */
+(() => {
+	// The menu, by the id Vector gives the pinnable element itself; and the rendered section, by the
+	// portlet class core builds from Adder's section name.
+	const MENU = "vector-appearance";
+	const SECTION = ".mw-portlet-wikven-skins";
+
+	// Set on <html> once the move is done, so the stylesheet can hide what is left of the page-tools
+	// box. It cannot be hidden unconditionally: without JavaScript the list is still in that box,
+	// and hiding it would take the only switcher the export has with it.
+	const MOVED_CLASS = "wikven-vector-skins-moved";
+
+	// Vector fills the menu on the client, and how it fills it is its own business. Appending once
+	// it has drawn leaves the list after the preferences and out of the way of whatever the module
+	// does to the menu on its way in. If it never draws -- an export whose bundle left the module
+	// out -- the list is moved anyway once this expires: a menu holding only the skins still reads
+	// better than a skin list under "Tools".
+	const DRAWN_TIMEOUT = 5000;
+
+	const menu = () => document.getElementById(MENU);
+
+	// The preferences are radios, so one of them is the menu having been filled in.
+	const drawn = () => Boolean(menu()?.querySelector('input[type="radio"]'));
+
+	const move = () => {
+		const target = menu();
+		const section = document.querySelector(SECTION);
+		if (!target || !section) {
+			return;
+		}
+		target.append(section);
+		document.documentElement.classList.add(MOVED_CLASS);
+	};
+
+	const start = () => {
+		// A single-skin export renders no section, and a Vector that no longer draws the menu leaves
+		// nothing to move it into; both keep the list where the bake put it.
+		if (!menu() || !document.querySelector(SECTION)) {
+			return;
+		}
+		if (drawn()) {
+			move();
+			return;
+		}
+
+		const observer = new MutationObserver(() => {
+			if (!drawn()) {
+				return;
+			}
+			observer.disconnect();
+			clearTimeout(timer);
+			move();
+		});
+		observer.observe(menu(), { childList: true, subtree: true });
+		const timer = setTimeout(() => {
+			observer.disconnect();
+			move();
+		}, DRAWN_TIMEOUT);
+	};
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", start);
+	} else {
+		start();
+	}
+})();

--- a/tests/e2e/skin-switcher.spec.js
+++ b/tests/e2e/skin-switcher.spec.js
@@ -13,12 +13,12 @@ const { test, expect } = require("@playwright/test");
 const ENGLISH_HEADING = "Getting Started";
 const KOREAN_HEADING = "시작하기";
 
-// What each skin puts the switcher behind, where it takes a control to reveal. Vector discloses
-// with a transparent checkbox laid over its own label, so a click aimed at the label lands on the
-// checkbox. Citizen is not here: its list moves into the preferences panel, and is followed by
-// choosePreference().
+// What each skin puts the switcher behind, where it takes a control to reveal. Vector needs none:
+// its list moves into the appearance menu (ext.Wikven.vectorSkins), which is pinned open beside the
+// article. Citizen is not here either: its list moves into the preferences panel, and is followed
+// by choosePreference().
 const OPENERS = {
-	"vector-2022": "#vector-page-tools-dropdown-checkbox",
+	"vector-2022": null,
 	timeless: null,
 };
 

--- a/tests/e2e/tools-portlet.spec.js
+++ b/tests/e2e/tools-portlet.spec.js
@@ -1,24 +1,23 @@
 // The switcher is the only one the export has, so in every skin it must be somewhere a reader can
 // actually get to -- not merely present in the DOM. Each skin puts it somewhere different, and
-// behind a different control: Vector in the "Tools" dropdown, for one.
-// Only a rendered page shows whether opening that control reveals it.
+// behind a different control. Only a rendered page shows whether opening that control reveals it.
 //
 // A single-skin export has nothing to switch to and hides the empty box instead
 // (ext.Wikven.emptyToolbox); docs/ enables several, so that path is not exercised here.
 //
-// Two skins are exceptions, and have specs of their own. Citizen: with JavaScript its skin list
+// Three skins are exceptions, and have specs of their own. Citizen: with JavaScript its skin list
 // moves into the preferences panel and takes the toolbox with it (citizen.spec.js covers both that
-// and the plain list a reader without JavaScript is left). Minerva: it has no page-tools menu that
-// is not its page actions, so its list is on the settings page instead of on every page
+// and the plain list a reader without JavaScript is left). Vector: the same move, into its
+// appearance menu (vector-skins.spec.js). Minerva: it has no page-tools menu that is not its page
+// actions, so its list is on the settings page instead of on every page
 // (minerva-settings.spec.js).
 
 const { test, expect } = require("@playwright/test");
 
-// What each skin puts the switcher behind, where it takes a control to reveal. Vector discloses
-// with a transparent checkbox laid over its own label, so a click aimed at the label lands on the
-// checkbox. A skin absent from here carries no switcher on an article page.
+// What each skin puts the switcher behind, where it takes a control to reveal. A skin absent from
+// here either carries no switcher on an article page or keeps it somewhere a spec of its own
+// follows.
 const OPENERS = {
-	"vector-2022": "#vector-page-tools-dropdown-checkbox",
 	timeless: null,
 };
 

--- a/tests/e2e/vector-skins.spec.js
+++ b/tests/e2e/vector-skins.spec.js
@@ -71,7 +71,11 @@ test("what is left of the Tools box goes with it", async ({ page }) => {
 test("following an entry from the menu switches the skin, keeping the article", async ({
 	page,
 }) => {
-	const link = page.locator(`${LIST} .mw-list-item:not(.active) a`).first();
+	// The entry names the skin it leads to, which is the directory that skin's copy of the page is
+	// exported into -- so the entry says where following it should land.
+	const item = page.locator(`${LIST} .mw-list-item:not(.active)`).first();
+	const skin = (await item.getAttribute("id")).replace("t-wikven-skin-", "");
+	const link = item.locator("a");
 	await expect(link).toBeVisible();
 
 	const navigation = page.waitForResponse((response) =>
@@ -85,7 +89,7 @@ test("following an entry from the menu switches the skin, keeping the article", 
 	expect(response.status()).toBe(200);
 	await page.waitForLoadState("domcontentloaded");
 	await expect(page.locator("#firstHeading")).toHaveText(HEADING);
-	expect(page.url()).not.toMatch(new RegExp(`/${PAGE}$`));
+	expect(page.url()).toMatch(new RegExp(`/${skin}/${PAGE}$`));
 });
 
 test("the list travels with the menu when it is hidden and put back", async ({

--- a/tests/e2e/vector-skins.spec.js
+++ b/tests/e2e/vector-skins.spec.js
@@ -160,14 +160,34 @@ test("the list travels with the menu when it is hidden and put back", async ({
 
 	// The dropdown is a second piece of chrome with styling of its own, and it is the one that had
 	// the names strung down the middle of the menu. So the rows are asserted here too, rather than
-	// only in the pinned menu beside the article.
-	const lefts = await labelLefts(page, `${unpinned} .mw-list-item > *`);
-	expect(lefts.length).toBeGreaterThan(1);
-	for (const [index, left] of lefts.entries()) {
-		expect(
-			left,
-			`entry ${index}'s name does not line up in the dropdown`,
-		).toBeCloseTo(lefts[0], 0);
+	// only in the pinned menu beside the article. What the browser worked out for each entry rides
+	// along in the failure, because "does not line up" alone does not say which of the ways a row
+	// can be pushed off its edge did it.
+	const rows = await page
+		.locator(`${unpinned} .mw-list-item`)
+		.evaluateAll((items) =>
+			items.map((item) => {
+				const label = item.firstElementChild;
+				const range = document.createRange();
+				range.selectNodeContents(label);
+				const round = (n) => Math.round(n * 10) / 10;
+				return {
+					name: label.textContent.trim(),
+					textLeft: round(range.getBoundingClientRect().left),
+					item: `${round(item.getBoundingClientRect().left)}+${round(item.getBoundingClientRect().width)}`,
+					label: `${round(label.getBoundingClientRect().left)}+${round(label.getBoundingClientRect().width)}`,
+					align: `${getComputedStyle(item).textAlign}/${getComputedStyle(label).textAlign}`,
+					display: `${getComputedStyle(item).display}/${getComputedStyle(label).display}`,
+					list: `${getComputedStyle(item.parentElement).display} ${getComputedStyle(item.parentElement).alignItems}`,
+				};
+			}),
+		);
+	expect(rows.length).toBeGreaterThan(1);
+	for (const row of rows) {
+		expect(row.textLeft, JSON.stringify(rows, null, 1)).toBeCloseTo(
+			rows[0].textLeft,
+			0,
+		);
 	}
 
 	await page.locator(`${MENU} .vector-pinnable-header-pin-button`).click();

--- a/tests/e2e/vector-skins.spec.js
+++ b/tests/e2e/vector-skins.spec.js
@@ -56,6 +56,40 @@ test("the skin list is in the appearance menu, and every skin is on it", async (
 	await expect(list.locator(".mw-list-item.active a")).toHaveCount(0);
 });
 
+test("the skins are laid out one to a row, like the choices above them", async ({
+	page,
+}) => {
+	// The list is styled for the page-tools menu, which lays its entries out along a line. Moved
+	// into a sidebar-width menu unchanged, the skin names ran together into one word
+	// ("CitizenMinervaNeue") beside the current one. Presence is not enough to catch that, so this
+	// measures where the entries actually land.
+	const rows = await page
+		.locator(`${LIST} .mw-list-item`)
+		.evaluateAll((items) =>
+			items.map((item) => {
+				const { top, bottom, left } = item.getBoundingClientRect();
+				return { top, bottom, left };
+			}),
+		);
+	expect(rows.length).toBeGreaterThan(1);
+
+	for (const [index, row] of rows.entries()) {
+		if (index === 0) {
+			continue;
+		}
+		// Below the entry before it, not beside it. Sub-pixel rounding is the tolerance.
+		expect(
+			row.top,
+			`entry ${index} shares a line with the one before it`,
+		).toBeGreaterThanOrEqual(rows[index - 1].bottom - 0.5);
+		// And down a common edge, so the section reads as a list rather than as prose.
+		expect(row.left, `entry ${index} does not line up`).toBeCloseTo(
+			rows[0].left,
+			0,
+		);
+	}
+});
+
 test("what is left of the Tools box goes with it", async ({ page }) => {
 	// The list left the page-tools menu, rather than merely being copied into the appearance menu:
 	// two switchers disagreeing about which skin is current is its own bug.

--- a/tests/e2e/vector-skins.spec.js
+++ b/tests/e2e/vector-skins.spec.js
@@ -22,6 +22,18 @@ const LIST = `${MENU} .mw-portlet-wikven-skins`;
 const TOOLS = ".vector-page-tools-landmark";
 const TOOLS_OPENER = "#vector-page-tools-dropdown-checkbox";
 
+// Where each label's text actually starts, which is what a reader sees lining up (or not). A
+// range over the contents rather than the element's own box: the element is laid out to the
+// menu's width, so its box is the same wherever the text inside it is put.
+const labelLefts = (page, selector) =>
+	page.locator(selector).evaluateAll((labels) =>
+		labels.map((label) => {
+			const range = document.createRange();
+			range.selectNodeContents(label);
+			return range.getBoundingClientRect().left;
+		}),
+	);
+
 // Vector renders the export's main skin at the root; a page there that no export renders in Vector
 // would leave every assertion below vacuous.
 test.beforeEach(async ({ page }) => {
@@ -82,9 +94,16 @@ test("the skins are laid out one to a row, like the choices above them", async (
 			row.top,
 			`entry ${index} shares a line with the one before it`,
 		).toBeGreaterThanOrEqual(rows[index - 1].bottom - 0.5);
-		// And down a common edge, so the section reads as a list rather than as prose.
-		expect(row.left, `entry ${index} does not line up`).toBeCloseTo(
-			rows[0].left,
+	}
+
+	// And down a common edge. Measured on the text rather than on the entry, because the entry
+	// fills the menu's width whatever the label inside it does: centred names sit on a row each
+	// and still line their boxes up, so the boxes say nothing about what a reader sees.
+	const lefts = await labelLefts(page, `${LIST} .mw-list-item > *`);
+	expect(lefts).toHaveLength(rows.length);
+	for (const [index, left] of lefts.entries()) {
+		expect(left, `entry ${index}'s name does not line up`).toBeCloseTo(
+			lefts[0],
 			0,
 		);
 	}

--- a/tests/e2e/vector-skins.spec.js
+++ b/tests/e2e/vector-skins.spec.js
@@ -155,9 +155,20 @@ test("the list travels with the menu when it is hidden and put back", async ({
 	await page.reload();
 
 	await page.locator("#vector-appearance-dropdown-checkbox").click();
-	await expect(
-		page.locator(`#vector-appearance-unpinned-container ${LIST}`),
-	).toBeVisible();
+	const unpinned = `#vector-appearance-unpinned-container ${LIST}`;
+	await expect(page.locator(unpinned)).toBeVisible();
+
+	// The dropdown is a second piece of chrome with styling of its own, and it is the one that had
+	// the names strung down the middle of the menu. So the rows are asserted here too, rather than
+	// only in the pinned menu beside the article.
+	const lefts = await labelLefts(page, `${unpinned} .mw-list-item > *`);
+	expect(lefts.length).toBeGreaterThan(1);
+	for (const [index, left] of lefts.entries()) {
+		expect(
+			left,
+			`entry ${index}'s name does not line up in the dropdown`,
+		).toBeCloseTo(lefts[0], 0);
+	}
 
 	await page.locator(`${MENU} .vector-pinnable-header-pin-button`).click();
 	await expect(

--- a/tests/e2e/vector-skins.spec.js
+++ b/tests/e2e/vector-skins.spec.js
@@ -1,0 +1,136 @@
+// Which skin to read a page in is a choice about how the page looks, so Vector offers it in the
+// appearance menu, beside the theme, the text size and the content width -- not under "Tools",
+// which is where the sidebar section it is rendered in lands (#405).
+//
+// The move is the client's: Vector's appearance menu is empty in the served HTML and exposes no way
+// to add an entry to it, so ext.Wikven.vectorSkins moves the rendered section into it. Nothing
+// static shows whether that arrived -- the section is present in the HTML either way, under Tools
+// -- so this follows it in a browser, and follows what it left behind.
+
+const { test, expect } = require("@playwright/test");
+
+const PAGE = "Installation.html";
+const HEADING = "Installation";
+
+// The menu, and the skin list once it is inside it. The list keeps the portlet the bake rendered,
+// heading and all, so the section names itself where it lands.
+const MENU = "#vector-appearance";
+const LIST = `${MENU} .mw-portlet-wikven-skins`;
+// The box Vector draws around its page-tools menu, which is where the rendered section lands, and
+// the control that opens it -- a transparent checkbox laid over the menu's own label, so a click
+// aimed at the label lands on the checkbox.
+const TOOLS = ".vector-page-tools-landmark";
+const TOOLS_OPENER = "#vector-page-tools-dropdown-checkbox";
+
+// Vector renders the export's main skin at the root; a page there that no export renders in Vector
+// would leave every assertion below vacuous.
+test.beforeEach(async ({ page }) => {
+	await page.goto(PAGE);
+	await expect(page.locator("#firstHeading")).toHaveText(HEADING);
+	test.skip(
+		!(await page.locator(MENU).count()),
+		"this export does not render Vector",
+	);
+	test.skip(
+		!(await page.locator(".mw-portlet-wikven-skins").count()),
+		"a single-skin export lists no skins",
+	);
+});
+
+test("the skin list is in the appearance menu, and every skin is on it", async ({
+	page,
+}) => {
+	const list = page.locator(LIST);
+	await expect(list).toBeVisible();
+
+	// Every skin the export renders, which is what the section held under Tools; asserted against
+	// the entries in the document rather than against a count, so this follows docs/.wikven.yml.
+	const entries = await page.locator('[id^="t-wikven-skin-"]').count();
+	expect(entries).toBeGreaterThan(1);
+	await expect(list.locator(".mw-list-item")).toHaveCount(entries);
+
+	// The skin being read is marked, and is not offered as a link to itself. The anchor inside the
+	// entry, not the entry: the list item never carries an href, so asserting on it would pass
+	// however the entry is rendered.
+	await expect(list.locator(".mw-list-item.active")).toHaveCount(1);
+	await expect(list.locator(".mw-list-item.active a")).toHaveCount(0);
+});
+
+test("what is left of the Tools box goes with it", async ({ page }) => {
+	// The list left the page-tools menu, rather than merely being copied into the appearance menu:
+	// two switchers disagreeing about which skin is current is its own bug.
+	await expect(page.locator(`${TOOLS} .mw-portlet-wikven-skins`)).toHaveCount(
+		0,
+	);
+
+	// All that menu held was the toolbox Hider empties and this list, so the box Vector draws
+	// around them has nothing left to frame.
+	await expect(page.locator(TOOLS).first()).toBeHidden();
+});
+
+test("following an entry from the menu switches the skin, keeping the article", async ({
+	page,
+}) => {
+	const link = page.locator(`${LIST} .mw-list-item:not(.active) a`).first();
+	await expect(link).toBeVisible();
+
+	const navigation = page.waitForResponse((response) =>
+		response.request().isNavigationRequest(),
+	);
+	await link.click();
+	const response = await navigation;
+
+	// The href the bake wrote, reparented for this page's own depth: the move must not have
+	// disturbed it, and the page it names must be one the export actually contains.
+	expect(response.status()).toBe(200);
+	await page.waitForLoadState("domcontentloaded");
+	await expect(page.locator("#firstHeading")).toHaveText(HEADING);
+	expect(page.url()).not.toMatch(new RegExp(`/${PAGE}$`));
+});
+
+test("the list travels with the menu when it is hidden and put back", async ({
+	page,
+}) => {
+	// The list is inside the pinnable element rather than beside it in the container, so Vector's
+	// own move takes it along. Unpinning is a client preference, so the reader arrives at the next
+	// page with the menu already in the header dropdown -- the state this has to keep working in.
+	await page.locator(`${MENU} .vector-pinnable-header-unpin-button`).click();
+	await page.reload();
+
+	await page.locator("#vector-appearance-dropdown-checkbox").click();
+	await expect(
+		page.locator(`#vector-appearance-unpinned-container ${LIST}`),
+	).toBeVisible();
+
+	await page.locator(`${MENU} .vector-pinnable-header-pin-button`).click();
+	await expect(
+		page.locator(`#vector-appearance-pinned-container ${LIST}`),
+	).toBeVisible();
+});
+
+test("without JavaScript the Tools menu still lists the skins", async ({
+	browser,
+	baseURL,
+}) => {
+	// Nothing moves the list without JavaScript, which is why the module moves the rendered section
+	// rather than replacing it: the server-rendered links stay the fallback, in the box that is
+	// hidden only once they have left it.
+	const context = await browser.newContext({
+		javaScriptEnabled: false,
+		baseURL,
+	});
+	const page = await context.newPage();
+	await page.goto(PAGE);
+
+	await expect(page.locator(LIST)).toHaveCount(0);
+	await page.locator(TOOLS_OPENER).click();
+
+	const list = page.locator(".mw-portlet-wikven-skins");
+	await expect(list).toBeVisible();
+	await expect(list.locator(".mw-list-item.active")).toBeVisible();
+	await expect(
+		list.locator(".mw-list-item:not(.active) a").first(),
+	).toHaveAttribute("href", /Installation\.html$/);
+
+	await context.close();
+});

--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -205,6 +205,41 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame($expected, in_array('ext.Wikven.citizenSkins', $modules, true));
 	}
 
+	/**
+	 * The module that carries the skin list out of Vector's page-tools menu and into its appearance
+	 * menu is only worth loading in Vector, and only where there is a list to move.
+	 *
+	 * @dataProvider provideVectorAppearanceCases
+	 */
+	public function testTheAppearanceMoveIsLoadedForVectorOnly(
+		string $skin,
+		array $skins,
+		bool $expected
+	) {
+		$this->overrideConfigValue('WikvenSkins', $skins);
+		$modules = [];
+		$out = $this->outputPage();
+		$out->method('addModules')->willReturnCallback(static function ($name) use (&$modules) {
+			$modules[] = $name;
+		});
+		$skinMock = $this->createMock(Skin::class);
+		$skinMock->method('getSkinName')->willReturn($skin);
+
+		( new Adder() )->onBeforePageDisplay($out, $skinMock);
+
+		$this->assertSame($expected, in_array('ext.Wikven.vectorSkins', $modules, true));
+	}
+
+	public static function provideVectorAppearanceCases() {
+		$two = ['vector-2022', 'citizen'];
+		return [
+			'vector with a choice' => ['vector-2022', $two, true],
+			'vector with nothing to choose between' => ['vector-2022', ['vector-2022'], false],
+			'citizen' => ['citizen', $two, false],
+			'minerva' => ['minerva', $two, false]
+		];
+	}
+
 	public static function provideSkinChooserCases() {
 		$two = ['vector-2022', 'citizen'];
 		return [


### PR DESCRIPTION
Closes #405.

Vector 2022 rendered the export's skin list as a portlet inside the page **Tools** menu. Which skin to read a page in is a choice about how the page looks, so it belongs in the **Appearance** menu beside the theme, the text size and the content width. Citizen already made this move into its preferences panel; Vector was the skin left listing skins among page actions.

## Is there a server-side route?

No. Checked first, as the issue asks. `VectorComponentAppearance` renders a pinnable element, a container and a header and nothing else, and the contents are built on the client out of `skins.vector.js/clientPreferences.json`. There is no hook for a third party to add an entry, and the client-preferences framework stores an enum as a class on `<html>` — which a link into another directory is not.

So this does what Citizen got: `ext.Wikven.vectorSkins` moves the section the bake already rendered into `#vector-appearance`, once Vector has drawn its own preferences into it (observed, with a timeout so a menu that never fills still gets the list out of Tools).

## What the move preserves

- **Moves rather than rebuilds**, so the entries keep the hrefs the bake already reparented for each page's own depth — no URL arithmetic here — and keep the `t-wikven-skin-*` ids that the generated settings page reads (`appearance.js`).
- **A reader without JavaScript** is left the plain list of links where the bake wrote it, in the Tools menu, still working.
- **The section goes inside `#vector-appearance` itself**, not beside it in either container, so Vector's own pin/unpin carries the list along when the reader hides the menu and puts it back.
- **The emptied Tools box goes too.** All that menu held was the toolbox `Hider` empties, so the box Vector draws around it is hidden — gated on a class the module sets (never without JavaScript, which would take the export's only switcher with it), and only above the width at which that box also carries the page tabs, mirroring the guard `empty-toolbox.less` already uses.

## Changes

| File | |
| --- | --- |
| `resources/vector-skins.js` | new module |
| `extension.json` | registers `ext.Wikven.vectorSkins` |
| `includes/Hooks/Adder.php` | queues it for Vector when there is more than one skin |
| `resources/ext.Wikven.styles.less` | spacing in the menu; hides the box left under Tools |
| `tests/e2e/vector-skins.spec.js` | new browser spec |
| `tests/e2e/tools-portlet.spec.js`, `skin-switcher.spec.js` | Vector no longer discloses its switcher under Tools |
| `tests/phpunit/integration/AdderTest.php` | the module is loaded for Vector only, and only when there is a list to move |

## Verification

All checks green, including `smoke` — which bakes `docs/` with the real image and runs the whole Playwright suite (48 specs) against the output. What that confirms in a browser, on real Vector markup:

- the list is in the appearance menu, every skin on it, the one being read marked and not a link;
- it has left the page-tools menu, and the box around it is hidden;
- following an entry lands on that skin's copy of the same article;
- hiding the menu and putting it back carries the list along;
- without JavaScript the Tools menu still lists the skins, with working hrefs.

The existing specs went with it: `skin-switcher.spec.js` and `tools-portlet.spec.js` were updated because Vector no longer discloses its switcher under Tools, and the settings-page list still fills in every skin.

The first run caught one bug — in the new spec, not the feature. It asserted "the URL no longer ends in `Installation.html`" to check the switch had happened, which the destination `citizen/Installation.html` also ends in; that assertion could not have passed. It now asserts the entry's own skin directory, which is what the entry names.