### PR TITLE
fix: confine a skin pass's translation-link walk to its own pages

### DIFF
--- a/includes/OutputTree.php
+++ b/includes/OutputTree.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use FilesystemIterator;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * The pages one skin pass owns, for the build steps that walk the output tree.
+ *
+ * A skin pass must never read or write a path outside its own output. The trap is that the main
+ * skin's output directory is dist/ itself, which is the parent of every other skin's
+ * ("dist/citizen/", "dist/minerva/"; see WikvenSettings.php), so a pass that walks its own
+ * directory recursively reaches the other skins' pages. Nothing is broken today only because of
+ * ordering: the main skin is always the first pass, so the other directories do not exist yet
+ * while it walks. That is not something a caller can be asked to preserve -- WIKVEN_BUILD_SKIN
+ * re-runs a single pass over a dist/ that already holds the others, and the passes are meant to
+ * become concurrent -- so the walk prunes them instead.
+ *
+ * history/ is pruned for the opposite reason: it is the pass's own, but it holds no page of the
+ * site. RebuildFileCache writes a history page per page and Build::renderSkin() deletes the whole
+ * tree a few steps later, so reading it is work thrown away.
+ */
+class OutputTree {
+	/** Trees a pass writes into its own output directory that hold no page of the site. */
+	private const NON_PAGE_DIRECTORIES = ['history'];
+
+	/**
+	 * Every exported page the pass rendering into $htmlDir owns.
+	 *
+	 * @param string $htmlDir The pass's own output directory ($wgWikvenHtmlDirectory).
+	 * @param string[] $skinDirectories Every skin pass's output directory, this one included
+	 *   ($wgWikvenSkinDirectories).
+	 * @return list<string> Absolute paths of .html files, in a fixed order.
+	 */
+	public static function pages(string $htmlDir, array $skinDirectories = []): array {
+		$htmlDir = rtrim($htmlDir, '/');
+		if ($htmlDir === '' || !is_dir($htmlDir)) {
+			return [];
+		}
+		$pruned = self::prunedDirectories($htmlDir, $skinDirectories);
+
+		$directories = new RecursiveDirectoryIterator($htmlDir, FilesystemIterator::SKIP_DOTS);
+		$own = new RecursiveCallbackFilterIterator(
+			$directories,
+			static function (SplFileInfo $file) use ($pruned): bool {
+				// Files are all kept here and filtered below; only descent is being decided.
+				return !$file->isDir() || !in_array(rtrim($file->getPathname(), '/'), $pruned, true);
+			}
+		);
+
+		$pages = [];
+		foreach (new RecursiveIteratorIterator($own) as $file) {
+			$path = $file->getPathname();
+			if ($file->isFile() && str_ends_with($path, '.html')) {
+				$pages[] = $path;
+			}
+		}
+		sort($pages);
+		return $pages;
+	}
+
+	/**
+	 * The directories a walk of $htmlDir must not descend into: every other skin's output that
+	 * lies under it, and the pass's own non-page trees.
+	 *
+	 * A skin directory that is not under $htmlDir is left out, since the walk cannot reach it
+	 * anyway; that is every other skin's, seen from a non-main pass.
+	 *
+	 * @param string $htmlDir The pass's own output directory, without a trailing slash.
+	 * @param string[] $skinDirectories Every skin pass's output directory, this one included.
+	 * @return list<string>
+	 */
+	public static function prunedDirectories(string $htmlDir, array $skinDirectories): array {
+		$htmlDir = rtrim($htmlDir, '/');
+		$pruned = [];
+		foreach ($skinDirectories as $directory) {
+			$directory = rtrim((string)$directory, '/');
+			if ($directory === '' || $directory === $htmlDir) {
+				continue;
+			}
+			if (str_starts_with($directory, "$htmlDir/")) {
+				$pruned[] = $directory;
+			}
+		}
+		foreach (self::NON_PAGE_DIRECTORIES as $name) {
+			$pruned[] = "$htmlDir/$name";
+		}
+		return array_values(array_unique($pruned));
+	}
+}

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -219,6 +219,15 @@ $wgWikvenSkins = array_values(array_unique($wgWikvenSkins));
 $wgWikvenMainSkin = $wgWikvenSkins[0] ?? $wgDefaultSkin;
 $wgDefaultSkin = $wgWikvenMainSkin;
 
+// Where each skin pass writes, which is the one place that knows the export's layout: the main
+// skin renders to the dist root, and every other skin to a subdirectory of it. A pass walking its
+// own output reads this to prune the other skins' pages out of the walk -- the main skin's
+// directory holds all of them (see OutputTree).
+$wgWikvenSkinDirectories = [];
+foreach ($wgWikvenSkins as $wikvenSkin) {
+	$wgWikvenSkinDirectories[$wikvenSkin] = $wikvenSkin === $wgWikvenMainSkin ? $wikvenDist : "$wikvenDist/$wikvenSkin";
+}
+
 // Per-skin build pass: WIKVEN_BUILD_SKIN renders main skin to dist root, others to dist/<skin>/.
 $wikvenBuildSkin = getenv('WIKVEN_BUILD_SKIN');
 if ($wikvenBuildSkin !== false && in_array($wikvenBuildSkin, $wgWikvenSkins, true)) {

--- a/maintenance/resolveTranslationLinks.php
+++ b/maintenance/resolveTranslationLinks.php
@@ -2,12 +2,9 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use FilesystemIterator;
 use Maintenance;
 use MediaWiki\Languages\LanguageNameUtils;
 use MediaWiki\Registration\ExtensionRegistry;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 	? getenv('MW_INSTALL_PATH')
@@ -23,6 +20,11 @@ require_once "$IP/maintenance/Maintenance.php";
  * Rename, over the final tree: it reads each file's language from its path, then rewrites every
  * "Special:MyLanguage/Target" link to the target's translation in that language when it exists, or
  * the source target otherwise, keeping the link's existing relative prefix.
+ *
+ * The tree walked is the running pass's own pages and no others; OutputTree says why that has to
+ * be asked for rather than assumed. It matters twice here: another skin's page would be rewritten
+ * by a pass that did not render it, and its links would be resolved against the wrong root, since
+ * the existence probe below looks for the target under this pass's directory.
  */
 class ResolveTranslationLinks extends Maintenance {
 	public function __construct() {
@@ -40,14 +42,8 @@ class ResolveTranslationLinks extends Maintenance {
 		}
 		$languageNameUtils = $this->getServiceContainer()->getLanguageNameUtils();
 
-		$iterator = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator($htmlDir, FilesystemIterator::SKIP_DOTS)
-		);
-		foreach ($iterator as $file) {
-			$path = $file->getPathname();
-			if (!$file->isFile() || !str_ends_with($path, '.html')) {
-				continue;
-			}
+		$pages = OutputTree::pages($htmlDir, $GLOBALS['wgWikvenSkinDirectories'] ?? []);
+		foreach ($pages as $path) {
 			$lang = $this->fileLanguage($path, $htmlDir, $languageNameUtils);
 			$html = (string)file_get_contents($path);
 			$resolved = RelativeUrl::resolveMyLanguage(

--- a/tests/phpunit/unit/OutputTreeTest.php
+++ b/tests/phpunit/unit/OutputTreeTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use FilesystemIterator;
+use MediaWiki\Extension\Wikven\OutputTree;
+use MediaWikiUnitTestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\OutputTree
+ */
+class OutputTreeTest extends MediaWikiUnitTestCase {
+	public function testAMissingDirectoryHasNoPages() {
+		$this->assertSame([], OutputTree::pages($this->makeTempDir() . '/absent'));
+		$this->assertSame([], OutputTree::pages(''));
+	}
+
+	public function testPagesAreTheHtmlFilesAtEveryDepth() {
+		$dist = $this->makeExport();
+		$this->assertSame(
+			[
+				"$dist/Deploying/ko.html",
+				"$dist/Installation.html",
+				"$dist/index.html"
+			],
+			OutputTree::pages($dist, $this->skinDirectories($dist))
+		);
+	}
+
+	public function testTheMainSkinsWalkStopsAtTheOtherSkinsDirectories() {
+		$dist = $this->makeExport();
+		$pages = OutputTree::pages($dist, $this->skinDirectories($dist));
+		// dist/ is the main skin's own output directory and the parent of every other skin's.
+		$this->assertNotContains("$dist/citizen/Installation.html", $pages);
+		$this->assertNotContains("$dist/minerva/Deploying/ko.html", $pages);
+	}
+
+	public function testASkinsWalkStopsAtTheHistoryTreeItWrote() {
+		$dist = $this->makeExport();
+		$this->assertNotContains(
+			"$dist/history/Installation.html",
+			OutputTree::pages($dist, $this->skinDirectories($dist))
+		);
+	}
+
+	public function testASkinPassSeesItsOwnPagesAndOnlyThose() {
+		$dist = $this->makeExport();
+		$this->assertSame(
+			["$dist/citizen/Installation.html"],
+			OutputTree::pages("$dist/citizen", $this->skinDirectories($dist))
+		);
+	}
+
+	public function testAPageDirectoryNamedAfterASkinIsStillWalked() {
+		$dist = $this->makeExport();
+		// "citizen" only names another skin's output directly under dist/; a page of that name
+		// inside a skin's own tree is a page like any other.
+		$this->write("$dist/minerva/citizen/ko.html");
+		$this->assertContains(
+			"$dist/minerva/citizen/ko.html",
+			OutputTree::pages("$dist/minerva", $this->skinDirectories($dist))
+		);
+	}
+
+	public function testWithNoSkinsNamedOnlyTheNonPageTreesArePruned() {
+		$dist = $this->makeExport();
+		$pages = OutputTree::pages($dist);
+		// Nothing said where the other skins are, so their pages are walked; history/ is known.
+		$this->assertContains("$dist/citizen/Installation.html", $pages);
+		$this->assertNotContains("$dist/history/Installation.html", $pages);
+	}
+
+	public function testOnlyTheSkinDirectoriesUnderThisOneArePruned() {
+		$this->assertSame(
+			['/w/dist/citizen', '/w/dist/history'],
+			OutputTree::prunedDirectories('/w/dist', [
+				'main' => '/w/dist',
+				'citizen' => '/w/dist/citizen'
+			])
+		);
+		// From a skin subdirectory the main skin's tree is above, so the walk never reaches it.
+		$this->assertSame(
+			['/w/dist/citizen/history'],
+			OutputTree::prunedDirectories('/w/dist/citizen', [
+				'main' => '/w/dist',
+				'citizen' => '/w/dist/citizen'
+			])
+		);
+	}
+
+	public function testATrailingSlashNamesTheSameDirectory() {
+		$this->assertSame(
+			['/w/dist/citizen', '/w/dist/history'],
+			OutputTree::prunedDirectories('/w/dist/', ['/w/dist/', '/w/dist/citizen/'])
+		);
+	}
+
+	/** A three-skin export: dist/ is the main skin's, with the other two and history/ inside it. */
+	private function makeExport(): string {
+		$dist = $this->makeTempDir();
+		foreach ([
+			'index.html',
+			'Installation.html',
+			'Deploying/ko.html',
+			'citizen/Installation.html',
+			'minerva/Deploying/ko.html',
+			'history/Installation.html',
+			'styles/main.css'
+		] as $path) {
+			$this->write("$dist/$path");
+		}
+		return $dist;
+	}
+
+	/** @return array<string,string> */
+	private function skinDirectories(string $dist): array {
+		return ['vector' => $dist, 'citizen' => "$dist/citizen", 'minerva' => "$dist/minerva"];
+	}
+
+	private function write(string $path): void {
+		$directory = dirname($path);
+		if (!is_dir($directory)) {
+			mkdir($directory, 0777, true);
+		}
+		file_put_contents($path, '<html></html>');
+	}
+
+	private function makeTempDir(): string {
+		$dir = sys_get_temp_dir() . '/wikven-output-tree-' . uniqid();
+		mkdir($dir);
+		$this->dirsToClean[] = $dir;
+		return $dir;
+	}
+
+	/** @var string[] */
+	private array $dirsToClean = [];
+
+	protected function tearDown(): void {
+		foreach ($this->dirsToClean as $dir) {
+			if (!is_dir($dir)) {
+				continue;
+			}
+			$entries = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($entries as $entry) {
+				if ($entry->isDir()) {
+					rmdir($entry->getPathname());
+				} else {
+					unlink($entry->getPathname());
+				}
+			}
+			rmdir($dir);
+		}
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
Closes #409.

`ResolveTranslationLinks` walked `$wgWikvenHtmlDirectory` recursively and rewrote every `.html` under it. For the main skin that directory is `dist/` itself — the parent of every other skin's output (`dist/citizen/`, `dist/minerva/`) and of the `history/` tree `renderSkin()` deletes a few steps later.

Nothing is broken today, but only because of ordering: the main skin is always the first pass (`$wgWikvenMainSkin = $wgWikvenSkins[0]`), so the other skins' directories do not exist yet while it walks. That is load-bearing and written down nowhere. It breaks if the loop order changes, if the passes ever run concurrently (#407), or if a single pass is re-run with `WIKVEN_BUILD_SKIN` over a `dist/` that already holds the other skins — and then the main pass rewrites another skin's pages and resolves their `Special:MyLanguage/` links against the wrong root, since the existence probe is `is_file("$htmlDir/$target/$lang.html")` with `$htmlDir` its own directory.

## What changed

- **`includes/OutputTree.php`** (new) — answers what one pass owns. `pages()` walks a pass's output directory and prunes the trees that are not its own pages; `prunedDirectories()` is the decision on its own. The class docblock is where "a skin pass must never touch a path outside its own output" is stated, since `dist/` being both the main skin's directory and everything else's parent is the trap.
- **`includes/WikvenSettings.php`** — adds `$wgWikvenSkinDirectories`, each skin pass's output directory, derived right where the per-skin paths are already decided. That keeps the export's layout stated in one place rather than re-inferred by each walker.
- **`maintenance/resolveTranslationLinks.php`** — takes its file list from `OutputTree::pages()`, and says in its docblock why the confinement matters here twice over.

`history/` is pruned as well, for the opposite reason: it is the pass's own, but holds no page of the site, so reading and matching over it was work thrown away (#408 is about not rendering it at all).

## Notes

- Only `resolveTranslationLinks.php` walked recursively; the other steps (`rename.php`, `rewriteScripts.php`, `storeImages.php`) `glob()` one level and never descend into a skin directory. `OutputTree` is reusable if that changes.
- A directory named after a skin *inside* a skin's own tree — a page titled "citizen" with subpages — is still walked: the pruning matches full paths, not names.

## Testing

- `tests/phpunit/unit/OutputTreeTest.php` (new), over a temp export laid out as a three-skin bake: pages at every depth, the main pass stopping at the other skins' directories and at `history/`, a non-main pass seeing only its own, a same-named page directory still walked, and the trailing-slash and no-skins-named cases.
- `phpcs`, `mago format --check` and `mago lint` clean.
- The bake itself is not run here (no MediaWiki install in this session); CI's PHPUnit and smoke jobs cover it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KppjxSg5kvmV7br7Ca5mCH)_