### PR TITLE
fix: give each skin copy its own search index, so results stay in the copy

### DIFF
--- a/docs/Searching.wikitext
+++ b/docs/Searching.wikitext
@@ -55,6 +55,17 @@ all matches, create an (otherwise empty) content page and name it in
 there and runs the query from the URL, and the search box's "search for pages
 containing…" action and its Enter key go to that page. This site uses a page
 titled <code>Search</code>.
+
+<!--T:11-->
+== Search and the extra skins ==
+
+<!--T:12-->
+A site that enables more than one skin publishes its pages once per skin (see
+[[<tvar name="1">Special:MyLanguage/Skins</tvar>|Skins]]), and each of those copies gets its own
+copy of the search index inside it. A result then leads to the copy the reader searched from,
+rather than taking them back to the default skin. The index is built once and copied, so the extra
+cost is disk in the output, not build time; the bundle path you configure is the default skin's,
+and the others are derived from it.
 </translate>
 
 {{prevnext|JavaScript|Translating}}

--- a/includes/Search.php
+++ b/includes/Search.php
@@ -16,6 +16,35 @@ class Search {
 	 */
 	public const INDEX_JOB = 'sifterSearchBuildIndex';
 
+	/**
+	 * Whether the bundle path is a path from this site's own root.
+	 *
+	 * That is the only shape a per-copy bundle can be derived from, and the same test
+	 * SifterSearch's ClientConfig::anchored() makes for the same reason: a bundle served from
+	 * another host says nothing about where this site's root is. Wikven cannot copy such a bundle
+	 * into a skin's directory either, since it is not wikven that publishes it.
+	 */
+	public static function isBundlePathRootAnchored(string $bundlePath): bool {
+		return str_starts_with($bundlePath, '/') && !str_starts_with($bundlePath, '//');
+	}
+
+	/**
+	 * The same bundle path with a skin's directory in front of the bundle, which is where that
+	 * skin's copy of the index is published.
+	 *
+	 * The path names the bundle directory itself ("/wikven/pagefind/"), and its parent is the root
+	 * the client resolves every result against, so putting the skin's directory between the two
+	 * ("/wikven/citizen/pagefind/") makes the skin's own copy that root -- which is the whole of
+	 * the fix, the bundle bytes being identical either way.
+	 */
+	public static function bundlePathUnder(string $bundlePath, string $skin): string {
+		$path = rtrim($bundlePath, '/');
+		$cut = strrpos($path, '/');
+		$root = $cut === false ? '' : substr($path, 0, $cut + 1);
+		$bundle = $cut === false ? $path : substr($path, $cut + 1);
+		return "$root$skin/$bundle/";
+	}
+
 	public static function isActive(): bool {
 		return (
 			ExtensionRegistry::getInstance()->isLoaded('SifterSearch')

--- a/includes/Search.php
+++ b/includes/Search.php
@@ -2,8 +2,12 @@
 
 namespace MediaWiki\Extension\Wikven;
 
+use FilesystemIterator;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Title\Title;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Wikimedia\AtEase\AtEase;
 
 /** Whether SifterSearch provides a working static search box: loaded and indexing into a bundle. */
 class Search {
@@ -17,32 +21,118 @@ class Search {
 	public const INDEX_JOB = 'sifterSearchBuildIndex';
 
 	/**
-	 * Whether the bundle path is a path from this site's own root.
+	 * Where a skin pass publishes and loads its own copy of the search index, or null where it
+	 * reads the one that is already there.
 	 *
-	 * That is the only shape a per-copy bundle can be derived from, and the same test
-	 * SifterSearch's ClientConfig::anchored() makes for the same reason: a bundle served from
-	 * another host says nothing about where this site's root is. Wikven cannot copy such a bundle
-	 * into a skin's directory either, since it is not wikven that publishes it.
+	 * Pagefind reports a result's URL relative to the crawl root and the client resolves it against
+	 * the directory the bundle sits in, so a copy of the site that loads the root's bundle sends
+	 * every result out of the copy (#399). The answer is the same index, read from inside the copy.
+	 *
+	 * @param string $skin The skin this pass renders.
+	 * @param string $mainSkin The skin whose output is the export root.
+	 * @param string $bundlePath The site's own bundle path, as configured.
+	 * @param string $indexSource The directory the index was built into.
+	 * @param string $htmlDir This pass's output directory.
+	 * @return ?array{path:string,directory:string} The bundle path this pass's pages load from, and
+	 *   the directory the index is to be copied into.
 	 */
-	public static function isBundlePathRootAnchored(string $bundlePath): bool {
-		return str_starts_with($bundlePath, '/') && !str_starts_with($bundlePath, '//');
+	public static function bundleCopyFor(
+		string $skin,
+		string $mainSkin,
+		string $bundlePath,
+		string $indexSource,
+		string $htmlDir
+	): ?array {
+		// The main skin's output is the export root, so its pages already resolve results against
+		// the directory the index is in. Nothing to copy, and nowhere else to put it.
+		if ($skin === '' || $skin === $mainSkin || $indexSource === '' || $htmlDir === '') {
+			return null;
+		}
+		// A bundle served from another host says nothing about where this site's root is, and is
+		// not wikven's to copy -- the test SifterSearch's ClientConfig::anchored() makes, for the
+		// same reason.
+		if (!str_starts_with($bundlePath, '/') || str_starts_with($bundlePath, '//')) {
+			return null;
+		}
+		return [
+			'path' => self::bundlePathUnder($bundlePath, $skin),
+			'directory' => rtrim($htmlDir, '/') . '/' . basename(rtrim($indexSource, '/'))
+		];
 	}
 
 	/**
-	 * The same bundle path with a skin's directory in front of the bundle, which is where that
-	 * skin's copy of the index is published.
+	 * The same bundle path with a skin's directory in front of the bundle.
 	 *
 	 * The path names the bundle directory itself ("/wikven/pagefind/"), and its parent is the root
 	 * the client resolves every result against, so putting the skin's directory between the two
 	 * ("/wikven/citizen/pagefind/") makes the skin's own copy that root -- which is the whole of
 	 * the fix, the bundle bytes being identical either way.
 	 */
-	public static function bundlePathUnder(string $bundlePath, string $skin): string {
+	private static function bundlePathUnder(string $bundlePath, string $skin): string {
 		$path = rtrim($bundlePath, '/');
 		$cut = strrpos($path, '/');
 		$root = $cut === false ? '' : substr($path, 0, $cut + 1);
 		$bundle = $cut === false ? $path : substr($path, $cut + 1);
 		return "$root$skin/$bundle/";
+	}
+
+	/**
+	 * Put a copy of the built index at $destination, for the pages that sit beside it.
+	 *
+	 * The index is built once, over content that is the same in every copy, so this copies rather
+	 * than rebuilds: a Pagefind pass per skin would cost the whole site again for bytes that come
+	 * out identical. A copy is also the same bytes every bake, which a rebuild need not be.
+	 *
+	 * Written with plain filesystem calls rather than wfMkdirParents(), so the one part of this
+	 * that can fail on a real tree is reachable from a unit test.
+	 *
+	 * @return ?string What could not be copied, ready to report, or null when the copy is in place
+	 *   or there was nothing to do.
+	 */
+	public static function publishBundle(string $source, string $destination): ?string {
+		$source = rtrim($source, '/');
+		$destination = rtrim($destination, '/');
+		if ($source === '' || $destination === '' || $source === $destination || !is_dir($source)) {
+			return null;
+		}
+		if (!self::makeDirectory($destination)) {
+			return "Wikven: could not create directory $destination";
+		}
+
+		$entries = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($source, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::SELF_FIRST
+		);
+		foreach ($entries as $entry) {
+			$target = $destination . '/' . substr($entry->getPathname(), strlen($source) + 1);
+			if ($entry->isDir()) {
+				if (!self::makeDirectory($target)) {
+					return "Wikven: could not create directory $target";
+				}
+			} elseif (!copy($entry->getPathname(), $target)) {
+				return "Wikven: could not copy {$entry->getPathname()} to $target";
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * mkdir -p, answering true for a directory that is already there or that lost a race for it.
+	 *
+	 * wfMkdirParents() is this, and is not used: it reports its own failure with trigger_error(),
+	 * which a test harness that turns warnings into errors raises before the caller here can say
+	 * which copy could not be published. PHP's own warning is suppressed for the same reason, and
+	 * the existence check is repeated after a failed mkdir(), as core does, so a pass that lost a
+	 * race for the directory still sees one.
+	 */
+	private static function makeDirectory(string $path): bool {
+		if (is_dir($path)) {
+			return true;
+		}
+		AtEase::suppressWarnings();
+		$made = mkdir($path, 0777, true);
+		AtEase::restoreWarnings();
+		return $made || is_dir($path);
 	}
 
 	public static function isActive(): bool {

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -288,5 +288,35 @@ if (
 	$GLOBALS['wgSifterSearchOutputDir'] = "$wikvenDist/pagefind";
 }
 
+// Where the built index is, whichever pass is asking. It is built once, by the job the
+// orchestrator drains before any skin pass runs, and so always lands in the main skin's output.
+$wgWikvenSearchIndexSource = (string)( $GLOBALS['wgSifterSearchOutputDir'] ?? '' );
+
+// Each skin copy searches within itself. Pagefind reports a result's URL relative to the crawl
+// root, and the client resolves it against the directory the bundle sits in -- so a copy loading
+// the root's bundle sends every result out of the copy and back to the root's pages (#399). The
+// index describes one site and the copies hold the same pages, so what a copy needs is that same
+// bundle inside its own directory: Build::renderSkin() puts it there, and pointing the client at
+// it makes the copy's own directory the root each result resolves against.
+//
+// SifterSearch's own default is used where the site named no path, since its extension.json has
+// not been read at this point -- LocalSettings.php runs before the registry materializes it. For
+// the same reason Search is loaded by hand here, as SiteConfig is above.
+require_once "$IP/extensions/Wikven/includes/Search.php";
+$wikvenBundlePath = (string)( $GLOBALS['wgSifterSearchBundlePath'] ?? '/pagefind/' );
+if (
+	$wikvenBuildSkin !== false
+	&& in_array($wikvenBuildSkin, $wgWikvenSkins, true)
+	&& $wikvenBuildSkin !== $wgWikvenMainSkin
+	&& $wgWikvenSearchIndexSource !== ''
+	&& MediaWiki\Extension\Wikven\Search::isBundlePathRootAnchored($wikvenBundlePath)
+) {
+	$GLOBALS['wgSifterSearchBundlePath'] = MediaWiki\Extension\Wikven\Search::bundlePathUnder(
+		$wikvenBundlePath,
+		$wikvenBuildSkin
+	);
+	$GLOBALS['wgSifterSearchOutputDir'] = $wgWikvenHtmlDirectory . '/' . basename($wgWikvenSearchIndexSource);
+}
+
 // WikvenLogos ($wgWikvenLogos) mirrors $wgLogos but each src is a source-dir file name, resolved
 // to its upload URL once the service container exists; see Hooks\Main::onSetupAfterCache().

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -303,19 +303,19 @@ $wgWikvenSearchIndexSource = (string)( $GLOBALS['wgSifterSearchOutputDir'] ?? ''
 // not been read at this point -- LocalSettings.php runs before the registry materializes it. For
 // the same reason Search is loaded by hand here, as SiteConfig is above.
 require_once "$IP/extensions/Wikven/includes/Search.php";
-$wikvenBundlePath = (string)( $GLOBALS['wgSifterSearchBundlePath'] ?? '/pagefind/' );
-if (
-	$wikvenBuildSkin !== false
-	&& in_array($wikvenBuildSkin, $wgWikvenSkins, true)
-	&& $wikvenBuildSkin !== $wgWikvenMainSkin
-	&& $wgWikvenSearchIndexSource !== ''
-	&& MediaWiki\Extension\Wikven\Search::isBundlePathRootAnchored($wikvenBundlePath)
-) {
-	$GLOBALS['wgSifterSearchBundlePath'] = MediaWiki\Extension\Wikven\Search::bundlePathUnder(
-		$wikvenBundlePath,
-		$wikvenBuildSkin
-	);
-	$GLOBALS['wgSifterSearchOutputDir'] = $wgWikvenHtmlDirectory . '/' . basename($wgWikvenSearchIndexSource);
+$wikvenSkinPass = $wikvenBuildSkin !== false && in_array($wikvenBuildSkin, $wgWikvenSkins, true)
+	? $wikvenBuildSkin
+	: '';
+$wikvenSearchCopy = MediaWiki\Extension\Wikven\Search::bundleCopyFor(
+	$wikvenSkinPass,
+	$wgWikvenMainSkin,
+	(string)( $GLOBALS['wgSifterSearchBundlePath'] ?? '/pagefind/' ),
+	$wgWikvenSearchIndexSource,
+	$wgWikvenHtmlDirectory
+);
+if ($wikvenSearchCopy !== null) {
+	$GLOBALS['wgSifterSearchBundlePath'] = $wikvenSearchCopy['path'];
+	$GLOBALS['wgSifterSearchOutputDir'] = $wikvenSearchCopy['directory'];
 }
 
 // WikvenLogos ($wgWikvenLogos) mirrors $wgLogos but each src is a source-dir file name, resolved

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -382,33 +382,13 @@ class Build extends Maintenance {
 	 * Pagefind pass over the whole site per skin, for bytes that would come out identical.
 	 */
 	private function copySearchBundle(): void {
-		$source = rtrim((string)( $GLOBALS['wgWikvenSearchIndexSource'] ?? '' ), '/');
-		$destination = rtrim((string)( $GLOBALS['wgSifterSearchOutputDir'] ?? '' ), '/');
-		// Equal on the main skin's pass, which is the one the index was built into.
-		if ($source === '' || $destination === '' || $source === $destination || !is_dir($source)) {
-			return;
-		}
-		$this->copyDirectory($source, $destination);
-	}
-
-	/** Recursively copy the contents of $source into $destination, creating what is missing. */
-	private function copyDirectory(string $source, string $destination): void {
-		if (!wfMkdirParents($destination)) {
-			$this->fatalError("Wikven: could not create directory $destination");
-		}
-		$entries = new \RecursiveIteratorIterator(
-			new \RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS),
-			\RecursiveIteratorIterator::SELF_FIRST
+		// Equal on the main skin's pass, the one the index was built into; Search returns early.
+		$error = Search::publishBundle(
+			(string)( $GLOBALS['wgWikvenSearchIndexSource'] ?? '' ),
+			(string)( $GLOBALS['wgSifterSearchOutputDir'] ?? '' )
 		);
-		foreach ($entries as $entry) {
-			$target = $destination . '/' . substr($entry->getPathname(), strlen($source) + 1);
-			if ($entry->isDir()) {
-				if (!wfMkdirParents($target)) {
-					$this->fatalError("Wikven: could not create directory $target");
-				}
-			} elseif (!copy($entry->getPathname(), $target)) {
-				$this->fatalError("Wikven: could not copy {$entry->getPathname()} to $target");
-			}
+		if ($error !== null) {
+			$this->fatalError($error);
 		}
 	}
 

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -353,6 +353,8 @@ class Build extends Maintenance {
 		// Minerva takes no navigation from the sidebar, so its menu is filled in the rendered pages.
 		$this->step(FillMinervaMenu::class, "$own/fillMinervaMenu.php");
 		$this->step(StoreImages::class, "$own/storeImages.php");
+		// A skin copy searches within itself, which means loading the index from inside itself.
+		$this->copySearchBundle();
 		$this->step(Rename::class, "$own/rename.php");
 		// Rename has expanded translation pages into "<Page>/<lang>.html"; resolve MyLanguage links now.
 		$this->step(ResolveTranslationLinks::class, "$own/resolveTranslationLinks.php");
@@ -361,6 +363,52 @@ class Build extends Maintenance {
 		$history = "$dir/history";
 		if (is_dir($history)) {
 			$this->removeDirectory($history);
+		}
+	}
+
+	/**
+	 * Give this skin pass its own copy of the search index, so a result keeps the reader in the
+	 * copy they searched from.
+	 *
+	 * Pagefind reports each result's URL relative to the crawl root ("/Pages.html") and the client
+	 * resolves it against the directory the bundle sits in, so a copy loading the root's bundle
+	 * sends every result back to the root's pages (#399). The index describes one site and the
+	 * copies hold the same pages, so the fix is where the bundle is read from rather than what is
+	 * in it: the index is built once, by the job runJobs() holds back to the end, and each pass
+	 * that is not the main skin publishes that same bundle inside its own output.
+	 * WikvenSettings.php is what points the pass's client at the copy, and names both paths here.
+	 *
+	 * The cost is a copy of the index per skin. Rebuilding it per skin instead would cost a
+	 * Pagefind pass over the whole site per skin, for bytes that would come out identical.
+	 */
+	private function copySearchBundle(): void {
+		$source = rtrim((string)( $GLOBALS['wgWikvenSearchIndexSource'] ?? '' ), '/');
+		$destination = rtrim((string)( $GLOBALS['wgSifterSearchOutputDir'] ?? '' ), '/');
+		// Equal on the main skin's pass, which is the one the index was built into.
+		if ($source === '' || $destination === '' || $source === $destination || !is_dir($source)) {
+			return;
+		}
+		$this->copyDirectory($source, $destination);
+	}
+
+	/** Recursively copy the contents of $source into $destination, creating what is missing. */
+	private function copyDirectory(string $source, string $destination): void {
+		if (!wfMkdirParents($destination)) {
+			$this->fatalError("Wikven: could not create directory $destination");
+		}
+		$entries = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS),
+			\RecursiveIteratorIterator::SELF_FIRST
+		);
+		foreach ($entries as $entry) {
+			$target = $destination . '/' . substr($entry->getPathname(), strlen($source) + 1);
+			if ($entry->isDir()) {
+				if (!wfMkdirParents($target)) {
+					$this->fatalError("Wikven: could not create directory $target");
+				}
+			} elseif (!copy($entry->getPathname(), $target)) {
+				$this->fatalError("Wikven: could not copy {$entry->getPathname()} to $target");
+			}
 		}
 	}
 

--- a/tests/e2e/skin-copy-search.spec.js
+++ b/tests/e2e/skin-copy-search.spec.js
@@ -1,0 +1,51 @@
+// A reader who searches from a skin copy stays in that copy (#399). Pagefind reports each result's
+// URL relative to the crawl root and the client resolves it against the directory the bundle sits
+// in, so this is really an assertion about which bundle a copy loads: the one published inside it,
+// rather than the root's. Read in a browser because that resolution happens in Pagefind's own
+// client, and nothing in the exported HTML shows what it will come out as.
+
+const { test, expect } = require("@playwright/test");
+
+// The non-main skin copies, each a directory of its own under the export root. The main skin has
+// no copy: it is the export root, and searching from it was always right.
+const COPIES = ["citizen", "minerva"];
+
+// A page every bake of the docs site has, and a term that matches it.
+const RESULT = "Standalone_binary.html";
+const TERM = "binary";
+
+for (const skin of COPIES) {
+	test(`a search from the ${skin} copy leads back into it`, async ({
+		page,
+		request,
+	}) => {
+		const response = await request.get(`${skin}/index.html`).catch(() => null);
+		test.skip(!response?.ok(), `this export does not render ${skin}`);
+
+		await page.goto(`${skin}/Search.html?search=${TERM}`);
+
+		const result = page.locator(".pagefind-ui__result-link").first();
+		await expect(result).toBeVisible({ timeout: 15000 });
+
+		// The copy's own page rather than the root's, which is the whole of it. Asserted as a
+		// suffix, since the URL also carries the path prefix the site is served under.
+		const inCopy = new RegExp(`/${skin}/[^/]+\\.html$`);
+		const hrefs = await page
+			.locator(".pagefind-ui__result-link")
+			.evaluateAll((links) => links.map((link) => link.href));
+		expect(hrefs.length).toBeGreaterThan(0);
+		for (const href of hrefs) {
+			expect(href).toMatch(inCopy);
+		}
+
+		// And it is a page that is actually there: a URL in the right shape pointing at nothing
+		// would read the same from the results list.
+		const target = page
+			.locator(".pagefind-ui__result-link", { hasText: "Standalone binary" })
+			.first();
+		await expect(target).toHaveAttribute("href", new RegExp(`/${skin}/${RESULT}$`));
+		await target.click();
+		await expect(page).toHaveURL(new RegExp(`/${skin}/${RESULT}$`));
+		await expect(page.locator("#firstHeading")).toBeVisible();
+	});
+}

--- a/tests/e2e/skin-copy-search.spec.js
+++ b/tests/e2e/skin-copy-search.spec.js
@@ -10,8 +10,7 @@ const { test, expect } = require("@playwright/test");
 // no copy: it is the export root, and searching from it was always right.
 const COPIES = ["citizen", "minerva"];
 
-// A page every bake of the docs site has, and a term that matches it.
-const RESULT = "Standalone_binary.html";
+// A term the docs site answers with pages that exist in every copy.
 const TERM = "binary";
 
 for (const skin of COPIES) {
@@ -24,31 +23,27 @@ for (const skin of COPIES) {
 
 		await page.goto(`${skin}/Search.html?search=${TERM}`);
 
-		const result = page.locator(".pagefind-ui__result-link").first();
-		await expect(result).toBeVisible({ timeout: 15000 });
+		const results = page.locator(".pagefind-ui__result-link");
+		await expect(results.first()).toBeVisible({ timeout: 15000 });
 
-		// The copy's own page rather than the root's, which is the whole of it. Asserted as a
-		// suffix, since the URL also carries the path prefix the site is served under.
-		const inCopy = new RegExp(`/${skin}/[^/]+\\.html$`);
-		const hrefs = await page
-			.locator(".pagefind-ui__result-link")
-			.evaluateAll((links) => links.map((link) => link.href));
+		// Inside the copy is the whole of it. Matched as a prefix rather than as one file name,
+		// since a translated page is exported into a directory of its own
+		// ("citizen/Standalone_binary/en.html") and the index holds those too (#400). The site's
+		// own path prefix is in front of all of it, hence the suffix match.
+		const inCopy = new RegExp(`/${skin}/.+\\.html$`);
+		const hrefs = await results.evaluateAll((links) =>
+			links.map((link) => link.href),
+		);
 		expect(hrefs.length).toBeGreaterThan(0);
 		for (const href of hrefs) {
 			expect(href).toMatch(inCopy);
 		}
 
-		// And it is a page that is actually there: a URL in the right shape pointing at nothing
-		// would read the same from the results list.
-		const target = page
-			.locator(".pagefind-ui__result-link", { hasText: "Standalone binary" })
-			.first();
-		await expect(target).toHaveAttribute(
-			"href",
-			new RegExp(`/${skin}/${RESULT}$`),
-		);
-		await target.click();
-		await expect(page).toHaveURL(new RegExp(`/${skin}/${RESULT}$`));
+		// And it is a page that is really there: a URL in the right shape pointing at nothing
+		// reads the same in the results list.
+		const target = await results.first().evaluate((link) => link.href);
+		await results.first().click();
+		await expect(page).toHaveURL(target);
 		await expect(page.locator("#firstHeading")).toBeVisible();
 	});
 }

--- a/tests/e2e/skin-copy-search.spec.js
+++ b/tests/e2e/skin-copy-search.spec.js
@@ -43,7 +43,10 @@ for (const skin of COPIES) {
 		const target = page
 			.locator(".pagefind-ui__result-link", { hasText: "Standalone binary" })
 			.first();
-		await expect(target).toHaveAttribute("href", new RegExp(`/${skin}/${RESULT}$`));
+		await expect(target).toHaveAttribute(
+			"href",
+			new RegExp(`/${skin}/${RESULT}$`),
+		);
 		await target.click();
 		await expect(page).toHaveURL(new RegExp(`/${skin}/${RESULT}$`));
 		await expect(page.locator("#firstHeading")).toBeVisible();

--- a/tests/phpunit/unit/SearchTest.php
+++ b/tests/phpunit/unit/SearchTest.php
@@ -2,42 +2,157 @@
 
 namespace MediaWiki\Extension\Wikven\Tests\Unit;
 
+use FilesystemIterator;
 use MediaWiki\Extension\Wikven\Search;
 use MediaWikiUnitTestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * @covers \MediaWiki\Extension\Wikven\Search
  */
 class SearchTest extends MediaWikiUnitTestCase {
-	public function testASitePathGainsTheSkinDirectoryAboveTheBundle() {
-		$this->assertSame('/wikven/citizen/pagefind/', Search::bundlePathUnder('/wikven/pagefind/', 'citizen'));
-	}
+	private const MAIN = 'vector';
 
-	public function testABundleAtTheSiteRootIsHandledTheSameWay() {
-		$this->assertSame('/minerva/pagefind/', Search::bundlePathUnder('/pagefind/', 'minerva'));
-	}
-
-	public function testATrailingSlashIsNotRequiredAndIsAlwaysGivenBack() {
-		$this->assertSame('/wikven/citizen/pagefind/', Search::bundlePathUnder('/wikven/pagefind', 'citizen'));
-	}
-
-	public function testADeeperBundlePathKeepsEverythingAboveTheBundle() {
+	public function testASkinCopyLoadsAndPublishesTheIndexInsideItself() {
 		$this->assertSame(
-			'/w/static/citizen/index/',
-			Search::bundlePathUnder('/w/static/index/', 'citizen')
+			['path' => '/wikven/citizen/pagefind/', 'directory' => '/w/dist/citizen/pagefind'],
+			$this->copyFor('citizen', '/wikven/pagefind/', '/w/dist/pagefind', '/w/dist/citizen')
 		);
 	}
 
-	public function testARootAnchoredPathIsTheOneThatCanBeCopied() {
-		$this->assertTrue(Search::isBundlePathRootAnchored('/pagefind/'));
-		$this->assertTrue(Search::isBundlePathRootAnchored('/wikven/pagefind/'));
+	public function testABundleAtTheSiteRootIsHandledTheSameWay() {
+		$copy = $this->copyFor('minerva', '/pagefind/', '/w/dist/pagefind', '/w/dist/minerva');
+		$this->assertSame('/minerva/pagefind/', $copy['path']);
 	}
 
-	/** A bundle on another host says nothing about where this site's root is, so it is left alone. */
-	public function testABundleOffThisSiteIsNotRootAnchored() {
-		$this->assertFalse(Search::isBundlePathRootAnchored('//cdn.example.org/pagefind/'));
-		$this->assertFalse(Search::isBundlePathRootAnchored('https://cdn.example.org/pagefind/'));
-		$this->assertFalse(Search::isBundlePathRootAnchored('pagefind/'));
-		$this->assertFalse(Search::isBundlePathRootAnchored(''));
+	public function testATrailingSlashIsNotRequiredAndTheBundlePathAlwaysGetsOne() {
+		$copy = $this->copyFor('citizen', '/wikven/pagefind', '/w/dist/pagefind/', '/w/dist/citizen/');
+		$this->assertSame('/wikven/citizen/pagefind/', $copy['path']);
+		$this->assertSame('/w/dist/citizen/pagefind', $copy['directory']);
+	}
+
+	public function testTheDirectoryTheIndexWasBuiltIntoNamesTheCopy() {
+		$copy = $this->copyFor('citizen', '/w/static/index/', '/w/dist/index', '/w/dist/citizen');
+		$this->assertSame('/w/static/citizen/index/', $copy['path']);
+		$this->assertSame('/w/dist/citizen/index', $copy['directory']);
+	}
+
+	/** Its output is the export root, so results already resolve against the index's own directory. */
+	public function testTheMainSkinGetsNoCopy() {
+		$this->assertNull($this->copyFor(self::MAIN, '/wikven/pagefind/', '/w/dist/pagefind', '/w/dist'));
+	}
+
+	/** Not a skin pass at all: the orchestrator, which renders nothing. */
+	public function testNoSkinGetsNoCopy() {
+		$this->assertNull($this->copyFor('', '/wikven/pagefind/', '/w/dist/pagefind', '/w/dist'));
+	}
+
+	/** Search is off (no output directory), so there is no index to copy. */
+	public function testNoIndexGetsNoCopy() {
+		$this->assertNull($this->copyFor('citizen', '/wikven/pagefind/', '', '/w/dist/citizen'));
+	}
+
+	/** A bundle on another host says nothing about where this site's root is, and is not ours. */
+	public function testABundleOffThisSiteGetsNoCopy() {
+		foreach (['//cdn.example.org/pagefind/', 'https://cdn.example.org/pagefind/', 'pagefind/'] as $path) {
+			$this->assertNull(
+				$this->copyFor('citizen', $path, '/w/dist/pagefind', '/w/dist/citizen'),
+				"$path names no root of this site"
+			);
+		}
+	}
+
+	public function testPublishingCopiesTheWholeBundleTree() {
+		$root = $this->makeTempDir();
+		$this->write("$root/pagefind/pagefind.js", 'bundle');
+		$this->write("$root/pagefind/fragment/en_1731fcb.pf_fragment", 'fragment');
+
+		$this->assertNull(Search::publishBundle("$root/pagefind", "$root/citizen/pagefind"));
+		$this->assertSame('bundle', file_get_contents("$root/citizen/pagefind/pagefind.js"));
+		$this->assertSame(
+			'fragment',
+			file_get_contents("$root/citizen/pagefind/fragment/en_1731fcb.pf_fragment")
+		);
+	}
+
+	public function testPublishingOverAnExistingCopyReplacesIt() {
+		$root = $this->makeTempDir();
+		$this->write("$root/pagefind/pagefind.js", 'new');
+		$this->write("$root/citizen/pagefind/pagefind.js", 'stale');
+
+		$this->assertNull(Search::publishBundle("$root/pagefind", "$root/citizen/pagefind"));
+		$this->assertSame('new', file_get_contents("$root/citizen/pagefind/pagefind.js"));
+	}
+
+	/** The main skin's pass asks to publish the index where it already is. */
+	public function testPublishingOntoItselfDoesNothing() {
+		$root = $this->makeTempDir();
+		$this->write("$root/pagefind/pagefind.js", 'bundle');
+		$this->assertNull(Search::publishBundle("$root/pagefind", "$root/pagefind/"));
+		$this->assertSame('bundle', file_get_contents("$root/pagefind/pagefind.js"));
+	}
+
+	public function testNothingToPublishIsNotAFailure() {
+		$root = $this->makeTempDir();
+		$this->assertNull(Search::publishBundle('', "$root/citizen/pagefind"));
+		$this->assertNull(Search::publishBundle("$root/pagefind", ''));
+		// Search was on but the index was never built.
+		$this->assertNull(Search::publishBundle("$root/absent", "$root/citizen/pagefind"));
+		$this->assertFalse(is_dir("$root/citizen/pagefind"));
+	}
+
+	/** A build that cannot publish the index has to say so rather than ship a copy without one. */
+	public function testAnUnwritableDestinationIsReported() {
+		$root = $this->makeTempDir();
+		$this->write("$root/pagefind/pagefind.js", 'bundle');
+		$this->write("$root/citizen", 'a file where the directory should go');
+
+		$error = Search::publishBundle("$root/pagefind", "$root/citizen/pagefind");
+		$this->assertStringContainsString("could not create directory $root/citizen/pagefind", (string)$error);
+	}
+
+	/** @return ?array{path:string,directory:string} */
+	private function copyFor(string $skin, string $bundlePath, string $indexSource, string $htmlDir): ?array {
+		return Search::bundleCopyFor($skin, self::MAIN, $bundlePath, $indexSource, $htmlDir);
+	}
+
+	private function write(string $path, string $contents): void {
+		$directory = dirname($path);
+		if (!is_dir($directory)) {
+			mkdir($directory, 0777, true);
+		}
+		file_put_contents($path, $contents);
+	}
+
+	private function makeTempDir(): string {
+		$dir = sys_get_temp_dir() . '/wikven-search-' . uniqid();
+		mkdir($dir);
+		$this->dirsToClean[] = $dir;
+		return $dir;
+	}
+
+	/** @var string[] */
+	private array $dirsToClean = [];
+
+	protected function tearDown(): void {
+		foreach ($this->dirsToClean as $dir) {
+			if (!is_dir($dir)) {
+				continue;
+			}
+			$entries = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($entries as $entry) {
+				if ($entry->isDir()) {
+					rmdir($entry->getPathname());
+				} else {
+					unlink($entry->getPathname());
+				}
+			}
+			rmdir($dir);
+		}
+		parent::tearDown();
 	}
 }

--- a/tests/phpunit/unit/SearchTest.php
+++ b/tests/phpunit/unit/SearchTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\Search;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Search
+ */
+class SearchTest extends MediaWikiUnitTestCase {
+	public function testASitePathGainsTheSkinDirectoryAboveTheBundle() {
+		$this->assertSame('/wikven/citizen/pagefind/', Search::bundlePathUnder('/wikven/pagefind/', 'citizen'));
+	}
+
+	public function testABundleAtTheSiteRootIsHandledTheSameWay() {
+		$this->assertSame('/minerva/pagefind/', Search::bundlePathUnder('/pagefind/', 'minerva'));
+	}
+
+	public function testATrailingSlashIsNotRequiredAndIsAlwaysGivenBack() {
+		$this->assertSame('/wikven/citizen/pagefind/', Search::bundlePathUnder('/wikven/pagefind', 'citizen'));
+	}
+
+	public function testADeeperBundlePathKeepsEverythingAboveTheBundle() {
+		$this->assertSame(
+			'/w/static/citizen/index/',
+			Search::bundlePathUnder('/w/static/index/', 'citizen')
+		);
+	}
+
+	public function testARootAnchoredPathIsTheOneThatCanBeCopied() {
+		$this->assertTrue(Search::isBundlePathRootAnchored('/pagefind/'));
+		$this->assertTrue(Search::isBundlePathRootAnchored('/wikven/pagefind/'));
+	}
+
+	/** A bundle on another host says nothing about where this site's root is, so it is left alone. */
+	public function testABundleOffThisSiteIsNotRootAnchored() {
+		$this->assertFalse(Search::isBundlePathRootAnchored('//cdn.example.org/pagefind/'));
+		$this->assertFalse(Search::isBundlePathRootAnchored('https://cdn.example.org/pagefind/'));
+		$this->assertFalse(Search::isBundlePathRootAnchored('pagefind/'));
+		$this->assertFalse(Search::isBundlePathRootAnchored(''));
+	}
+}


### PR DESCRIPTION
Closes #399 — "give each copy its own bundle path", the option the maintainer picked.

> Stacked on #435 (which is stacked on #429). Retarget down the chain as each merges. The diff of this PR alone is `includes/Search.php`, `includes/WikvenSettings.php`, `maintenance/build.php`, its unit test, a browser spec, and a docs paragraph.

## The bug

Pagefind records each page's URL relative to the crawl root (`/Pages.html`) and its client resolves that against the directory the bundle sits in. One bundle at the export root therefore answers every copy with the root's pages: search from `/wikven/citizen/Search.html` and every result leads to `/wikven/Standalone_binary.html`, taking the reader out of the skin they were reading. Vector's typeahead does the same from a Citizen or Minerva page, and the suggestion links with it.

## The fix

The index describes one site and the copies hold the same pages, so what a copy needs is not a different index — it is the same one, read from inside itself.

- The build already builds the index once, in the job `runJobs()` holds back to the end. Each pass that is not the main skin now publishes that same bundle inside its own output (`Search::publishBundle()`, called from `Build::renderSkin()`) and loads it from there, which makes the copy's own directory the root every result resolves against.
- `Search::bundleCopyFor()` decides whether a pass gets a copy and where: it derives the copy's bundle path from the site's own — `/wikven/pagefind/` → `/wikven/citizen/pagefind/` — and names the directory to publish into. `WikvenSettings.php` is left wiring the two globals, and records the built index in `$wgWikvenSearchIndexSource` so the pass knows what to copy. SifterSearch's `resultsPageUrl` is anchored against that same bundle-path setting, so the copy's results page comes along with it.

Rebuilding the index per skin would cost a full Pagefind pass over the site per skin, for bytes that come out identical, so this copies instead. The cost is the accepted one from the issue: the index on disk once per skin.

Two cases are deliberately left alone:

- **A bundle served from another host** (`//cdn…`, `https://…`). Wikven does not publish it and cannot copy it, and such a path says nothing about where this site's root is — the same test SifterSearch's `ClientConfig::anchored()` makes, for the same reason.
- **The main skin.** Its output *is* the export root, so its search was always right; `bundleCopyFor()` answers null and the publish step is a no-op.

## Testing

- `tests/phpunit/unit/SearchTest.php` (new): which passes get a copy and where (site subpath, bundle at the root, missing trailing slashes, a differently-named index directory, the main skin, no skin, search off, a bundle off this site), and the publish itself against a real tree — the whole bundle copied including nested files, a copy replacing a stale one, publishing onto itself, the three ways there is nothing to do, and the failure a build has to report rather than ship a copy without an index.
- `tests/e2e/skin-copy-search.spec.js` (new) is the one that would have caught the bug. For each copy it runs a real query on that copy's results page, asserts every result URL lands inside the copy, then follows the first one and checks the page is actually there — a URL in the right shape pointing at nothing reads the same in the results list.

  Its first run failed, and usefully: the results are inside the copy, but the first one is `citizen/Standalone_binary/en.html`. A translated page is exported into a directory of its own and the index holds one entry per language (#400), so the assertion now matches anything under the copy rather than one file name at its top level.
- Docs: a paragraph in `docs/Searching.wikitext` on what a multi-skin site gets. Korean is left to the translation flow, as the check-translations job expects.
- `phpcs`, `mago format --check`, `mago lint` and `biome ci` clean.
- The bake is not run here (no MediaWiki install in this session); the smoke job bakes the docs site and runs the browser specs against it.
