### PR TITLE
fix: keep a skin pass out of the other skins' pages

### DIFF
--- a/includes/SkinOutput.php
+++ b/includes/SkinOutput.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use FilesystemIterator;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * The pages one skin pass owns, out of everything under its output directory.
+ *
+ * A pass renders into $wgWikvenHtmlDirectory, and for the main skin that directory is dist/
+ * itself: the parent of every other skin's output (dist/citizen/, dist/minerva/) and of the
+ * history/ tree renderSkin() deletes. So "everything under my output directory" is not the same
+ * set as "my pages", and a pass must never touch a path outside its own: another skin's page
+ * resolves its links against the wrong root when read from here, and writing one races the pass
+ * that owns it once the passes run together (#407, #409).
+ *
+ * A skin's directory is named after the skin, so it cannot be mistaken for a page's: the cache
+ * writes a page under its title, and MediaWiki capitalizes a title's first letter, while the
+ * canonical skin names these directories take are lowercase.
+ */
+class SkinOutput {
+	/**
+	 * Every .html file the pass rendering $skin owns, below $htmlDir.
+	 *
+	 * @param string $htmlDir The pass's output directory ($wgWikvenHtmlDirectory).
+	 * @param string[] $skins Every skin the site renders ($wgWikvenSkins).
+	 * @param string $mainSkin The skin rendered into the output root ($wgWikvenMainSkin).
+	 * @param string $skin The skin this pass renders ($wgDefaultSkin).
+	 * @return iterable<string> Absolute paths.
+	 */
+	public static function pages(string $htmlDir, array $skins, string $mainSkin, string $skin): iterable {
+		$htmlDir = rtrim($htmlDir, '/');
+		$foreign = array_fill_keys(self::foreignDirectories($htmlDir, $skins, $mainSkin, $skin), true);
+
+		$entries = new RecursiveIteratorIterator(
+			new RecursiveCallbackFilterIterator(
+				new RecursiveDirectoryIterator($htmlDir, FilesystemIterator::SKIP_DOTS),
+				static function (SplFileInfo $current) use ($foreign): bool {
+					return !isset($foreign[$current->getPathname()]);
+				}
+			)
+		);
+		foreach ($entries as $entry) {
+			$path = $entry->getPathname();
+			if ($entry->isFile() && str_ends_with($path, '.html')) {
+				yield $path;
+			}
+		}
+	}
+
+	/**
+	 * The directories directly under $htmlDir that hold something other than this pass's pages.
+	 *
+	 * @param string $htmlDir The pass's output directory ($wgWikvenHtmlDirectory).
+	 * @param string[] $skins Every skin the site renders ($wgWikvenSkins).
+	 * @param string $mainSkin The skin rendered into the output root ($wgWikvenMainSkin).
+	 * @param string $skin The skin this pass renders ($wgDefaultSkin).
+	 * @return string[] Absolute paths.
+	 */
+	public static function foreignDirectories(string $htmlDir, array $skins, string $mainSkin, string $skin): array {
+		$htmlDir = rtrim($htmlDir, '/');
+		// Every pass writes a per-page history/ tree that renderSkin() deletes on its way out, so
+		// reading it here is work no one ever looks at (#408).
+		$directories = ["$htmlDir/history"];
+		// Only the main skin renders into the output root; every other pass has a directory to
+		// itself, with nobody else's pages below it.
+		if ($skin !== $mainSkin) {
+			return $directories;
+		}
+		foreach ($skins as $other) {
+			if ($other !== $mainSkin) {
+				$directories[] = "$htmlDir/$other";
+			}
+		}
+		return $directories;
+	}
+}

--- a/maintenance/resolveTranslationLinks.php
+++ b/maintenance/resolveTranslationLinks.php
@@ -2,12 +2,9 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use FilesystemIterator;
 use Maintenance;
 use MediaWiki\Languages\LanguageNameUtils;
 use MediaWiki\Registration\ExtensionRegistry;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 	? getenv('MW_INSTALL_PATH')
@@ -23,6 +20,10 @@ require_once "$IP/maintenance/Maintenance.php";
  * Rename, over the final tree: it reads each file's language from its path, then rewrites every
  * "Special:MyLanguage/Target" link to the target's translation in that language when it exists, or
  * the source target otherwise, keeping the link's existing relative prefix.
+ *
+ * "The final tree" is this pass's own pages and no one else's: the walk goes through SkinOutput,
+ * which keeps the main skin's out of the other skins' output below it. Deciding a link in
+ * dist/citizen/Foo/ko.html by whether dist/Foo/ko.html exists is how that goes wrong.
  */
 class ResolveTranslationLinks extends Maintenance {
 	public function __construct() {
@@ -40,14 +41,13 @@ class ResolveTranslationLinks extends Maintenance {
 		}
 		$languageNameUtils = $this->getServiceContainer()->getLanguageNameUtils();
 
-		$iterator = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator($htmlDir, FilesystemIterator::SKIP_DOTS)
+		$pages = SkinOutput::pages(
+			$htmlDir,
+			$GLOBALS['wgWikvenSkins'] ?? [],
+			(string)( $GLOBALS['wgWikvenMainSkin'] ?? $GLOBALS['wgDefaultSkin'] ),
+			(string)$GLOBALS['wgDefaultSkin']
 		);
-		foreach ($iterator as $file) {
-			$path = $file->getPathname();
-			if (!$file->isFile() || !str_ends_with($path, '.html')) {
-				continue;
-			}
+		foreach ($pages as $path) {
 			$lang = $this->fileLanguage($path, $htmlDir, $languageNameUtils);
 			$html = (string)file_get_contents($path);
 			$resolved = RelativeUrl::resolveMyLanguage(

--- a/tests/phpunit/integration/SkinOutputTest.php
+++ b/tests/phpunit/integration/SkinOutputTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\SkinOutput;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\SkinOutput
+ */
+class SkinOutputTest extends MediaWikiIntegrationTestCase {
+	private const SKINS = ['vector-2022', 'citizen', 'minerva'];
+
+	public function testMainSkinLeavesTheOtherSkinsAlone() {
+		$dist = $this->getNewTempDirectory();
+		$this->write("$dist/index.html");
+		$this->write("$dist/Manual/ko.html");
+		$this->write("$dist/history/index.html");
+		$this->write("$dist/citizen/index.html");
+		$this->write("$dist/citizen/Manual/ko.html");
+		$this->write("$dist/minerva/index.html");
+
+		$this->assertSame(
+			["$dist/Manual/ko.html", "$dist/index.html"],
+			$this->pages($dist, 'vector-2022')
+		);
+	}
+
+	public function testAnotherSkinWalksItsOwnDirectory() {
+		$dist = $this->getNewTempDirectory();
+		$this->write("$dist/citizen/index.html");
+		$this->write("$dist/citizen/Manual/ko.html");
+		$this->write("$dist/citizen/history/index.html");
+
+		$this->assertSame(
+			["$dist/citizen/Manual/ko.html", "$dist/citizen/index.html"],
+			$this->pages("$dist/citizen", 'citizen')
+		);
+	}
+
+	public function testOnlyHtmlIsWalked() {
+		$dist = $this->getNewTempDirectory();
+		$this->write("$dist/index.html");
+		$this->write("$dist/img-0123456789ab.png");
+		$this->write("$dist/styles/vector.css");
+
+		$this->assertSame(["$dist/index.html"], $this->pages($dist, 'vector-2022'));
+	}
+
+	public function testATrailingSlashNamesTheSameDirectories() {
+		$this->assertSame(
+			SkinOutput::foreignDirectories('/dist', self::SKINS, 'vector-2022', 'vector-2022'),
+			SkinOutput::foreignDirectories('/dist/', self::SKINS, 'vector-2022', 'vector-2022')
+		);
+	}
+
+	public function testTheMainSkinExcludesEveryOtherSkinAndTheHistoryTree() {
+		$this->assertSame(
+			['/dist/history', '/dist/citizen', '/dist/minerva'],
+			SkinOutput::foreignDirectories('/dist', self::SKINS, 'vector-2022', 'vector-2022')
+		);
+	}
+
+	public function testAnotherSkinExcludesOnlyTheHistoryTree() {
+		$this->assertSame(
+			['/dist/citizen/history'],
+			SkinOutput::foreignDirectories('/dist/citizen', self::SKINS, 'vector-2022', 'citizen')
+		);
+	}
+
+	/** The walk's paths, sorted: the filesystem's own order is not a promise. */
+	private function pages(string $htmlDir, string $skin): array {
+		$pages = iterator_to_array(SkinOutput::pages($htmlDir, self::SKINS, 'vector-2022', $skin), false);
+		sort($pages);
+		return $pages;
+	}
+
+	private function write(string $path): void {
+		$this->assertTrue(wfMkdirParents(dirname($path)));
+		file_put_contents($path, 'x');
+	}
+}


### PR DESCRIPTION
Closes #409. First of a stack that works through the performance issues around the skin phase (#409 → #410 → #408 → #411 → #407).

## What is wrong

`ResolveTranslationLinks` walks `$wgWikvenHtmlDirectory` recursively, and for the main skin that directory is `dist/` itself — the parent of every other skin's output (`dist/citizen/`, `dist/minerva/`) and of the `history/` tree `renderSkin()` deletes a few lines later.

Nothing is broken today, and only ordering keeps it that way: `$wgWikvenMainSkin = $wgWikvenSkins[0]` and `Build::execute()` loops in that order, so `dist/citizen/` does not exist yet when the main pass walks `dist/`. That dependency is load-bearing and written down nowhere. It breaks if the loop order changes, if the passes run together (#407), or if a single pass is re-run with `WIKVEN_BUILD_SKIN` over a `dist/` that already holds the other skins — the existence probe behind a `Special:MyLanguage/` link is `is_file("$htmlDir/$target/$lang.html")` with `$htmlDir` the main skin's directory, so a link in `dist/citizen/Foo/ko.html` gets decided by whether `dist/Foo/ko.html` exists.

## What this does

Adds `includes/SkinOutput.php`, which yields the `.html` files a pass owns and descends into neither another skin's output nor `history/`, and gives the walk to it. The `history/` pruning also drops wasted work as it stands: that tree is read and matched here and deleted moments later (#408 is about not rendering it at all).

A skin's directory cannot be mistaken for a page's, which the class says in a comment: the cache writes a page under its title, MediaWiki capitalizes a title's first letter, and the canonical skin names these directories take are lowercase.

## Testing

`tests/phpunit/integration/SkinOutputTest.php` builds a `dist/` holding two skins and a `history/` tree and asserts each pass sees its own pages only, plus the directory-list cases (trailing slash, main vs. non-main skin). `phpcs`, `mago format --check` and `mago lint` pass locally; the bake itself is covered by the smoke workflow on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzaVRrQe9B2xNeNzrsz5bS)_