### PR TITLE
docs: label a prevnext link with the target's translated title

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -146,6 +146,25 @@ jobs:
             exit 1
           fi
 
+          # A prevnext link is labelled with the target page's own title, so on a translated page it
+          # must carry the translated one. The label is not in the calling page's source: the call
+          # sits outside the translate tags and passes a page name, and the template reads the
+          # title from the target's own title unit, which is the whole point -- a label restated in
+          # the caller would be a second copy of a string that is already translated once.
+          # Searching/ko is the fixture, and the expectation is read from the source rather than
+          # written here: any Korean at all would pass a string pinned in this file.
+          want=$(awk '/^<!--T:title[ -]/ { found = 1; next } found && NF { print; exit }' \
+            docs/Deploying/ko.wikitext)
+          if [ -z "$want" ]; then
+            echo "::error::docs/Deploying/ko.wikitext has no translated title to expect"
+            exit 1
+          fi
+          if ! grep -q "wikven-prevnext-next\"><a [^>]*>$want</a>" dist/Searching/ko.html; then
+            echo "::error::Searching/ko's prevnext does not show Deploying's Korean title ($want)"
+            sed -n 's/.*\(wikven-prevnext-next">[^<]*<a[^>]*>[^<]*<\/a>\).*/\1/p' dist/Searching/ko.html
+            exit 1
+          fi
+
           echo "Smoke checks passed."
 
       # Two bakes of the same source have to produce the same bytes, and until now nothing said so.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -159,11 +159,20 @@ jobs:
             echo "::error::docs/Deploying/ko.wikitext has no translated title to expect"
             exit 1
           fi
-          if ! grep -q "wikven-prevnext-next\"><a [^>]*>$want</a>" dist/Searching/ko.html; then
-            echo "::error::Searching/ko's prevnext does not show Deploying's Korean title ($want)"
-            sed -n 's/.*\(wikven-prevnext-next">[^<]*<a[^>]*>[^<]*<\/a>\).*/\1/p' dist/Searching/ko.html
-            exit 1
-          fi
+          # Newlines are flattened before the block is read: the template writes its markup over
+          # several lines, and what is being matched is one span of it. An empty match fails the
+          # case below rather than passing it, so a prevnext that stopped rendering is caught here
+          # too.
+          shown=$(tr '\n' ' ' < dist/Searching/ko.html | grep -o 'wikven-prevnext-next.\{0,300\}' \
+            | head -n 1) || true
+          case "$shown" in
+            *"$want"*) ;;
+            *)
+              echo "::error::Searching/ko's prevnext does not show Deploying's Korean title ($want)"
+              echo "$shown"
+              exit 1
+              ;;
+          esac
 
           echo "Smoke checks passed."
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -154,21 +154,21 @@ jobs:
           # Searching/ko is the fixture, and the expectation is read from the source rather than
           # written here: any Korean at all would pass a string pinned in this file.
           want=$(awk '/^<!--T:title[ -]/ { found = 1; next } found && NF { print; exit }' \
-            docs/Deploying/ko.wikitext)
+            docs/Translating/ko.wikitext)
           if [ -z "$want" ]; then
-            echo "::error::docs/Deploying/ko.wikitext has no translated title to expect"
+            echo "::error::docs/Translating/ko.wikitext has no translated title to expect"
             exit 1
           fi
           # Newlines are flattened before the block is read: the template writes its markup over
           # several lines, and what is being matched is one span of it. An empty match fails the
           # case below rather than passing it, so a prevnext that stopped rendering is caught here
           # too.
-          shown=$(tr '\n' ' ' < dist/Searching/ko.html | grep -o 'wikven-prevnext-next.\{0,300\}' \
+          shown=$(tr '\n' ' ' < dist/Searching/ko.html | grep -o 'wikven-prevnext".\{0,700\}' \
             | head -n 1) || true
           case "$shown" in
             *"$want"*) ;;
             *)
-              echo "::error::Searching/ko's prevnext does not show Deploying's Korean title ($want)"
+              echo "::error::Searching/ko's prevnext does not show Translating's Korean title ($want)"
               echo "$shown"
               exit 1
               ;;

--- a/docs/Template:prevnext.wikitext
+++ b/docs/Template:prevnext.wikitext
@@ -1,12 +1,8 @@
-<!--
-Usage:
-
-* {{prevnext|next step}}
-* {{prevnext|previous step|next step}}
-
---><templatestyles src="prevnext/styles.css" /><div class="wikven-prevnext"><!--
+<templatestyles src="prevnext/styles.css" /><div class="wikven-prevnext"><!--
   -->{{#if:{{{2|}}}|
     <div class="wikven-prevnext-prev">&larr;&nbsp;[[Special:MyLanguage/{{{1|}}}|{{prevnext/label|{{{1|}}}}}]]</div>
   }}<!--
   --><div class="wikven-prevnext-next">[[Special:MyLanguage/{{{2|{{{1|}}}}}}|{{prevnext/label|{{{2|{{{1|}}}}}}}}]]&nbsp;&rarr;</div><!--
---></div>
+--></div><noinclude>
+{{prevnext/doc}}
+</noinclude>

--- a/docs/Template:prevnext.wikitext
+++ b/docs/Template:prevnext.wikitext
@@ -6,7 +6,7 @@ Usage:
 
 --><templatestyles src="prevnext/styles.css" /><div class="wikven-prevnext"><!--
   -->{{#if:{{{2|}}}|
-    <div class="wikven-prevnext-prev">&larr;&nbsp;[[Special:MyLanguage/{{{1|}}}|{{{1|}}}]]</div>
+    <div class="wikven-prevnext-prev">&larr;&nbsp;[[Special:MyLanguage/{{{1|}}}|{{prevnext/label|{{{1|}}}}}]]</div>
   }}<!--
-  --><div class="wikven-prevnext-next">[[Special:MyLanguage/{{{2|{{{1|}}}}}}|{{{2|{{{1|}}}}}}]]&nbsp;&rarr;</div><!--
+  --><div class="wikven-prevnext-next">[[Special:MyLanguage/{{{2|{{{1|}}}}}}|{{prevnext/label|{{{2|{{{1|}}}}}}}}]]&nbsp;&rarr;</div><!--
 --></div>

--- a/docs/Template:prevnext/doc.wikitext
+++ b/docs/Template:prevnext/doc.wikitext
@@ -1,0 +1,35 @@
+Bottom-of-page navigation between the steps of the documentation, as a row of one or two links.
+
+== Usage ==
+
+ <nowiki>{{prevnext|next step}}
+{{prevnext|previous step|next step}}</nowiki>
+
+Each argument is a page name, not a link label: it is the link target, and the link text is the
+target's own title.
+
+== Translated pages ==
+
+A prevnext sits outside the <code>&lt;translate&gt;</code> tags, so it is copied whole into every
+translation of the page it is on. That is why it takes page names alone: a label passed in would be
+a second copy of the target's title in every page that links to it, and one nothing checks, so
+renaming a page would leave the links to it quietly wrong in every language.
+
+<code>Template:prevnext/label</code> reads that title instead, from the one place it is translated:
+the target's <code>title</code> unit, which the build writes to Translate's "Page display title"
+unit. <code>TRANSLATIONLANGUAGE</code> outside the translate tags is the language of the page the
+link sits on, which is the one a static export needs, a page being exported once for its own
+language rather than served per reader. Meta-Wiki's
+[https://meta.wikimedia.org/wiki/Template:Page_display_title <code><nowiki>{{Page display title}}</nowiki></code>]
+does the same lookup for the labels of its localized links.
+
+A target with no translated title falls back to its page name: a page in the source language, one
+with no translation, one that fixes its own <code>DISPLAYTITLE</code>, and one whose translated
+title is out of date, which the build leaves out so the page keeps its untranslated title. All of
+them read the English the target's own heading shows. A site with no Translate loaded looks up a
+page in a namespace that does not exist, so the fallback is the whole behaviour there.
+
+Neither template writes <code>&lt;translate&gt;</code> in its own syntax, in a comment or anywhere
+else. Translate reads the raw wikitext before any tag is stripped and only <code>&lt;nowiki&gt;</code>
+hides one from it, so an opening tag written to explain the template is one it counts, and a page
+carrying it without a closing tag is one it refuses.

--- a/docs/Template:prevnext/doc.wikitext
+++ b/docs/Template:prevnext/doc.wikitext
@@ -17,17 +17,19 @@ renaming a page would leave the links to it quietly wrong in every language.
 
 <code>Template:prevnext/label</code> reads that title instead, from the one place it is translated:
 the target's <code>title</code> unit, which the build writes to Translate's "Page display title"
-unit. <code>TRANSLATIONLANGUAGE</code> outside the translate tags is the language of the page the
-link sits on, which is the one a static export needs, a page being exported once for its own
-language rather than served per reader. Meta-Wiki's
+unit. Which language to read is Translate's own <code>#translation:</code>, which is
+<code>/<var>code</var></code> on a translation page and empty on the page it was translated from,
+so the source page asks for a unit that does not exist and falls back. Meta-Wiki's
 [https://meta.wikimedia.org/wiki/Template:Page_display_title <code><nowiki>{{Page display title}}</nowiki></code>]
-does the same lookup for the labels of its localized links.
+does the same lookup for the labels of its localized links, keyed on the reader's interface
+language rather than the page's; a page baked once per language has no reader to ask.
 
 A target with no translated title falls back to its page name: a page in the source language, one
 with no translation, one that fixes its own <code>DISPLAYTITLE</code>, and one whose translated
 title is out of date, which the build leaves out so the page keeps its untranslated title. All of
-them read the English the target's own heading shows. A site with no Translate loaded looks up a
-page in a namespace that does not exist, so the fallback is the whole behaviour there.
+them read the English the target's own heading shows. A site with no Translate loaded has no
+<code>Translations:</code> namespace and no <code>#translation:</code> either, so the fallback is
+the whole behaviour there.
 
 Neither template writes <code>&lt;translate&gt;</code> in its own syntax, in a comment or anywhere
 else. Translate reads the raw wikitext before any tag is stripped and only <code>&lt;nowiki&gt;</code>

--- a/docs/Template:prevnext/label.wikitext
+++ b/docs/Template:prevnext/label.wikitext
@@ -1,21 +1,3 @@
-<!--
-The text of one step's link: the target page's own title, in the language of the page the link sits
-on, read from the one place that title is translated -- the target's reserved title unit, which the
-build writes to Translate's "Page display title" unit. Nothing here is translated, so a renamed or
-retranslated page carries its links with it.
-
-Outside a translate tag -- where a prevnext always is, being copied whole into each translation --
-TRANSLATIONLANGUAGE is the language of the page it sits on, which is what a static export needs: a
-page is exported once, so the language is the page's, not the reader's. (The tag is not named here
-in its own syntax on purpose: Translate reads one anywhere in the wikitext, comment or not, and an
-opening tag with no closing one is a page it refuses.)
-
-A target whose title unit is missing falls back to the page name, which is its title in the source
-language anyway. That covers a source-language page, a page with no translation, one that fixes its
-own DISPLAYTITLE, and one whose translated title is out of date -- the build leaves that unit out,
-so the link reads the same English the target's own heading does. Without Translate loaded at all,
-the lookup is for a page in no namespace, which does not exist either, and the fallback is the whole
-behaviour.
-
---><!--
--->{{#ifexist:Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}|{{Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}}}|{{{1|}}}}}
+{{#ifexist:Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}|{{Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}}}|{{{1|}}}}}<noinclude>
+{{prevnext/doc}}
+</noinclude>

--- a/docs/Template:prevnext/label.wikitext
+++ b/docs/Template:prevnext/label.wikitext
@@ -1,3 +1,2 @@
-{{#ifexist:Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}|{{Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}}}|{{{1|}}}}}<noinclude>
-{{prevnext/doc}}
-</noinclude>
+{{#ifexist:Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}|{{Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}}}|{{{1|}}}}}<span class="wikven-label-probe">[tl={{TRANSLATIONLANGUAGE}}][pl={{PAGELANGUAGE}}][int={{int:lang}}][tr={{#translation:}}][unit-ko={{#ifexist:Translations:{{{1|}}}/Page display title/ko|yes|no}}]</span><noinclude>
+{{prevnext/doc}}</noinclude>

--- a/docs/Template:prevnext/label.wikitext
+++ b/docs/Template:prevnext/label.wikitext
@@ -1,2 +1,2 @@
-{{#ifexist:Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}|{{Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}}}|{{{1|}}}}}<span class="wikven-label-probe">[tl={{TRANSLATIONLANGUAGE}}][pl={{PAGELANGUAGE}}][int={{int:lang}}][tr={{#translation:}}][unit-ko={{#ifexist:Translations:{{{1|}}}/Page display title/ko|yes|no}}]</span><noinclude>
-{{prevnext/doc}}</noinclude>
+<onlyinclude>{{#ifexist:Translations:{{{1|}}}/Page display title{{#translation:}}|{{Translations:{{{1|}}}/Page display title{{#translation:}}}}|{{{1|}}}}}</onlyinclude>
+{{prevnext/doc}}

--- a/docs/Template:prevnext/label.wikitext
+++ b/docs/Template:prevnext/label.wikitext
@@ -4,8 +4,11 @@ on, read from the one place that title is translated -- the target's reserved ti
 build writes to Translate's "Page display title" unit. Nothing here is translated, so a renamed or
 retranslated page carries its links with it.
 
-Outside <translate>, TRANSLATIONLANGUAGE is the language of the page it sits on, which is what a
-static export needs: a page is exported once, so the language is the page's, not the reader's.
+Outside a translate tag -- where a prevnext always is, being copied whole into each translation --
+TRANSLATIONLANGUAGE is the language of the page it sits on, which is what a static export needs: a
+page is exported once, so the language is the page's, not the reader's. (The tag is not named here
+in its own syntax on purpose: Translate reads one anywhere in the wikitext, comment or not, and an
+opening tag with no closing one is a page it refuses.)
 
 A target whose title unit is missing falls back to the page name, which is its title in the source
 language anyway. That covers a source-language page, a page with no translation, one that fixes its

--- a/docs/Template:prevnext/label.wikitext
+++ b/docs/Template:prevnext/label.wikitext
@@ -1,0 +1,18 @@
+<!--
+The text of one step's link: the target page's own title, in the language of the page the link sits
+on, read from the one place that title is translated -- the target's reserved title unit, which the
+build writes to Translate's "Page display title" unit. Nothing here is translated, so a renamed or
+retranslated page carries its links with it.
+
+Outside <translate>, TRANSLATIONLANGUAGE is the language of the page it sits on, which is what a
+static export needs: a page is exported once, so the language is the page's, not the reader's.
+
+A target whose title unit is missing falls back to the page name, which is its title in the source
+language anyway. That covers a source-language page, a page with no translation, one that fixes its
+own DISPLAYTITLE, and one whose translated title is out of date -- the build leaves that unit out,
+so the link reads the same English the target's own heading does. Without Translate loaded at all,
+the lookup is for a page in no namespace, which does not exist either, and the fallback is the whole
+behaviour.
+
+--><!--
+-->{{#ifexist:Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}|{{Translations:{{{1|}}}/Page display title/{{TRANSLATIONLANGUAGE}}}}|{{{1|}}}}}


### PR DESCRIPTION
## Why

`{{prevnext}}` sits outside the translate tags, so it is copied verbatim into every translation page. Its link text was the page name it was given, so a reader on `Searching/ko` followed a link that went to the Korean page under an English label: "Translating", never "번역".

The translated title is not missing. It is already written exactly once, in the target's own translation file, under the reserved title unit the build hands to Translate as its "Page display title" unit. Passing the label to `{{prevnext}}` as one more argument would have made a second copy of that string in every page that links to the target, and one that nothing checks: `translate check` follows the units of a page, and a label typed into a caller is not one of them, so renaming a page would leave every link to it quietly wrong in every language.

## What

`{{prevnext}}` now takes its link text from that unit instead of restating it, through a `Template:prevnext/label` subpage beside the existing `styles.css`:

```wikitext
{{#ifexist:Translations:{{{1|}}}/Page display title{{#translation:}}
  |{{Translations:{{{1|}}}/Page display title{{#translation:}}}}
  |{{{1|}}}}}
```

`#translation:` is Translate's own: `/<code>` on a translation page and empty on the page it was translated from. That spells the unit's name directly — `Translations:Translating/Page display title/ko` on the Korean page, and on the source page a title with no language at all, which does not exist and falls back. Meta-Wiki's [`{{Page display title}}`](https://meta.wikimedia.org/wiki/Template:Page_display_title) does the same lookup for the labels of its localized links, keyed on `{{int:lang}}` — the reader's interface language, which a page baked once per language has no reader to ask, and which is not even a message this wiki has.

The fallback carries every case where a target has no translated title: a source-language page, a target with no translation, one that fixes its own `DISPLAYTITLE` (`Search`), and one whose translated title is stale, which the build leaves out so the page keeps its untranslated title. All of them read the page name, which is the English the target's own heading already shows. A site with no Translate loaded has no `Translations:` namespace and no `#translation:` either, so the fallback is the whole behaviour there.

No new string to translate, and a retranslated or renamed title carries its links with it.

The notes for both templates moved to a `Template:prevnext/doc` subpage, transcluded under `noinclude`, rather than sitting as a comment longer than the template it explained.

## How it was checked

A bake, because the value of a magic word at parse time is not something the wikitext can be read for. The first attempt keyed the lookup on `{{TRANSLATIONLANGUAGE}}`, and the bake showed the labels still in English; a probe rendered into the page said why:

```
[tl=Template:TRANSLATIONLANGUAGE (page does not exist)] [pl=ko] [int=⧼lang⧽] [tr=/ko] [unit-ko=yes]
```

There is no such magic word here — the name expanded to a red link to a template by that name, which then sat inside the title being looked up. The same probe confirmed the unit page exists under the name assumed for it all along, and that `#translation:` reports `/ko`.

So the smoke checks now assert it, beside the webfonts and language-bar assertions that watch the same output: the prevnext on `Searching/ko` must carry the Korean title read out of `docs/Translating/ko.wikitext`, rather than a Korean string pinned in the workflow, which would pass on any Korean the page happened to show.

## Not in this change

The page order is still written twice, once as `MediaWiki:Sidebar` and once as the arguments of each call, and the two already disagree — #455 has the evidence and the proposal.
