### PR TITLE
perf: render the skins beside each other

### DIFF
--- a/includes/BuildConcurrency.php
+++ b/includes/BuildConcurrency.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * How many skin passes a bake runs beside each other.
+ *
+ * A pass is a MediaWiki boot rendering every page, so the useful number is one per processor: more
+ * than that only has them wait for each other, with a boot's worth of memory each. The processors
+ * that count are the ones this process may use, which under a CPU limit are fewer than the ones
+ * /proc/cpuinfo lists -- a bake usually runs in a container on a much larger host.
+ */
+class BuildConcurrency {
+	/**
+	 * @param int $passes How many passes there are to run.
+	 * @param string $configured WIKVEN_BUILD_JOBS, or "" when it is not set. A number here is the
+	 *   answer, whatever the machine looks like.
+	 * @param string $cpuinfo The contents of /proc/cpuinfo, or "" when it cannot be read.
+	 * @param string $cpuMax The contents of the cgroup's cpu.max, or "" when there is none.
+	 */
+	public static function limit(int $passes, string $configured, string $cpuinfo, string $cpuMax): int {
+		if (preg_match('/^[1-9]\d*$/', trim($configured))) {
+			return min((int)trim($configured), max($passes, 1));
+		}
+		return min(self::processors($cpuinfo, $cpuMax), max($passes, 1));
+	}
+
+	/** The processors this process may use, by the two accounts of it a container has. */
+	public static function processors(string $cpuinfo, string $cpuMax): int {
+		$listed = max(1, preg_match_all('/^processor\s*:/m', $cpuinfo));
+		$allowed = self::cpuLimit($cpuMax);
+		return $allowed > 0 ? min($listed, $allowed) : $listed;
+	}
+
+	/**
+	 * The CPU allowance of a cgroup v2 file, in whole processors, or 0 when it grants no limit.
+	 *
+	 * The file reads "<quota> <period>" in microseconds, or "max <period>" for a container that
+	 * was given no limit at all. Half a processor is rounded up rather than down to zero: it is
+	 * still a processor's worth of passes, run slowly.
+	 */
+	private static function cpuLimit(string $cpuMax): int {
+		$fields = preg_split('/\s+/', trim($cpuMax));
+		if (count($fields) !== 2 || !ctype_digit($fields[0]) || !ctype_digit($fields[1]) || (int)$fields[1] === 0) {
+			return 0;
+		}
+		return max(1, (int)ceil((int)$fields[0] / (int)$fields[1]));
+	}
+}

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -235,6 +235,13 @@ if ($wikvenBuildSkin !== false && in_array($wikvenBuildSkin, $wgWikvenSkins, tru
 	// chrome would point at a Special: page the export does not have. Citizen's is the visible
 	// one: it moves the entry out of the toolbox (which Hider empties) into the sidebar.
 	$wgEnableUploads = false;
+	// The passes run beside each other, and SQLite takes one writer at a time -- a pass still
+	// writes to the object cache, which is a table. build.php hands each one a copy of the
+	// database to work on and names its directory here; nothing reads the copies afterwards.
+	$wikvenPassDatabase = getenv('WIKVEN_BUILD_DB_DIR');
+	if (is_string($wikvenPassDatabase) && is_dir($wikvenPassDatabase)) {
+		$wgSQLiteDataDir = $wikvenPassDatabase;
+	}
 	if ($wikvenBuildSkin !== $wgWikvenMainSkin) {
 		$wgWikvenHtmlDirectory = "$wikvenDist/$wikvenBuildSkin";
 		$wgFileCacheDirectory = $wgWikvenHtmlDirectory;

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -31,6 +31,9 @@ class Build extends Maintenance {
 	/** Template the generated software list is written to, so an About page can place it itself. */
 	private const SOFTWARE_TEMPLATE = 'Wikven software';
 
+	/** Names the directory a skin pass's own copy of the database goes in, beside the original. */
+	private const PASS_DATABASE_PREFIX = 'wikven-pass-';
+
 	public function __construct() {
 		parent::__construct();
 		$this->addDescription('Run the full wikven static-site build in a single process.');
@@ -71,9 +74,7 @@ class Build extends Maintenance {
 		if (!$skins) {
 			$skins = [$GLOBALS['wgDefaultSkin']];
 		}
-		foreach ($skins as $skin) {
-			$this->renderSkinPass($skin);
-		}
+		$this->renderSkinPasses(array_values($skins));
 	}
 
 	/**
@@ -309,8 +310,69 @@ class Build extends Maintenance {
 		$linkCache->clear();
 	}
 
-	/** Render one skin in a fresh boot by re-invoking this script with WIKVEN_BUILD_SKIN set. */
-	private function renderSkinPass(string $skin): void {
+	/**
+	 * Render every enabled skin, several passes at a time.
+	 *
+	 * The passes are independent by construction: everything they read is in the database before
+	 * the first one starts, each writes into an output directory of its own, and each is a
+	 * separate process with its own boot. So the skin phase is the half of the bake that
+	 * parallelizes, and the half that grows -- the populate phase above is O(pages) and stays
+	 * serial, while this is O(pages x skins) and gains a pass every time a skin is added (#407).
+	 *
+	 * What the passes still share is the database, and a pass is not quite a reader of it: the
+	 * object cache is a table ($wgMainCacheType = CACHE_DB), and SQLite takes one writer at a
+	 * time. Each therefore gets a copy of the database file to work on, which also keeps a pass
+	 * from reading what another one cached -- so a pass renders from the same state whether it
+	 * runs first, last or beside the others, which is what keeps the output reproducible (#411).
+	 *
+	 * @param string[] $skins
+	 */
+	private function renderSkinPasses(array $skins): void {
+		$command = $this->skinPassCommand();
+		$limit = $this->passLimit(count($skins));
+		$databases = $this->copyDatabasePerPass($skins);
+
+		$this->output('Rendering ' . count($skins) . ' skin(s), up to ' . $limit . " at a time\n");
+
+		$queued = $skins;
+		$running = [];
+		$failed = [];
+		while ($queued || $running) {
+			while ($queued && count($running) < $limit) {
+				$skin = array_shift($queued);
+				$running[$skin] = $this->startSkinPass($command, $skin, $databases[$skin] ?? '');
+			}
+
+			$this->waitForPassOutput($running);
+			foreach (array_keys($running) as $skin) {
+				$this->readPass($running[$skin]);
+				$exit = $this->reapPass($running[$skin]);
+				if ($exit === null) {
+					continue;
+				}
+				// Whole and in one piece, now that the pass is done: three renders writing to this
+				// process's own stdout as they go would interleave into something no one could
+				// attribute a failure from, and the log is how a bake is debugged.
+				$this->reportPass($skin, $running[$skin], $exit);
+				if ($exit !== 0) {
+					$failed[] = "$skin (exit $exit)";
+				}
+				unset($running[$skin]);
+			}
+		}
+
+		$this->removeDatabaseCopies($databases);
+		if ($failed) {
+			$this->fatalError('Wikven: build failed for skin ' . implode(', ', $failed));
+		}
+	}
+
+	/**
+	 * The argv that re-invokes this script for one skin, resolved once for every pass.
+	 *
+	 * @return string[]
+	 */
+	private function skinPassCommand(): array {
 		$self = PHP_BINARY;
 		$prefix = [$self];
 		// Embedded FrankenPHP leaves PHP_BINARY empty; re-run the binary itself as "<self> php-cli".
@@ -321,30 +383,199 @@ class Build extends Maintenance {
 		if ($self === '' || !is_executable($self)) {
 			$this->fatalError('Wikven: cannot locate the PHP executable to render skins');
 		}
+		return array_merge($prefix, ['maintenance/run.php', __FILE__]);
+	}
 
-		$command = array_merge($prefix, ['maintenance/run.php', __FILE__]);
-
-		// The skin and the working directory are passed as arguments, scoped to the child alone, so
-		// this process's own environment and cwd stay untouched while a skin renders. run.php resolves
-		// relative to the install root, which the binary's php-cli requires, hence $GLOBALS['IP'] as
-		// the child's cwd. An array argv also means the arguments never pass through a shell to be
-		// quoted for.
-		$descriptors = [0 => STDIN, 1 => STDOUT, 2 => STDERR];
+	/**
+	 * Start one skin's pass in a fresh boot, with its output on pipes this process reads.
+	 *
+	 * @param string[] $command
+	 * @return array{process:resource,pipes:array<int,?resource>,output:array<int,string>}
+	 */
+	private function startSkinPass(array $command, string $skin, string $databaseDirectory): array {
+		// The skin, the database and the working directory are passed to the child alone, so this
+		// process's own environment and cwd stay untouched while a skin renders. run.php resolves
+		// relative to the install root, which the binary's php-cli requires, hence $GLOBALS['IP']
+		// as the child's cwd. An array argv also means the arguments never pass through a shell to
+		// be quoted for. Both variables are set even when empty, so that a pass never inherits a
+		// value another run left in this process's environment.
+		$environment = ['WIKVEN_BUILD_SKIN' => $skin, 'WIKVEN_BUILD_DB_DIR' => $databaseDirectory] + getenv();
+		$descriptors = [0 => STDIN, 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
 		$pipes = [];
-		$process = proc_open(
-			$command,
-			$descriptors,
-			$pipes,
-			$GLOBALS['IP'],
-			['WIKVEN_BUILD_SKIN' => $skin] + getenv()
-		);
+		$process = proc_open($command, $descriptors, $pipes, $GLOBALS['IP'], $environment);
 		if ($process === false) {
 			$this->fatalError("Wikven: could not start the build for skin '$skin'");
 		}
-		$exit = proc_close($process);
+		// Non-blocking, so reading a quiet pass never holds up a talkative one.
+		stream_set_blocking($pipes[1], false);
+		stream_set_blocking($pipes[2], false);
+		return ['process' => $process, 'pipes' => $pipes, 'output' => [1 => '', 2 => '']];
+	}
 
-		if ($exit !== 0) {
-			$this->fatalError("Wikven: build failed for skin '$skin' (exit $exit)");
+	/**
+	 * Block until one of the running passes has something to say, or briefly if none of them has.
+	 *
+	 * @param array[] $running
+	 */
+	private function waitForPassOutput(array $running): void {
+		$read = [];
+		foreach ($running as $pass) {
+			foreach ($pass['pipes'] as $pipe) {
+				// A pipe this process has closed is left as null, and there is nothing to wait for.
+				if ($pipe !== null) {
+					$read[] = $pipe;
+				}
+			}
+		}
+		if (!$read) {
+			// Every pass has closed its pipes and none has been reaped yet; that gap is short.
+			usleep(50_000);
+			return;
+		}
+		$write = [];
+		$except = [];
+		// The timeout is what bounds the wait, since a pass that exits without a last word leaves
+		// nothing to wake this up. A closed pipe reads as ready, so an ending pass is seen at once.
+		stream_select($read, $write, $except, 0, 200_000);
+	}
+
+	/**
+	 * Take whatever a pass has written so far, so its pipe buffer never fills and blocks it.
+	 *
+	 * @param array &$pass
+	 */
+	private function readPass(array &$pass): void {
+		foreach ($pass['pipes'] as $descriptor => $pipe) {
+			if ($pipe === null) {
+				continue;
+			}
+			$chunk = fread($pipe, 65_536);
+			while ($chunk !== false && $chunk !== '') {
+				$pass['output'][$descriptor] .= $chunk;
+				$chunk = fread($pipe, 65_536);
+			}
+			// Dropped once the pass has closed its end, so it stops waking the select above.
+			if (feof($pipe)) {
+				fclose($pipe);
+				$pass['pipes'][$descriptor] = null;
+			}
+		}
+	}
+
+	/**
+	 * Close a finished pass and answer how it exited, or null while it is still running.
+	 *
+	 * @param array &$pass
+	 */
+	private function reapPass(array &$pass): ?int {
+		$status = proc_get_status($pass['process']);
+		if ($status['running']) {
+			return null;
+		}
+		// Anything the pass wrote before exiting is still in the pipes; a pipe outlives its writer.
+		$this->readPass($pass);
+		foreach ($pass['pipes'] as $descriptor => $pipe) {
+			if ($pipe !== null) {
+				fclose($pipe);
+				$pass['pipes'][$descriptor] = null;
+			}
+		}
+		// The status above already reaped the child, so proc_close's own answer is not the exit
+		// code any more; it is called to release the handle.
+		proc_close($pass['process']);
+		return (int)$status['exitcode'];
+	}
+
+	/**
+	 * Print one pass's output under a heading naming it, once the pass is over.
+	 *
+	 * @param string $skin
+	 * @param array $pass
+	 * @param int $exit
+	 */
+	private function reportPass(string $skin, array $pass, int $exit): void {
+		$this->output("--- $skin pass" . ( $exit === 0 ? '' : " failed (exit $exit)" ) . " ---\n");
+		$this->output($pass['output'][1]);
+		if ($pass['output'][2] !== '') {
+			$this->error(rtrim($pass['output'][2], "\n"));
+		}
+	}
+
+	/** How many passes to run at once; BuildConcurrency reads what the answer is made of. */
+	private function passLimit(int $passes): int {
+		return BuildConcurrency::limit(
+			$passes,
+			(string)getenv('WIKVEN_BUILD_JOBS'),
+			$this->readFile('/proc/cpuinfo'),
+			$this->readFile('/sys/fs/cgroup/cpu.max')
+		);
+	}
+
+	/** A file that describes the machine, or "" where this one does not have it. */
+	private function readFile(string $path): string {
+		return is_readable($path) ? (string)file_get_contents($path) : '';
+	}
+
+	/**
+	 * Give each pass a copy of the database to render from.
+	 *
+	 * A pass reads the content, but it still writes: the object cache is a table of this database
+	 * ($wgMainCacheType = CACHE_DB, which is there so the Commons thumbnail lookups a bake makes
+	 * are made once). SQLite takes one writer at a time, so passes sharing the file would be
+	 * serialized by it at best and fail with SQLITE_BUSY at worst. The file is small and the
+	 * content is final by now, so a copy each is the cheap way out -- and the copies are taken
+	 * after the populate phase, so each pass inherits its lookups rather than repeating them.
+	 *
+	 * A server database has no such limit and is left alone, as is a single-pass bake.
+	 *
+	 * @param string[] $skins
+	 * @return array<string,string> Skin to the data directory holding its copy; empty when the
+	 *   passes share the database.
+	 */
+	private function copyDatabasePerPass(array $skins): array {
+		$directory = rtrim((string)( $GLOBALS['wgSQLiteDataDir'] ?? '' ), '/');
+		if (count($skins) < 2 || ( $GLOBALS['wgDBtype'] ?? '' ) !== 'sqlite' || !is_dir($directory)) {
+			return [];
+		}
+
+		// Everything this process wrote has to be in the file before it is copied.
+		$this->getServiceContainer()->getDBLoadBalancerFactory()->commitPrimaryChanges(__METHOD__);
+		$databases = glob("$directory/*.sqlite");
+		if (!$databases) {
+			// Nothing to copy is nothing to isolate; leave the passes on the database as it is.
+			return [];
+		}
+		// The write-ahead log alongside a database holds commits the database file does not have
+		// yet; the shared-memory index beside it is rebuilt from that log and is not copied.
+		$logs = glob("$directory/*.sqlite-wal");
+		$files = array_merge($databases, $logs === false ? [] : $logs);
+
+		$copies = [];
+		foreach ($skins as $skin) {
+			$destination = "$directory/" . self::PASS_DATABASE_PREFIX . $skin;
+			if (!wfMkdirParents($destination)) {
+				$this->fatalError("Wikven: could not create the database directory $destination");
+			}
+			foreach ($files as $file) {
+				if (!copy($file, $destination . '/' . basename($file))) {
+					$this->fatalError("Wikven: could not copy $file for the '$skin' pass");
+				}
+			}
+			$copies[$skin] = $destination;
+		}
+		return $copies;
+	}
+
+	/**
+	 * Drop the per-pass databases, which say nothing about the site once its pages are rendered.
+	 *
+	 * @param array<string,string> $copies
+	 */
+	private function removeDatabaseCopies(array $copies): void {
+		foreach ($copies as $directory) {
+			if (is_dir($directory)) {
+				$this->removeDirectory($directory);
+			}
 		}
 	}
 

--- a/tests/phpunit/unit/BuildConcurrencyTest.php
+++ b/tests/phpunit/unit/BuildConcurrencyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\BuildConcurrency;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\BuildConcurrency
+ */
+class BuildConcurrencyTest extends MediaWikiUnitTestCase {
+	/** Four processors, as a runner has. */
+	private const CPUINFO = "processor\t: 0\nvendor_id\t: X\n\nprocessor\t: 1\n\nprocessor\t: 2\n\nprocessor\t: 3\n";
+
+	public function testItRunsOnePassPerProcessor() {
+		$this->assertSame(4, BuildConcurrency::limit(6, '', self::CPUINFO, ''));
+	}
+
+	public function testItNeverRunsMorePassesThanThereAre() {
+		$this->assertSame(3, BuildConcurrency::limit(3, '', self::CPUINFO, ''));
+		$this->assertSame(3, BuildConcurrency::limit(3, '8', self::CPUINFO, ''));
+	}
+
+	public function testAConfiguredNumberWins() {
+		$this->assertSame(1, BuildConcurrency::limit(6, '1', self::CPUINFO, ''));
+		$this->assertSame(6, BuildConcurrency::limit(6, ' 8 ', self::CPUINFO, ''));
+	}
+
+	/**
+	 * @dataProvider provideNonsense
+	 */
+	public function testNonsenseIsNotANumberOfPasses(string $configured) {
+		$this->assertSame(4, BuildConcurrency::limit(6, $configured, self::CPUINFO, ''));
+	}
+
+	public static function provideNonsense() {
+		return [
+			'unset' => [''],
+			'zero' => ['0'],
+			'negative' => ['-2'],
+			'a word' => ['many'],
+			'a fraction' => ['2.5']
+		];
+	}
+
+	public function testACpuLimitCountsForMoreThanTheHostsProcessors() {
+		// 200ms of every 100ms period: two processors, on a host that has four.
+		$this->assertSame(2, BuildConcurrency::processors(self::CPUINFO, "200000 100000\n"));
+	}
+
+	public function testAPartialProcessorIsStillAPass() {
+		$this->assertSame(1, BuildConcurrency::processors(self::CPUINFO, "50000 100000\n"));
+	}
+
+	public function testAnUnlimitedCgroupLeavesTheCountAlone() {
+		$this->assertSame(4, BuildConcurrency::processors(self::CPUINFO, "max 100000\n"));
+	}
+
+	public function testALimitAboveTheHostsProcessorsDoesNotRaiseTheCount() {
+		$this->assertSame(4, BuildConcurrency::processors(self::CPUINFO, "800000 100000\n"));
+	}
+
+	/**
+	 * @dataProvider provideUnreadableMachines
+	 */
+	public function testAMachineThatSaysNothingRunsOnePassAtATime(string $cpuinfo, string $cpuMax) {
+		$this->assertSame(1, BuildConcurrency::processors($cpuinfo, $cpuMax));
+	}
+
+	public static function provideUnreadableMachines() {
+		return [
+			'no cpuinfo' => ['', ''],
+			'no cpuinfo, a limit' => ['', "400000 100000\n"],
+			'cpuinfo without processors' => ["vendor_id\t: X\n", '']
+		];
+	}
+}


### PR DESCRIPTION
Closes #407. Last of the skin-phase stack; **based on #433**, which is based on #432 → #431 → #430. The three before it are what make this one safe to do, and the one before it is what checks it.

## What this does

`Build::execute()` walked the skins one by one and `renderSkinPass()` blocked on each child. Now every pass is started and waited on together, up to a limit.

On the docs bake that turns 22.6s of serial passes into about the length of the slowest, ~16% of an 88.5s bake — modest, and worth saying plainly: the docs site is small and most of its bake is the populate phase, which is one pass over the content and stays serial. The reason to do it is how the halves scale. Populate is O(pages); the skin phase is O(pages × skins), and it is the half that grows every time someone adds a skin to `skins:`.

## The four things it needed

**Concurrency.** `WIKVEN_BUILD_JOBS` if it names a number, else one pass per processor, never more than there are skins. "One per processor" is the container's allowance, not the host's: `/proc/cpuinfo` reports the host's processors, so the cgroup v2 `cpu.max` quota is read too and the smaller wins. That decision is `includes/BuildConcurrency.php`, with unit tests over the parsing edges (`max 100000`, a fractional quota, an unreadable machine).

**Output.** Each pass's stdout and stderr go to pipes this process drains as they fill, and are printed whole under a heading when the pass ends. Interleaved output from three renders would make a failure impossible to attribute, and the log is how bakes are debugged. A failing pass no longer stops the others either: all of them run and report, then the build fails naming each that did.

**Confinement.** Done in #430 — `ResolveTranslationLinks` no longer walks out of its own output into another skin's.

**SQLite.** A pass is not a pure reader even after #431 moved the `page_touched` freeze out: the object cache is a table (`$wgMainCacheType = CACHE_DB`, which exists so a bake's Commons thumbnail lookups are made once). SQLite takes one writer at a time, so passes sharing the file would serialize on it at best and hit `SQLITE_BUSY` at worst. Each pass therefore gets a copy of the database file, made after the populate phase and handed over as `WIKVEN_BUILD_DB_DIR`, which `WikvenSettings.php` turns into that pass's `$wgSQLiteDataDir`. The copies are taken after populate, so each pass inherits the cached Commons lookups rather than repeating them, and no pass can read what another wrote afterwards — a pass renders from the same state whether it runs first, last or beside the others. A server database has no such limit and is left alone, as is a single-skin bake.

## Reproducibility

This is exactly the change the check added in #433 exists for, which is why that one goes first in the stack: the smoke job on this PR bakes the docs site twice and `diff -r`s the two, with the passes running concurrently in both.

Two shared writable things are worth naming, neither of them new here: the localisation cache under `$wgCacheDirectory`, which the populate phase has already built and which `Cdb\Writer` replaces by rename rather than in place, and thumbnails under `$wgUploadDirectory`, which the job queue has already generated. Both are read, not written, by a pass in a normal bake.

What does change run to run is the log: passes are reported in the order they finish. The bytes in `dist/` are not.

## Testing

`tests/phpunit/unit/BuildConcurrencyTest.php` for the limit; the smoke workflow for the bake, twice, in a browser afterwards. Not covered by an automated check: a machine without `/proc/cpuinfo`, and the `WIKVEN_BUILD_JOBS` override, which are unit-tested at the value level only.

`docs/Development.wikitext` describes the pipeline but not the per-skin passes, so nothing there went stale; documenting the passes (and `WIKVEN_BUILD_JOBS` with them) wants its own change, since editing that page adds translation units.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzaVRrQe9B2xNeNzrsz5bS)_