### PR TITLE
perf: stop rendering the history pages the export throws away

### DIFF
--- a/bin/build.php
+++ b/bin/build.php
@@ -94,7 +94,9 @@ $run(["$ip/extensions/Wikven/maintenance/fetchExtensions.php"]);
 $run(['update', '--quick']);
 $run(["$ip/extensions/Wikven/maintenance/build.php"]);
 
-// Drop the per-page history the file cache emits, as the Docker run does. Done without a shell: this
+// Drop any per-page history left in the output, as the Docker run does. The file cache no longer
+// emits one (SkippedHistoryAction), so this is a guard over a workdir that was built before that or
+// by other means, and normally finds nothing. Done without a shell: this
 // is the entry point that has to work on a host with no distro toolchain -- it hunts for its own
 // executable and a CA bundle above for the same reason -- and each removal's result is checked so a
 // failure here is reported instead of leaving dist/history/ published under a misleading "done".

--- a/includes/SkippedHistoryAction.php
+++ b/includes/SkippedHistoryAction.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use MediaWiki\Actions\Action;
+
+/**
+ * The history action, registered so it can render nothing.
+ *
+ * rebuildFileCache.php caches two actions for every page it walks, unconditionally: ?action=view,
+ * which is the export, and ?action=history, which is not. Nothing ever asks the export for a local
+ * history page -- Hooks\Main::onGetLocalURL sends a history request to $wgWikvenHistoryUrl, and
+ * Hooks\Hider removes the link entirely when that is not configured -- and the tree it writes is
+ * deleted at the end of the pass. It was a database query, a formatted list and a full skin render
+ * per page, in every pass, on every bake, thrown away in full each time (#408).
+ *
+ * Core offers no way to ask for one action and not the other: the script has no --actions option,
+ * and turning history off with $wgActions['history'] = false is worse than useless, since
+ * Action::factory() then returns false and the script calls show() on it. So the action stays
+ * registered, as something that costs nothing to run: OutputPage::output() returns immediately
+ * once disabled, so the script's capture comes back empty, and HTMLFileCache::saveToFileCache()
+ * writes nothing for output under 512 bytes. No render, no file, no history/ tree.
+ *
+ * Only the bake loads this. A wiki serving the history action wants core's own HistoryAction.
+ */
+class SkippedHistoryAction extends Action {
+	/** @inheritDoc */
+	public function getName() {
+		return 'history';
+	}
+
+	/** @inheritDoc */
+	public function show() {
+		$this->getOutput()->disable();
+	}
+}

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -18,6 +18,13 @@ $wgFileCacheDirectory = $wikvenDist;
 $wgWikvenSourceDirectory = $wikvenSrc;
 $wgWikvenHtmlDirectory = $wikvenDist;
 
+// That file cache holds two actions per page, and the export is one of them. rebuildFileCache.php
+// renders ?action=history for every page as well, in every skin pass, into a tree the pass then
+// deletes -- and no exported page ever links to a local history page. Swap the action for one that
+// renders nothing rather than pay for it (see SkippedHistoryAction for why not $wgActions off).
+// Through $GLOBALS because the setting defaults to an empty array that is never written here.
+$GLOBALS['wgActions']['history'] = MediaWiki\Extension\Wikven\SkippedHistoryAction::class;
+
 // Per-page "last edited" dates and authors come from the source tree's git history. A bake usually
 // cannot reach it -- actions/bake mounts the source directory alone, without the .git beside it --
 // so the action dumps the log on the runner and mounts it here instead. Absent, the build asks git

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -374,9 +374,15 @@ class Build extends Maintenance {
 		// Rename has expanded translation pages into "<Page>/<lang>.html"; resolve MyLanguage links now.
 		$this->step(ResolveTranslationLinks::class, "$own/resolveTranslationLinks.php");
 
-		// RebuildFileCache emits a per-page history/ tree the static host won't serve; drop it.
+		// SkippedHistoryAction leaves RebuildFileCache nothing to write here, so this finds nothing
+		// on a normal bake; it stays as the guard for a pass over an output directory that already
+		// holds a history/ tree, which the static host would not serve.
 		$history = "$dir/history";
 		if (is_dir($history)) {
+			// Say so rather than tidy up in silence: on a bake that starts from an empty output
+			// directory, a tree here means the skipped action is no longer being asked for, and
+			// every page has paid for a render nobody reads.
+			$this->output("Wikven: removing a history/ tree the export does not want ($history)\n");
 			$this->removeDirectory($history);
 		}
 	}

--- a/tests/phpunit/unit/SkippedHistoryActionTest.php
+++ b/tests/phpunit/unit/SkippedHistoryActionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Context\IContextSource;
+use MediaWiki\Extension\Wikven\SkippedHistoryAction;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Page\Article;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\SkippedHistoryAction
+ */
+class SkippedHistoryActionTest extends MediaWikiUnitTestCase {
+	public function testItAnswersToHistory() {
+		$this->assertSame('history', $this->action($this->createMock(OutputPage::class))->getName());
+	}
+
+	public function testShowingItRendersNothing() {
+		// Disabling the output is the whole of the saving: rebuildFileCache.php calls
+		// OutputPage::output() on the same context right after, which then returns at once.
+		$output = $this->createMock(OutputPage::class);
+		$output->expects($this->once())->method('disable');
+
+		$this->action($output)->show();
+	}
+
+	private function action(OutputPage $output): SkippedHistoryAction {
+		$context = $this->createMock(IContextSource::class);
+		$context->method('getOutput')->willReturn($output);
+		return new SkippedHistoryAction($this->createMock(Article::class), $context);
+	}
+}


### PR DESCRIPTION
Closes #408. Third of the skin-phase stack; **based on #431** (which is based on #430).

## What this does

`rebuildFileCache.php` caches two actions for every page: `?action=view`, which is the export, and `?action=history`, which nothing ever asks for. `Hooks\Main::onGetLocalURL()` sends a history request to `$wgWikvenHistoryUrl`, `Hooks\Hider` removes the link entirely when that is not configured, and `renderSkin()` deletes the tree as its last act — so every bake paid a database query, a formatted list and a full skin render per page, in every skin pass, for output nobody reads. Like the rest of the skin phase it grows with pages × skins.

The issue asked for the size of the prize to be measured first, and the honest answer is that it can be read off the bake log without instrumenting anything: core prints `[view: 38801 bytes; history: 44831 bytes]` per page, so the history half is a page of comparable size, produced the same way — an `Action::show()` plus a full `OutputPage::output()` through the skin. It is not half the pass (the view render also reparses, the parser cache being `CACHE_NONE`), but it is a second skin render per page, and all of it wasted.

## Why an action rather than an option

Core offers no way to ask for one action and not the other: `rebuildFileCache.php` has `--start`, `--end`, `--overwrite` and `--all` and nothing else, and `$wgActions['history'] = false` is worse than useless — `Action::factory()` returns `false` and the script immediately calls `->show()` on it. The third route the issue lists, owning a copy of the script, is ~100 lines of core's loop, batching and cacheability checks to keep in sync.

So the action is replaced rather than disabled. `SkippedHistoryAction::show()` disables the `OutputPage`; `OutputPage::output()` returns immediately once disabled, so the script's `ob_get_clean()` comes back empty, and `HTMLFileCache::saveToFileCache()` returns early for anything under 512 bytes. No render, no file, no `history/` tree — and no divergence from core to maintain, since this is a config hook core already offers.

`$wgActions['history']` is set in `WikvenSettings.php`, which only ever loads inside the bake (`serve` is `php -S` over `dist/`).

## The safety net now speaks

`renderSkin()` still removes `$dir/history` if it finds one, for output built before this change, and now prints a line when it does. On a bake that starts from an empty output directory a tree there means the skipped action is no longer being asked for — a MediaWiki upgrade changing this out from under us would otherwise be invisible, since the tree gets deleted either way.

## Testing

`tests/phpunit/unit/SkippedHistoryActionTest.php` covers the action's name and that showing it disables the output. The smoke workflow on this PR bakes the docs site end to end, and its bake log is where the change shows: `[view: N bytes; history: 0 bytes]` for every page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzaVRrQe9B2xNeNzrsz5bS)_