### PR TITLE
feat: index each language separately, and assert it stays that way

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -98,6 +98,22 @@ jobs:
             fi
           done
 
+          # Each page is indexed in the language it is written in, so Pagefind builds one index per
+          # language and a reader searching from a translated page is answered out of that
+          # language's index (#400). A single index means every translation was stamped with the
+          # wiki's content language and stemmed by English rules, which is what this site looked
+          # like until SifterSearch indexed per page rather than per wiki.
+          echo "Search indexes built:"
+          ls dist/pagefind/*.pf_meta | xargs -n1 basename
+          echo "Indexed pages per language:"
+          ls dist/pagefind/fragment | sed 's/_.*//' | sort | uniq -c
+          for lang in en ko; do
+            if ! ls dist/pagefind/pagefind."${lang}"_*.pf_meta >/dev/null 2>&1; then
+              echo "::error::dist/pagefind has no $lang index; pages are not indexed in their own language"
+              exit 1
+            fi
+          done
+
           # Every printfooter "Retrieved from" link must resolve from the page that carries it
           # (#394). Core builds it from the page's own URL and expands away the "./" wikven writes,
           # so a page exported into a subdirectory needs the "../" per level rename.php adds; the

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 ARG TARGETARCH
-ARG SIFTERSEARCH_VERSION=v0.7.1
+ARG SIFTERSEARCH_VERSION=v0.7.2
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \
  && curl -fsSL "https://github.com/chaotic-ground/SifterSearch/releases/download/${SIFTERSEARCH_VERSION}/SifterSearch-linux-${arch}.tar.gz" \


### PR DESCRIPTION
Bumps SifterSearch to **v0.7.2** and adds the assertion that proves what it fixes. Rebased onto the current `main`; the reproducibility half that was on this branch went in separately as #451.

Closes #400 — but only its language half. The other half is filed as #454; see the end of this description.

## What changes for a reader

SifterSearch indexed every page as the wiki's content language, whatever it was written in (chaotic-ground/SifterSearch#69). Pagefind builds one index per language it finds and its client picks the index by the language of the page the reader is on, so this site shipped **one English index holding every page**:

```console
$ ls dist/pagefind/fragment | sed 's/_.*//' | sort | uniq -c
     59 en
```

Two consequences. Korean and Khmer were tokenised and stemmed by English rules, so relevance for a translated page was whatever English stemming happened to give it. And a reader searching from a translated page was answered out of the English index — the client looked for `ko`, found none, and fell back to the only one there was.

A bake now produces three indexes: **en 39, ko 19, km 1.**

Searching from a page now answers in that page's language. Content not translated into the reader's language is no longer surfaced to them, which is the intended trade and the reason per-language indexes exist.

## The assertion

`smoke` prints what the bundle holds and fails if English and Korean are not indexed apart:

```
Search indexes built:
Indexed pages per language:
```

This is the check the site was missing. Nothing here would have caught a search answering a Korean reader out of an English index, **because the search still worked** — Pagefind falls back to whatever index exists. The existing Pagefind checks assert a bundle exists per skin copy (#399); none of them looked at what was inside it.

Khmer appears in the printed counts without being required to pass; one page is a thin basis to gate on.

## Reproducibility, already handled

Three languages made Pagefind's language map come out in a different order each bake, breaking #411's byte-identical check on `pagefind-entry.json` alone. #451 settled that ahead of this bump, so this PR does not fail the two-bake check for a reason unrelated to what it changes.

## How this was verified

The whole chain was proven against `nightly-2026-08-17` before the pin moved to the release:

| claim | evidence |
|---|---|
| Pagefind indexes per language off `<html lang>` | ran its own binary over the HTML `BuildIndexJob` emits — 1 index when all pages claim `en`, 2 when they tell the truth |
| `getPageLanguage()` returns the translation's language for Translate subpages | a real bake of this site: `en`/`ko`/`km` |
| the fix does not break the two-bake check | smoke green end to end, once #451's normalisation was in |

## What #400 asked for that this does not do

#400 raised two faults. This closes the first and leaves the second, now tracked as **#454**: a translatable page reaches the export twice in the same language — as the source page and as the `/en` translation Translate materialises — so the English index holds 39 entries for 20 pages, and an English reader is offered each one twice.

No language split can separate those two; they are the same language by construction. It needs a decision about *what* to index, and an extension point in SifterSearch to express it, since `SifterSearchNamespaces` cannot tell a source page from its translation.