### PR TITLE
perf: freeze page_touched once, in the orchestrator

### DIFF
--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -63,6 +63,9 @@ class Build extends Maintenance {
 		$this->stampSourceHistory();
 		$this->hideBuildAuthors();
 		$this->forgetCachedRevisionRows();
+		// The content is final here, so this is the last write the database needs and the passes
+		// below can be readers of it.
+		$this->freezePageTouched();
 
 		$skins = $GLOBALS['wgWikvenSkins'] ?? [];
 		if (!$skins) {
@@ -266,7 +269,22 @@ class Build extends Maintenance {
 		}
 	}
 
-	/** Freeze page_touched once content is final; wiki-page modules fold it into their version hash. */
+	/**
+	 * Freeze page_touched once content is final; wiki-page modules fold it into their version hash.
+	 *
+	 * Once, in the orchestrator, rather than once per skin pass: what it writes is content state,
+	 * the same in every pass and derived from nothing a pass did, so a three-skin bake was running
+	 * the same full-table update three times for two no-ops. It is also one of the two writes that
+	 * kept a pass from being a reader of the database -- rebuildFileCache.php puts the wiki in
+	 * read-only mode for its own duration, so a pass has no business writing around it -- and a
+	 * reader is what a pass has to be to run beside another one (#407).
+	 *
+	 * Freezing here also means the pages are rendered with the frozen value rather than with
+	 * whatever the import and the job queue left, since the passes now boot after it. That is the
+	 * point of the freeze rather than a cost of moving it: SOURCE_DATE_EPOCH differs per commit,
+	 * so a page_touched written under the frozen clock differs per commit too, and pinning it is
+	 * what keeps the module version hashes embedded in the HTML stable between bakes.
+	 */
 	private function freezePageTouched(): void {
 		$dbw = $this->getPrimaryDB();
 		$dbw->newUpdateQueryBuilder()
@@ -276,8 +294,9 @@ class Build extends Maintenance {
 			->caller(__METHOD__)
 			->execute();
 
-		// The modules read page_touched through LinkCache, not the row just written: it is warmed in
-		// process while the pages render, and MediaWiki: pages are cached in the object cache too.
+		// The modules read page_touched through LinkCache, not the row just written: this process
+		// has warmed it filling the wiki, and its MediaWiki: entries are kept in the object cache
+		// as well, which the passes below boot onto rather than build for themselves.
 		$linkCache = $this->getServiceContainer()->getLinkCache();
 		$pages = $dbw->newSelectQueryBuilder()
 			->select(['page_namespace', 'page_title'])
@@ -343,8 +362,6 @@ class Build extends Maintenance {
 		$this->step(RetranslateChrome::class, "$own/retranslateChrome.php");
 		// Every page is rendered by now: drop what each one recorded about the request that made it.
 		$this->step(StripBuildStamps::class, "$own/stripBuildStamps.php");
-		// Nothing is rendered after this, so freezing costs no staleness; the asset dumps below read it.
-		$this->freezePageTouched();
 		$this->step(BuildStyles::class, "$own/buildStyles.php");
 		// Opt-in: bake ULS webfonts into a static stylesheet rewriteScripts links below.
 		$this->step(BakeWebfonts::class, "$own/bakeWebfonts.php");


### PR DESCRIPTION
Closes #410. Second of the skin-phase stack; **based on #430**, so review that one first (this PR's diff against it is one file).

## What this does

Moves `Build::freezePageTouched()` out of `renderSkin()` and into `execute()`, after `forgetCachedRevisionRows()` and before the loop that spawns the passes.

It updates `page_touched` on every row of `page` and invalidates every title in the `LinkCache`. What it writes is content state — identical in every pass, derived from nothing the pass did — so a three-skin bake ran the same full-table update three times and only the first one changed anything.

The waste is small on its own. Removing a writer from the passes is the point: `rebuildFileCache.php` puts the wiki in read-only mode for its own duration ("Avoid DB writes"), so a pass has no business writing around it, and being a reader is what lets two passes run beside each other (#407).

## The part that needed checking

It is not a pure move. The pages used to be rendered *before* the freeze, so they saw whatever `page_touched` the import and the job queue left; only the asset dumps that followed saw the frozen value. Now the passes boot after it, so the rendered HTML sees it too, and it folds into the version hash of the wiki-page modules embedded in that HTML.

That is an improvement rather than a risk, and it is what the freeze is for: `SOURCE_DATE_EPOCH` differs per commit, so a `page_touched` written under the frozen clock differs per commit too, and the hashes that fold it in would move with it. Pinning it is what keeps them stable.

`HTMLFileCache::isCacheGood()` compares the cache file's mtime against `page_touched` and so now answers "good" for a page whose file survived a previous run — which changes nothing here, because the bake clears `dist/` before it starts and always passes `--overwrite`, and `--overwrite` sets `$rebuilt = true` on that branch instead of skipping the page.

## Testing

The smoke workflow on this PR bakes the docs site with the real image, so the rendered output is exercised end to end; #411 (later in the stack) adds the double-bake diff that would catch a version hash moving between bakes. `phpcs`, `mago format --check` and `mago lint` pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzaVRrQe9B2xNeNzrsz5bS)_