### PR TITLE
fix: give Citizen's "View source" tab an icon

### DIFF
--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -256,6 +256,22 @@ class Main implements
 			'text' => $sktemplate->msg('viewsource')->text(),
 			'href' => str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $wgWikvenViewSourceUrl)
 		];
+
+		// Citizen draws the page actions as icon buttons and stops rendering their labels below
+		// desktop width (font-size: 0, Pagetools.less), so a tab it has no icon for is a blank box
+		// the width of its padding: nothing to read and little to hit. Its icons come from a map
+		// keyed by the names core uses, which this tab -- being ours -- is not in; what the skin
+		// does for every entry is turn an 'icon' the item carries into the markup, so the tab has
+		// to bring its own. wikiText rather than the editLock the skin gives core's "View source",
+		// because the Edit tab beside it works: a padlock would read as a permission this reader is
+		// missing rather than as a link to the file.
+		//
+		// Citizen alone, because core hands the key to whichever skin renders the page. Vector 2022
+		// suppresses icons on the tabs themselves, but not in the page-tools dropdown it copies
+		// them into, where Edit and View history next to it have none.
+		if ($sktemplate->getSkinName() === 'citizen') {
+			$links['views']['wikven-viewsource']['icon'] = 'wikiText';
+		}
 	}
 
 	/** @inheritDoc */

--- a/tests/e2e/citizen.spec.js
+++ b/tests/e2e/citizen.spec.js
@@ -165,6 +165,36 @@ test("Citizen's last-modified button leads to what changed", async ({
 	);
 });
 
+test("Citizen's view-source tab is a button a reader can hit", async ({
+	page,
+}) => {
+	// Below the skin's desktop breakpoint the page actions are icon-only -- Citizen sets the
+	// labels to font-size: 0 -- so a tab it has no icon for is a box the width of its padding
+	// with nothing in it. The tab is wikven's own, which is why it carries an icon of its own:
+	// the skin's icon map is keyed by the names core uses.
+	await page.setViewportSize({ width: 800, height: 600 });
+	await page.goto(PAGE);
+
+	const tab = page.locator("#ca-wikven-viewsource");
+	await expect(tab.locator("a")).toHaveAttribute(
+		"href",
+		/Installation\.wikitext$/,
+	);
+
+	// The glyph is a mask on the icon's ::before, so an icon whose stylesheet never reached the
+	// export leaves a span that is sized and blank rather than one that is missing.
+	const mask = await tab.locator(".citizen-ui-icon").evaluate((span) => {
+		const style = getComputedStyle(span, "::before");
+		return style.maskImage || style.webkitMaskImage;
+	});
+	expect(mask, "the icon's mask image").toMatch(/^url\(/);
+
+	// And the button around it is the size of the ones beside it, rather than an empty sliver.
+	const box = await tab.locator("a").boundingBox();
+	const history = await page.locator("#ca-history a").boundingBox();
+	expect(box.width).toBeGreaterThanOrEqual(history.width * 0.9);
+});
+
 test("a Citizen page gets everything it asks for, and asks no backend", async ({
 	page,
 }) => {

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
 use MediaWiki\Extension\Wikven\Hooks\Main;
+use MediaWiki\Skin\SkinTemplate;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 
@@ -125,5 +126,58 @@ class MainTest extends MediaWikiIntegrationTestCase {
 		$url = '/x';
 		$this->main()->onGetLocalURL(Title::newFromText('Special:Search'), $url, '');
 		$this->assertSame('#', $url);
+	}
+
+	/**
+	 * The "View source" tab points at the page's source file in the repository, and in Citizen it
+	 * brings an icon: the skin renders the page actions as icon buttons and stops rendering their
+	 * labels below desktop width, so a tab it has no icon for is a blank box there. It maps icons
+	 * onto the keys core uses, and this key is Wikven's own.
+	 */
+	public function testViewSourceTabCarriesCitizensIcon() {
+		$dir = $this->getNewTempDirectory();
+		file_put_contents("$dir/Real.wikitext", '');
+		$this->overrideConfigValue('WikvenSourceDirectory', $dir);
+		$this->overrideConfigValue('WikvenViewSourceUrl', 'https://repo/blob/$1');
+
+		$tab = $this->viewsFor('Real', 'citizen')['wikven-viewsource'];
+		$this->assertSame('https://repo/blob/Real.wikitext', $tab['href']);
+		$this->assertSame('wikiText', $tab['icon']);
+	}
+
+	/**
+	 * Every other skin gets the tab without one: core passes the key on to whichever skin is
+	 * rendering, and Vector 2022 draws it in the page-tools dropdown, where the edit and history
+	 * tabs beside it have no icon either.
+	 */
+	public function testViewSourceTabHasNoIconElsewhere() {
+		$dir = $this->getNewTempDirectory();
+		file_put_contents("$dir/Real.wikitext", '');
+		$this->overrideConfigValue('WikvenSourceDirectory', $dir);
+		$this->overrideConfigValue('WikvenViewSourceUrl', 'https://repo/blob/$1');
+
+		$tab = $this->viewsFor('Real', 'vector-2022')['wikven-viewsource'];
+		$this->assertSame('https://repo/blob/Real.wikitext', $tab['href']);
+		$this->assertArrayNotHasKey('icon', $tab);
+	}
+
+	/** A generated page has no source file behind it, so it gets no tab to a link that would 404. */
+	public function testViewSourceTabSkippedWithoutASourceFile() {
+		$this->overrideConfigValue('WikvenSourceDirectory', $this->getNewTempDirectory());
+		$this->overrideConfigValue('WikvenViewSourceUrl', 'https://repo/blob/$1');
+
+		$this->assertArrayNotHasKey('wikven-viewsource', $this->viewsFor('Version', 'citizen'));
+	}
+
+	/** @return array The 'views' menu the hook leaves behind, keyed as the skins read it. */
+	private function viewsFor(string $titleText, string $skin): array {
+		$sktemplate = $this->createMock(SkinTemplate::class);
+		$sktemplate->method('getTitle')->willReturn(Title::newFromText($titleText));
+		$sktemplate->method('getSkinName')->willReturn($skin);
+		$sktemplate->method('msg')->willReturnCallback(static fn($key) => wfMessage($key));
+
+		$links = ['views' => []];
+		$this->main()->onSkinTemplateNavigation__Universal($sktemplate, $links);
+		return $links['views'];
 	}
 }

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -174,7 +174,8 @@ class MainTest extends MediaWikiIntegrationTestCase {
 		$sktemplate = $this->createMock(SkinTemplate::class);
 		$sktemplate->method('getTitle')->willReturn(Title::newFromText($titleText));
 		$sktemplate->method('getSkinName')->willReturn($skin);
-		$sktemplate->method('msg')->willReturnCallback(static fn($key) => wfMessage($key));
+		// The hook asks for one message, the label; a mock has none of its own to answer with.
+		$sktemplate->method('msg')->willReturn(wfMessage('viewsource'));
 
 		$links = ['views' => []];
 		$this->main()->onSkinTemplateNavigation__Universal($sktemplate, $links);


### PR DESCRIPTION
Citizen renders the page actions as icon buttons, and below its desktop breakpoint it stops rendering their labels entirely (`font-size: 0` in `Pagetools.less`). The "View source" tab wikven adds carried no icon, so in that skin it was a blank box the width of its padding — visually absent, and a poor hit target.

The skin gets its icons from a map keyed by the names core uses (`NavigationMenuTransformer::updateViewsMenu`), which `wikven-viewsource` — being ours — is not in. What the skin does do for every entry is turn an `icon` the item carries into the markup, so the tab now brings its own.

## Changes

- `includes/Hooks/Main.php`: set `'icon' => 'wikiText'` on the tab, for Citizen only.
  - **wikiText, not editLock** (what Citizen gives core's "View source"): the Edit tab beside it works here, so a padlock would read as a permission this reader is missing rather than as a link to the file. `wikiText` is in Citizen's icon pack, which the export already ships.
  - **Citizen only**, because core hands the key to whichever skin renders the page: Vector 2022 suppresses icons on the tabs themselves but not in the page-tools dropdown it copies them into, where Edit and View history next to it have none.
- `tests/phpunit/integration/MainTest.php`: the tab's href and icon in Citizen, no icon elsewhere, and no tab at all for a page with no source file.
- `tests/e2e/citizen.spec.js`: at a width where the labels are hidden, the tab's icon has a mask image (so the icon's stylesheet really reached the export) and its button is as wide as the ones beside it.

## Testing

- `mago format --check` and `mago lint` clean.
- The PHPUnit and browser suites run in CI (no MediaWiki checkout or Docker daemon in this environment, so they were not run locally).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVM1ahs3mZqrhxGQbg8p5k)_