### PR TITLE
build(deps): bump SifterSearch to v0.7.1, which anchors the results page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 ARG TARGETARCH
-ARG SIFTERSEARCH_VERSION=v0.7.0
+ARG SIFTERSEARCH_VERSION=v0.7.1
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \
  && curl -fsSL "https://github.com/chaotic-ground/SifterSearch/releases/download/${SIFTERSEARCH_VERSION}/SifterSearch-linux-${arch}.tar.gz" \

--- a/tests/e2e/subpage-search.spec.js
+++ b/tests/e2e/subpage-search.spec.js
@@ -1,0 +1,66 @@
+// Search from a page the export put in a subdirectory. A translated page is exported into a real
+// directory ("Deploying/ko.html"), and everything the export writes into its HTML is rebased by
+// that depth. The search targets are not all written into the HTML: SifterSearch carries the
+// results page's URL inside the module bundle, which is one file serving every page at every
+// depth, so a page-relative URL there is right only at the export root (#393, SifterSearch #63).
+// The reader-facing consequence is silent -- the box still opens, still suggests -- so what
+// follows reads the targets themselves, from a page that is not at the root.
+
+const { test, expect } = require("@playwright/test");
+
+// A translated page, exported one directory down. The Korean translations are the only pages the
+// docs site keeps at depth, and this one exists because docs/Deploying/ko.wikitext does.
+const SUBPAGE = "Deploying/ko.html";
+
+test("a search from a subpage aims at the results page, not inside its own directory", async ({
+	page,
+	baseURL,
+}) => {
+	await page.goto(SUBPAGE);
+
+	const results = new URL("Search.html", baseURL).href;
+	const form = page.locator('[role="search"] form').first();
+
+	// The skin renders the form aimed at the script path, and ext.sifter.retarget repoints it once
+	// the bundle runs. So the action leaving the script path is what says the module has had its
+	// say, and only then is there anything to assert about where it left the targets.
+	await expect
+		.poll(() => form.evaluate((el) => el.action), { timeout: 15000 })
+		.toBe(results);
+
+	// Read as the browser resolves them, since these are relative and the point is where they land.
+	// Every link inside the search box: Vector's collapsed-box toggle is the one that exists today.
+	const hrefs = await page
+		.locator('[role="search"] a[href]')
+		.evaluateAll((links) => links.map((link) => link.href));
+	expect(hrefs.length).toBeGreaterThan(0);
+	for (const href of hrefs) {
+		expect(href).toBe(results);
+	}
+});
+
+test("the 'containing' suggestion from a subpage carries the query to the results page", async ({
+	page,
+	baseURL,
+}) => {
+	await page.goto(SUBPAGE);
+
+	// Focusing the raw box mounts the Codex typeahead and focuses its input; wait for the mounted
+	// input before typing so no keystroke is dropped mid-swap, as the root-page suggestion test does.
+	await page.locator("#searchInput").first().click();
+	await page
+		.locator(".cdx-text-input__input")
+		.first()
+		.waitFor({ state: "visible", timeout: 15000 });
+	await page.keyboard.type("binary", { delay: 40 });
+
+	// The footer row a full-text search goes to. Its URL comes from the same configured value as the
+	// form's action, and core appends a wprov= tracking parameter, so the query is matched by prefix.
+	const containing = page
+		.locator('.cdx-menu-item a[href*="Search.html?search="]')
+		.first();
+	await expect(containing).toBeVisible({ timeout: 15000 });
+	const href = await containing.evaluate((link) => link.href);
+	const query = new URL("Search.html?search=binary", baseURL).href;
+	expect(href.startsWith(query)).toBe(true);
+});


### PR DESCRIPTION
Refs #425, which stays open — see the last section.

The results page's URL is baked into SifterSearch's module bundle from `Title::getLocalURL()`, which on a wiki means the same thing read from any page. An export's does not: wikven writes `./Search.html` and corrects the depth per page, in the HTML alone, so the one copy a shared bundle carries was right only at the export root. From `Deploying/ko.html` it pointed at `Deploying/Search.html`, and nothing is served there.

[v0.7.1](https://github.com/chaotic-ground/SifterSearch/releases/tag/v0.7.1) ([SifterSearch#64](https://github.com/chaotic-ground/SifterSearch/pull/64), closing [#63](https://github.com/chaotic-ground/SifterSearch/issues/63)) anchors it before baking, at the parent of the bundle path — the one setting that is site-root-anchored by construction, since the client loads the bundle by it from every page. A URL that already means the same thing everywhere is left alone, as is one whose bundle path (another host's, or unset) says nothing about the site root.

## What it reaches

| Target | Built by |
| --- | --- |
| the search form's `action` | `ext.sifter.retarget` |
| the fallback link in the search box | `ext.sifter.retarget` |
| the submit navigation, and the typeahead's "search for pages containing…" row | `ext.sifter.pagefind` |

The second row is the one #421 could not fix from here. That toggle's href is written relative and reparented per subdirectory, so the HTML was already right at any depth — and the script then overwrote it with the bundle's copy, right only at the root.

## Tests

`tests/e2e/subpage-search.spec.js`, on `Deploying/ko.html` (a translated page, exported into a real directory — the only pages the docs site keeps at depth):

1. The form's `action` and every link inside the search box resolve to the results page at the site root. Read after the action leaves the script path, which is what says `ext.sifter.retarget` has run — before that there is nothing of the module's to assert.
2. The typeahead's "containing" row carries the query to that same page.

Both read the targets rather than following a reader's eye, because the failure is silent: the box opens, it suggests, and only the landing is wrong. Under v0.7.0 both resolve into `Deploying/`, so they fail.

The bake could not be run here (no Docker daemon in this environment), so the new spec runs for the first time in the smoke job.

## What stays open

#425 reports the class, not this instance: a local URL that escapes the HTML into a module bundle, a JS config var or a generated asset is never reparented, and reparenting is what keeps the export's relative URLs honest. This one is closed on the consumer's side, which is option 1 of the three that issue lists.

---
_Generated by [Claude Code](https://claude.ai/code/session_019dBoQc7RNwSThCroMUtRzK)_