### PR TITLE
test: assert two bakes of the same source are identical

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 node_modules
 vendor
 dist
+dist-again

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -148,6 +148,35 @@ jobs:
 
           echo "Smoke checks passed."
 
+      # Two bakes of the same source have to produce the same bytes, and until now nothing said so.
+      # Everything in the bake that exists for it -- the frozen clock and SOURCE_DATE_EPOCH, the
+      # frozen page_touched, the fifo job queue, the disabled NewPP limit report, the PNG timestamp
+      # chunks stripped on import, the installer's main page deleted -- was written after someone
+      # noticed the output moving between bakes, so the next regression was going to be found the
+      # same way (#411).
+      #
+      # Same checkout, same image, same runner, so the bake itself is the only thing that can
+      # differ. Baking from two separate clones is the stronger check and is not this one: it fails
+      # today because importWikitext.php stamps revisions with filemtime(), which a second clone
+      # changes (#406).
+      - name: Bake the docs site again and assert the two bakes are identical
+        run: |
+          set -euo pipefail
+          mkdir -p dist-again
+          docker run --rm \
+            -v "$(pwd)/docs:/workspace/src" \
+            -v "$(pwd)/dist-again:/workspace/dist" \
+            wikven
+          if diff -rq dist dist-again; then
+            echo "Two bakes of the same source are byte-identical."
+          else
+            echo "::error::two bakes of the same source are not identical (#411)"
+            # The file list above says which pages moved; this says what moved in them, and is cut
+            # off because a single differing byte in a shared header differs in every page.
+            diff -r dist dist-again | head -n 200 || true
+            exit 1
+          fi
+
       # Node.js is preinstalled on the runner; no setup-node (its caching trips
       # the cache-poisoning audit, and this job shares a build cache with the
       # image-publishing workflow).

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /vendor/
 /composer.lock
 /dist/
+/dist-again/
 /out/
 /test-results/
 /playwright-report/


### PR DESCRIPTION
Closes #411. Fourth of the skin-phase stack; **based on #432**. It goes here rather than at the end on purpose: the change that follows it (#407, running the passes together) is exactly the kind of change this check exists to guard, and this way it is already in place when that one lands.

## What this does

`smoke.yml` bakes `docs/` with the real image. This bakes it a second time into `dist-again/` and `diff -r`s the two. Same checkout, same image, same runner, so the bake itself is the only thing that can differ. It costs about the length of one bake (~90s).

A lot of the bake exists to make this true — the frozen clock and `SOURCE_DATE_EPOCH`, `page_touched` frozen to a fixed value, the job queue forced to `fifo` so page and revision ids do not shuffle, the NewPP limit report disabled, PNG timestamp chunks stripped on import, the installer's main page deleted — and every one of those was written after someone noticed the output moving. Nothing asserted the property they add up to.

On a failure the step prints `diff -rq` (which pages moved) and then the first 200 lines of the full diff (what moved in them), truncated because one differing byte in a shared header differs in every page.

## What it does not cover

The cross-checkout case, where the source files get new mtimes. That one fails today for the reason in #406 — `importWikitext.php` stamps revisions with `filemtime()` — so the stronger variant only makes sense once that is fixed.

## Testing

The check runs on this PR, which is the test: it has never been run before, so this run is the first evidence either way. If it fails, that is a real finding about the bake and not about the check — I'll report what the diff says here before doing anything else with it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzaVRrQe9B2xNeNzrsz5bS)_