### PR TITLE
build: ignore the directory the browser tests serve from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /out/
 /test-results/
 /playwright-report/
+/pw-root/
 
 # uv
 /.venv/


### PR DESCRIPTION
`playwright.config.js` builds `pw-root/` in its `webServer` command, to expose `dist/` under the site's own path prefix:

```
mkdir -p pw-root && ln -sfn "$PWD/dist" pw-root/wikven && python3 -m http.server 8080 --directory pw-root
```

That is deliberate — it is what makes `npm run test:e2e` work as-is outside CI, as the config's own comment says. But the directory it leaves behind is untracked, so running the browser tests locally puts a stray symlink in `git status`, next to the `dist/`, `test-results/` and `playwright-report/` that are already ignored.

Added beside the other two Playwright entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcazX6P45gP3irMPDkJACK)_