### PR TITLE
fix: settle the search bundle's language order between bakes

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,5 +2,10 @@
 extend-exclude = ["package-lock.json"]
 
 [default]
-# Translate staleness stamps (<!--T:n @<hex>-->) are md5 fragments, not words.
-extend-ignore-re = ['<!--T:\d+ @[0-9a-f]{8}-->']
+extend-ignore-re = [
+  # Translate staleness stamps (<!--T:n @<hex>-->) are md5 fragments, not words.
+  '<!--T:\d+ @[0-9a-f]{8}-->',
+  # Pagefind names each language's index after a hex digest of it ("ko_72ba3bbda7"), and a test
+  # that pins the bundle's entry file quotes them verbatim. Hex, not words.
+  '\b[a-z]{2,3}_[0-9a-f]{10}\b',
+]

--- a/includes/Search.php
+++ b/includes/Search.php
@@ -91,4 +91,45 @@ class Search {
 		}
 		return substr($path, 0, $cut + 1) . $directory . '/' . $segment . '/';
 	}
+
+	/** The file in the bundle that names each language's index, and the key holding that map. */
+	public const INDEX_ENTRY_FILE = 'pagefind-entry.json';
+	private const INDEX_ENTRY_LANGUAGES = 'languages';
+
+	/**
+	 * The bundle's entry file with its language map in a fixed order, or null to leave it alone.
+	 *
+	 * Pagefind writes the map in whatever order it iterated the languages, which is not the same
+	 * order twice, so two bakes of one source disagree on this file while agreeing on every index
+	 * it points at -- the hashes and page counts come out identical. A site with one language never
+	 * showed it, having nothing to order; a translated site does, and it broke the promise that two
+	 * bakes are byte-identical (#411). This is the same work as StripBuildStamps: the build owns
+	 * that promise, so the build settles what a tool upstream of it left unsettled.
+	 *
+	 * Only the order changes, and only of that one map. Key order carries no meaning in JSON, so
+	 * nothing that reads the bundle can tell -- the client looks languages up by name.
+	 *
+	 * Re-encoding need not reproduce Pagefind's own bytes, only the same bytes every time, which is
+	 * all the promise asks; the flags keep it close anyway, so a diff against an older bake stays
+	 * readable. Anything this cannot parse, or that does not hold the map, is returned as null and
+	 * left as it is: a bundle this does not understand is not one to rewrite.
+	 *
+	 * @param string $json The contents of pagefind-entry.json.
+	 * @return ?string The re-encoded file, or null when there is nothing safe to do.
+	 */
+	public static function stableIndexEntry(string $json): ?string {
+		$entry = json_decode($json, true);
+		if (!is_array($entry) || !isset($entry[self::INDEX_ENTRY_LANGUAGES])) {
+			return null;
+		}
+		$languages = $entry[self::INDEX_ENTRY_LANGUAGES];
+		if (!is_array($languages) || $languages === []) {
+			return null;
+		}
+		ksort($languages);
+		$entry[self::INDEX_ENTRY_LANGUAGES] = $languages;
+
+		$encoded = json_encode($entry, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+		return $encoded === false ? null : $encoded;
+	}
 }

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -69,6 +69,9 @@ class Build extends Maintenance {
 		// The content is final here, so this is the last write the database needs and the passes
 		// below can be readers of it.
 		$this->freezePageTouched();
+		// The search index is built by now, by the job runJobs() holds back to the end, and every
+		// skin pass below copies it. Settle it here so the one copy they all take is already stable.
+		$this->stabilizeSearchIndex();
 
 		$skins = $GLOBALS['wgWikvenSkins'] ?? [];
 		if (!$skins) {
@@ -624,6 +627,35 @@ class Build extends Maintenance {
 		// Last, so nothing above walks the bundle looking for pages to rewrite.
 		if ($searchBundle !== null) {
 			$this->copySearchBundle($searchBundle);
+		}
+	}
+
+	/**
+	 * Put the search bundle's entry file in an order it will come out in again next bake.
+	 *
+	 * Pagefind names each language's index in one JSON map and writes that map in whatever order it
+	 * happened to iterate, so two bakes of one source produce two spellings of the same fact: the
+	 * index hashes and page counts match, the order of the languages does not. One language has no
+	 * order to get wrong, which is why this surfaced only once translations were indexed in their
+	 * own language rather than all as the wiki's.
+	 *
+	 * Reproducibility is the build's promise (#411), not the indexer's, so the build keeps it --
+	 * exactly as StripBuildStamps drops the per-request ids MediaWiki leaves in a page. Search
+	 * explains what is safe to rewrite and why nothing reading the bundle can tell.
+	 */
+	private function stabilizeSearchIndex(): void {
+		$bundle = rtrim((string)( $GLOBALS['wgSifterSearchOutputDir'] ?? '' ), '/');
+		if ($bundle === '') {
+			return;
+		}
+		$path = "$bundle/" . Search::INDEX_ENTRY_FILE;
+		if (!is_file($path)) {
+			// Search is off, or on with nothing indexed. Either way there is no bundle to settle.
+			return;
+		}
+		$stable = Search::stableIndexEntry((string)file_get_contents($path));
+		if ($stable !== null) {
+			file_put_contents($path, $stable);
 		}
 	}
 

--- a/tests/phpunit/integration/SearchTest.php
+++ b/tests/phpunit/integration/SearchTest.php
@@ -82,4 +82,79 @@ class SearchTest extends MediaWikiIntegrationTestCase {
 			'no copy directory' => ['/wikven/pagefind/', '', null]
 		];
 	}
+
+	/** The two spellings a bake of the docs site produced of one index, differing only in order. */
+	private const ENTRY_KO_FIRST =
+		'{"version":"1.5.2","languages":'
+			. '{"ko":{"hash":"ko_72ba3bbda7","wasm":null,"page_count":19},'
+			. '"en":{"hash":"en_e66da688eb","wasm":"en","page_count":39},'
+			. '"km":{"hash":"km_8ad2c8bfcb","wasm":null,"page_count":1}},'
+			. '"include_characters":["_","‿","⁀","⁔","︳","︴","﹍","﹎","﹏","＿"]}';
+	private const ENTRY_EN_FIRST =
+		'{"version":"1.5.2","languages":'
+			. '{"en":{"hash":"en_e66da688eb","wasm":"en","page_count":39},'
+			. '"ko":{"hash":"ko_72ba3bbda7","wasm":null,"page_count":19},'
+			. '"km":{"hash":"km_8ad2c8bfcb","wasm":null,"page_count":1}},'
+			. '"include_characters":["_","‿","⁀","⁔","︳","︴","﹍","﹎","﹏","＿"]}';
+
+	/**
+	 * The fixtures are the real thing: the two files a single source produced on one runner, which
+	 * agreed on every hash and page count and disagreed on the order alone. That is the whole
+	 * failure, and normalising is what makes the two bakes byte-identical again (#411).
+	 */
+	public function testStableIndexEntrySettlesTheLanguageOrder() {
+		$this->assertNotSame(
+			self::ENTRY_KO_FIRST,
+			self::ENTRY_EN_FIRST,
+			'fixtures must differ, or this asserts nothing'
+		);
+		$this->assertSame(
+			Search::stableIndexEntry(self::ENTRY_KO_FIRST),
+			Search::stableIndexEntry(self::ENTRY_EN_FIRST)
+		);
+	}
+
+	/**
+	 * Only the order of that one map may move. The version and the character list keep their place,
+	 * and the characters keep their bytes -- escaping them to ‿ would make this file differ
+	 * from an older bake for no reason, which is the very thing being fixed.
+	 */
+	public function testStableIndexEntryChangesNothingButTheOrder() {
+		$stable = Search::stableIndexEntry(self::ENTRY_KO_FIRST);
+
+		$this->assertSame(
+			[
+				'version' => '1.5.2',
+				'languages' => [
+					'en' => ['hash' => 'en_e66da688eb', 'wasm' => 'en', 'page_count' => 39],
+					'km' => ['hash' => 'km_8ad2c8bfcb', 'wasm' => null, 'page_count' => 1],
+					'ko' => ['hash' => 'ko_72ba3bbda7', 'wasm' => null, 'page_count' => 19]
+				],
+				'include_characters' => ['_', '‿', '⁀', '⁔', '︳', '︴', '﹍', '﹎', '﹏', '＿']
+			],
+			json_decode((string)$stable, true)
+		);
+		$this->assertStringContainsString('"include_characters":["_","‿"', (string)$stable);
+		$this->assertStringStartsWith('{"version":"1.5.2","languages":{"en"', (string)$stable);
+	}
+
+	/**
+	 * @dataProvider provideUnrewritableEntries
+	 */
+	public function testStableIndexEntryLeavesWhatItCannotReadAlone(string $json) {
+		$this->assertNull(Search::stableIndexEntry($json));
+	}
+
+	public static function provideUnrewritableEntries() {
+		return [
+			// A bundle whose entry file this does not recognise is not one to rewrite: answering
+			// null leaves the file exactly as Pagefind wrote it.
+			'not json' => ['<!DOCTYPE html>'],
+			'truncated' => ['{"version":"1.5.2","languages":{'],
+			'no language map' => ['{"version":"1.5.2"}'],
+			'languages is not a map' => ['{"languages":"en"}'],
+			// Nothing to order, so nothing to settle; rewriting would only risk the bytes.
+			'no languages yet' => ['{"version":"1.5.2","languages":{}}']
+		];
+	}
 }


### PR DESCRIPTION
Split out of #447, which verified it. This is the half that can land now; the nightly pin and the smoke assertion that goes with it stay there, since they need each other and both wait on a formal SifterSearch release.

## The bug

Pagefind names each language's index in one JSON map in `pagefind-entry.json` and writes that map in whatever order it iterated, which is not the same order twice. Two bakes of one source then produce two spellings of the same fact — identical index hashes and page counts, different language order:

```
< {"languages":{"ko":{"hash":"ko_72ba3bbda7",…},"en":{"hash":"en_e66da688eb",…},"km":{…}},…}
> {"languages":{"en":{"hash":"en_e66da688eb",…},"ko":{"hash":"ko_72ba3bbda7",…},"km":{…}},…}
```

**This site does not show it yet.** Every page is indexed as the wiki's content language today, so there is one language and no order to get wrong. It appears the moment translations are indexed in their own, which is what chaotic-ground/SifterSearch#69 does — a bake against that build holds three (en 39, ko 19, km 1) and #411's two-bake check fails on this one file, in the root bundle and in both skin copies of it.

## Why it lands before the pin moves

So the bump that brings the language fix in just passes. Otherwise that PR fails the reproducibility check for a reason that has nothing to do with what it changed, and whoever opens it — updatecli, most likely — gets to work out why.

## Where the fix belongs

Reproducibility is this build's promise (#411), not the indexer's, so the build keeps it. That is the same work `StripBuildStamps` already does for the per-request ids MediaWiki leaves in a page: something upstream writes a value that varies per build, and the build settles it.

Key order carries no meaning in JSON and the client looks a language up by name, so sorting the map changes nothing any reader of the bundle can tell.

`Build::stabilizeSearchIndex()` runs in the orchestrator, after the index job `runJobs()` holds back to the end and before the skin passes, so the one bundle they all copy is already settled — nothing to do per pass.

## What the re-encode is careful about

It does not try to reproduce Pagefind's bytes, only the same bytes every time, which is all the promise asks — so a change in Pagefind's own formatting cannot quietly break this. The flags keep it close anyway, so a diff against an older bake stays readable; escaping the `include_characters` list to `‿` would make the file differ for no reason, which is the very thing being fixed.

An entry file that cannot be parsed, or that holds no language map, is returned as `null` and left exactly as Pagefind wrote it. A bundle this does not understand is not one to rewrite.

## Tests

`Search::stableIndexEntry()` is pure, so `SearchTest` covers it directly. The fixtures are the real two files, off one runner, from one source — and the test asserts they differ before asserting they normalise to the same thing, so it cannot pass vacuously.

`typos` reads the `ba` in a Pagefind hash (`ko_72ba3bbda7`) as a misspelling of `by`, so `.typos.toml` learns their shape, beside the entry already there for Translate's own hex stamps.

## Verification

Proven in CI on #447, which pins the nightly carrying SifterSearch#69: the bake produced `en`, `ko` and `km` indexes, and **the two bakes came out identical** — the step that failed before this fix.

On this branch, with the pin still at `v0.7.1`, the change is a no-op in effect: one language, nothing to reorder.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiyBN88bnGhcXVUXkpD7Mc)_