### PR TITLE
build: let updatecli move the TabberNeue and Citizen pins

### DIFF
--- a/docs/.wikven.yml
+++ b/docs/.wikven.yml
@@ -43,12 +43,14 @@ config:
   WikvenRepositories:
     # TabberNeue is not bundled in the image; clone it from Git to show off
     # third-party fetching. (TemplateStyles, which the templates use, is bundled
-    # in MediaWiki 1.46, so it needs no source here.)
+    # in MediaWiki 1.46, so it needs no source here.) Pinned to a release tag,
+    # which updatecli moves.
     TabberNeue:
       repository: https://github.com/StarCitizenTools/mediawiki-extensions-TabberNeue.git
       reference: v4.0.0
     # Citizen is a third-party skin, fetched rather than bundled. Wikven handles
     # what it does that a static export cannot serve, so nothing is needed here.
+    # Pinned to a release tag, which updatecli moves.
     Citizen:
       repository: https://github.com/StarCitizenTools/mediawiki-skins-Citizen.git
       reference: v3.17.0

--- a/updatecli/updatecli.d/wikven-repositories.yaml
+++ b/updatecli/updatecli.d/wikven-repositories.yaml
@@ -1,0 +1,61 @@
+---
+name: "build(deps): bump the docs site's tagged repositories"
+pipelineid: wikven-repositories
+
+scms:
+  default:
+    kind: github
+    spec:
+      owner: chaotic-ground
+      repository: wikven
+      branch: main
+      user: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      labels:
+        - dependencies
+
+# The WikvenRepositories pins that follow a release tag. A new one belongs here if its upstream
+# cuts releases; one that has to track a branch by commit belongs beside the cohort whose branch it
+# follows, the way MobileFrontend sits in mediawiki-extensions.yaml. The tag is copied in verbatim,
+# "v" and all, because it is what the site clones.
+sources:
+  tabberneue:
+    name: Latest TabberNeue release
+    kind: githubrelease
+    spec:
+      owner: StarCitizenTools
+      repository: mediawiki-extensions-TabberNeue
+      versionfilter:
+        kind: semver
+  citizen:
+    name: Latest Citizen release
+    kind: githubrelease
+    spec:
+      owner: StarCitizenTools
+      repository: mediawiki-skins-Citizen
+      versionfilter:
+        kind: semver
+
+targets:
+  tabberneue:
+    name: 'build(deps): bump TabberNeue to {{ source "tabberneue" }}'
+    kind: yaml
+    scmid: default
+    sourceid: tabberneue
+    spec:
+      file: docs/.wikven.yml
+      key: $.config.WikvenRepositories.TabberNeue.reference
+  citizen:
+    name: 'build(deps): bump Citizen to {{ source "citizen" }}'
+    kind: yaml
+    scmid: default
+    sourceid: citizen
+    spec:
+      file: docs/.wikven.yml
+      key: $.config.WikvenRepositories.Citizen.reference


### PR DESCRIPTION
`docs/.wikven.yml` pins TabberNeue and Citizen to release tags, and nothing watched either one: Dependabot does not read that file, and `mediawiki-extensions.yaml` only covers the commit pins that follow `REL1_46` (Translate, ULS, MobileFrontend). Both pins have drifted — TabberNeue is on `v4.0.0` against an upstream `v4.0.2`, Citizen on `v3.17.0` against `v3.21.0`.

This adds `updatecli/updatecli.d/wikven-repositories.yaml`. Each pin gets the shape `siftersearch.yaml` already uses — a `githubrelease` source with a semver `versionfilter` — writing through a `yaml` target to its `reference` key, the way `mediawiki-extensions.yaml` writes `MobileFrontend.commit` in the same file. The tag is copied in verbatim, `v` and all, because that is what the docs site clones.

One manifest rather than one per pin. An extension and a skin release on their own cadences, so separate pipelines were tempting, but the file that buys it is a quarter source and target and three quarters the `scms` and `actions` blocks every manifest here repeats verbatim.

It is grouped and named by how the pins are written, not by who publishes them. Both currently come from StarCitizenTools, but that is a coincidence, and a name resting on it would mislead the first pin that arrives from anywhere else. It is not named for extensions either, the way `mediawiki-extensions.yaml` is, since only one of the two is one and `.wikven.yml` lists skins separately. The header comment states the membership rule: a new pin belongs here if its upstream cuts releases, and beside its branch cohort if it has to track a branch by commit.

The comments beside the two pins now say updatecli moves them, matching the note already on `MobileFrontend`.

### Testing

- `yamllint --strict` clean on the new manifest and on `docs/.wikven.yml`.
- Ran updatecli v0.120.1 (the version the workflow pins) against the manifest with both sources stubbed to fixed versions, since this sandbox's proxy blocks the GitHub GraphQL API that the `githubrelease` source uses — the pre-existing `siftersearch.yaml` fails there identically. Both targets resolved their key paths and moved their own pin in a single pass without clobbering each other, leaving surrounding comments and quoting intact. The live source resolution is therefore unverified here and will first run in Actions; upstream releases were confirmed over the REST API instead.