### PR TITLE
fix: reparent the local URLs a page carries in its JavaScript config

### DIFF
--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -4,6 +4,9 @@ namespace MediaWiki\Extension\Wikven;
 
 /** Rewrites a page's output links: depth reparenting, and Special:MyLanguage resolution. */
 class RelativeUrl {
+	/** The assignment MediaWiki writes a page's JavaScript config into, opening brace included. */
+	private const CONFIG_ASSIGNMENT = 'RLCONF={';
+
 	/**
 	 * Add a "../" per level to every root-relative reference in a page moved $depth subdirectories down.
 	 *
@@ -11,7 +14,8 @@ class RelativeUrl {
 	 * non-main-skin canonical does). A subpage title such as "Manual/Config" caches to a flat file but
 	 * is exported into a real "Manual/" directory; its references then need a "../" per level so links
 	 * and files agree on a static host. Absolute, protocol-relative and data: URLs carry no leading
-	 * "./" and are left alone. Covers href/src/srcset attributes and CSS url().
+	 * "./" and are left alone. Covers href/src/srcset attributes, CSS url(), and the page's own
+	 * JavaScript config (see reparentConfigVars()).
 	 *
 	 * Each candidate is required to sit inside a real "<tag ...>" span (or, for url(), inside a
 	 * <style> block too): MediaWiki escapes preformatted text with htmlspecialchars(..., ENT_NOQUOTES),
@@ -87,7 +91,93 @@ class RelativeUrl {
 			PREG_OFFSET_CAPTURE
 		);
 
+		$html = self::reparentConfigVars($html, $rebase);
+
 		return self::rebasePrintFooter($html, $up);
+	}
+
+	/**
+	 * Rebase the root-relative URLs a page carries in its JavaScript config.
+	 *
+	 * Title::getLocalURL() answers "./Page.html" here (Hooks\Main::onGetLocalURL), and a URL that
+	 * shape means "from the output root" -- a claim only true of a page sitting at the root. In an
+	 * attribute the passes above correct it; the same string handed to the client through
+	 * mw.config rides in the page's RLCONF object, where nothing was correcting it. Core writes one
+	 * itself for a redirect (wgInternalRedirectTargetUrl), and any extension that asks a Title for
+	 * its URL and exports it as a config var writes another.
+	 *
+	 * Only that object is rewritten, and in it only strings that begin with "./" or "../". The rest
+	 * of the page cannot be treated this way, since a bare string carries no marker telling a URL
+	 * of ours from a path a page merely shows -- these very docs write "./Page.html" as text.
+	 * RLCONF is a span MediaWiki wrote, not the wikitext, and everything in it is data for scripts.
+	 *
+	 * What this cannot reach is a local URL baked into a ResourceLoader module's bundle: one file
+	 * serves every page at every depth, so there is no depth to correct it by, and an extension
+	 * shipping one has to anchor it itself (#425).
+	 *
+	 * @param string $html A rendered page.
+	 * @param callable(string):string $rebase Takes the matched "." or "..", returns its replacement.
+	 */
+	private static function reparentConfigVars(string $html, callable $rebase): string {
+		$offset = 0;
+		while (true) {
+			$start = strpos($html, self::CONFIG_ASSIGNMENT, $offset);
+			if ($start === false) {
+				break;
+			}
+			$open = $start + strlen(self::CONFIG_ASSIGNMENT) - 1;
+			$end = self::objectEnd($html, $open);
+			if ($end === null) {
+				break;
+			}
+			$rebased = preg_replace_callback(
+				'#"(\.\.?)/#',
+				static function (array $m) use ($rebase): string {
+					return '"' . $rebase($m[1]);
+				},
+				substr($html, $open, $end - $open)
+			);
+			$html = substr_replace($html, $rebased, $open, $end - $open);
+			$offset = $open + strlen($rebased);
+		}
+		return $html;
+	}
+
+	/**
+	 * The offset just past the "}" closing the object literal that opens at $open, or null if the
+	 * text runs out first.
+	 *
+	 * Braces inside a string are not counted, so a config value holding one -- a message with a
+	 * "{{PLURAL:}}" left in it, a regular expression -- does not end the object early, and the
+	 * object's own end is found however many nested objects it holds. The alternative, a non-greedy
+	 * match up to the next "};", stops at the first config value that contains that pair.
+	 */
+	private static function objectEnd(string $text, int $open): ?int {
+		$depth = 0;
+		$inString = false;
+		$length = strlen($text);
+		for ($i = $open; $i < $length; $i++) {
+			$char = $text[$i];
+			if ($inString) {
+				if ($char === '\\') {
+					$i++;
+				} elseif ($char === '"') {
+					$inString = false;
+				}
+				continue;
+			}
+			if ($char === '"') {
+				$inString = true;
+			} elseif ($char === '{') {
+				$depth++;
+			} elseif ($char === '}') {
+				$depth--;
+				if ($depth === 0) {
+					return $i + 1;
+				}
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/tests/phpunit/unit/RelativeUrlTest.php
+++ b/tests/phpunit/unit/RelativeUrlTest.php
@@ -153,6 +153,67 @@ class RelativeUrlTest extends MediaWikiUnitTestCase {
 		$this->assertSame($html, RelativeUrl::reparent($html, 1));
 	}
 
+	public function testAConfigVarHoldingALocalUrlIsRebased() {
+		$this->assertSame(
+			'<script>RLCONF={"wgPageName":"Deploying","wgInternalRedirectTargetUrl":"../Intro.html"};</script>',
+			RelativeUrl::reparent(
+				'<script>RLCONF={"wgPageName":"Deploying","wgInternalRedirectTargetUrl":"./Intro.html"};</script>',
+				1
+			)
+		);
+	}
+
+	public function testAConfigVarGainsOneLevelPerDepth() {
+		$this->assertSame(
+			'RLCONF={"u":"../../../Search.html"};',
+			RelativeUrl::reparent('RLCONF={"u":"../Search.html"};', 2)
+		);
+	}
+
+	/** Only a value that claims the output root moves; everything else names a fixed place. */
+	public function testConfigVarsThatAreNotRootRelativeAreLeftAlone() {
+		$html = 'RLCONF={"a":"https://example.org/x","b":"/w/index.php","c":"Intro.html","d":"see ./x"};';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
+	public function testTheWholeConfigObjectIsWalkedPastANestedOneAndABracedValue() {
+		$this->assertSame(
+			'RLCONF={"m":"a {{PLURAL:$1|b}} c","n":{"deep":"../x.html"},"u":"../y.html"};RLSTATE={"s":"ready"};',
+			RelativeUrl::reparent(
+				'RLCONF={"m":"a {{PLURAL:$1|b}} c","n":{"deep":"./x.html"},"u":"./y.html"};RLSTATE={"s":"ready"};',
+				1
+			)
+		);
+	}
+
+	/** A brace or a quote inside a string value must not be read as the object's own. */
+	public function testAValueHoldingABraceOrAnEscapedQuoteDoesNotEndTheObjectEarly() {
+		$this->assertSame(
+			'RLCONF={"re":"^\\{a\\}$","q":"say \\"}\\"","u":"../x.html"};',
+			RelativeUrl::reparent('RLCONF={"re":"^\\{a\\}$","q":"say \\"}\\"","u":"./x.html"};', 1)
+		);
+	}
+
+	/** The rewrite stops at the object's closing brace; what follows it is not config. */
+	public function testTextAfterTheConfigObjectIsLeftAlone() {
+		$this->assertSame(
+			'RLCONF={"u":"../x.html"};<pre>"./x.html"</pre>',
+			RelativeUrl::reparent('RLCONF={"u":"./x.html"};<pre>"./x.html"</pre>', 1)
+		);
+	}
+
+	/** A page documenting the export's link shape writes the same string as prose. */
+	public function testAQuotedRootRelativePathInTheBodyIsLeftAlone() {
+		$html = '<pre>Title::getLocalURL() answers "./Page.html"</pre>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 2));
+	}
+
+	/** An unterminated object is left as it is rather than rewritten to the end of the page. */
+	public function testAnUnclosedConfigObjectIsLeftAlone() {
+		$html = 'RLCONF={"u":"./x.html"';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
 	public function testMyLanguageResolvesToTheTranslationWhenItExists() {
 		$this->assertSame(
 			'href="./B/ko.html"',


### PR DESCRIPTION
Closes #444. Refs #425, which keeps the half this cannot reach.

This is option 2 of the three #425 lists, chosen by the maintainer: reparent JS config vars in the page, so a per-page value is corrected the way an `href` is. #425 raised two holes of the same shape together; #444 is the one that rides in the page, and #425 stays open for the one baked into a shared bundle.

> Stacked on #429. Base is `claude/resolve-open-bug-issues-y4afzw`; retarget to `main` once that merges. The diff of this PR alone is `includes/RelativeUrl.php` and its test.

## The hole

`Title::getLocalURL()` answers `./Page.html` (`Hooks\Main::onGetLocalURL`), and a URL that shape means "from the output root" — a claim only true of a page sitting at the root. `maintenance/rename.php` corrects it for every reference the skin renders into the page's own HTML (`href`, `src`, `srcset`, CSS `url()`, the printfooter).

The same string handed to the client through `mw.config` was not corrected. It rides in the page's `RLCONF` object, and from a page exported into a real directory — `Deploying/ko.html` — a value of `./Search.html` resolves to `Deploying/Search.html`, which does not exist. Core writes one of these itself for a redirect (`wgInternalRedirectTargetUrl`), and any extension that asks a `Title` for its URL and exports it as a config var writes another.

## What changed

`RelativeUrl::reparent()` gains a pass over the page's `RLCONF={…}` object, rebasing every string in it that begins with `./` or `../` by the page's depth.

Two things bound it deliberately:

- **Only that object.** The rest of the page cannot be treated this way: a bare string carries no marker telling a URL of ours from a path a page merely shows — wikven's own docs write `./Page.html` as prose. `RLCONF` is a span MediaWiki wrote, not the wikitext, and everything in it is data for scripts.
- **The object's real end.** Its closing brace is found by scanning with string literals skipped, rather than by a non-greedy match up to the next `};` — which would stop at the first config value containing that pair. A value holding a brace (`{{PLURAL:$1|…}}` left in a message, a regular expression) or an escaped quote no longer ends the object early.

## What this still does not reach — #425

A local URL baked into a ResourceLoader module's bundle. One file serves every page at every depth, so there is no depth to correct it by; an extension shipping one has to anchor it itself, which is what SifterSearch [#64](https://github.com/chaotic-ground/SifterSearch/pull/64) did for the results-page URL. The new docblock says so where the next reader will be looking.

## Testing

Seven cases added to `tests/phpunit/unit/RelativeUrlTest.php`: a config var rebased, one level gained per depth, absolute/host-root/bare/mid-string values left alone, a nested object and a braced value walked past, an escaped quote inside a value, text after the object left alone, a quoted root-relative path in the body left alone, and an unclosed object left as-is rather than rewritten to the end of the page.

`phpcs`, `mago format --check` and `mago lint` clean. The bake itself is not run here (no MediaWiki install in this session); CI's PHPUnit and smoke jobs cover it.
