### PR TITLE
docs: give the last page of the chain its previous link

### DIFF
--- a/docs/Licenses.wikitext
+++ b/docs/Licenses.wikitext
@@ -23,3 +23,5 @@ __TOC__
 <!--T:3-->
 The standalone binary is compiled with [https://frankenphp.dev/ FrankenPHP], which also links several Caddy modules; see the FrankenPHP project for their licenses. The Docker image keeps MediaWiki's own <code>COPYING</code>, and each component's full license text is available from its project.
 </translate>
+
+{{prevnext|prev=Writing an extension}}

--- a/docs/Template:prevnext.wikitext
+++ b/docs/Template:prevnext.wikitext
@@ -1,8 +1,11 @@
 <templatestyles src="prevnext/styles.css" /><div class="wikven-prevnext"><!--
-  -->{{#if:{{{2|}}}|
-    <div class="wikven-prevnext-prev">&larr;&nbsp;[[Special:MyLanguage/{{{1|}}}|{{prevnext/label|{{{1|}}}}}]]</div>
+  The next page is the last positional argument, so one argument is a next and two are a previous
+  and a next. The last page of the chain has a previous and no next, which no positional form can
+  spell -- an empty second argument reads the same as an absent one -- so that one names prev=.
+  -->{{#if:{{{2|}}}{{{prev|}}}|
+    <div class="wikven-prevnext-prev">&larr;&nbsp;[[Special:MyLanguage/{{{prev|{{{1|}}}}}}|{{prevnext/label|{{{prev|{{{1|}}}}}}}}]]</div>
   }}<!--
-  --><div class="wikven-prevnext-next">[[Special:MyLanguage/{{{2|{{{1|}}}}}}|{{prevnext/label|{{{2|{{{1|}}}}}}}}]]&nbsp;&rarr;</div><!--
+  -->{{#if:{{{2|{{{1|}}}}}}|<div class="wikven-prevnext-next">[[Special:MyLanguage/{{{2|{{{1|}}}}}}|{{prevnext/label|{{{2|{{{1|}}}}}}}}]]&nbsp;&rarr;</div>}}<!--
 --></div><noinclude>
 {{prevnext/doc}}
 </noinclude>

--- a/docs/Template:prevnext/doc.wikitext
+++ b/docs/Template:prevnext/doc.wikitext
@@ -3,10 +3,16 @@ Bottom-of-page navigation between the steps of the documentation, as a row of on
 == Usage ==
 
  <nowiki>{{prevnext|next step}}
-{{prevnext|previous step|next step}}</nowiki>
+{{prevnext|previous step|next step}}
+{{prevnext|prev=previous step}}</nowiki>
 
 Each argument is a page name, not a link label: it is the link target, and the link text is the
 target's own title.
+
+The next page is the last positional argument, so one of them is a next and two are a previous and
+a next. The last page of the chain is the one form that leaves out: it has a previous and no next,
+and an empty second argument reads the same as an absent one, so there is no positional way to say
+it. That page names <code>prev=</code> instead, which is otherwise the same previous link.
 
 == Translated pages ==
 


### PR DESCRIPTION
## Why

`Licenses` ends the documentation chain and was the one page carrying no `{{prevnext}}` at all. That was not an oversight in the page — the template had no form for it.

The next page is the last positional argument, so one argument is a next and two are a previous and a next. A trailing empty argument (`{{prevnext|Writing an extension|}}`) reads exactly like an absent one, so "a previous and no next" was unspellable.

## What

That one case gets a name: `prev=`. Everything else is unchanged, positional and all.

```wikitext
{{prevnext|next step}}
{{prevnext|previous step|next step}}
{{prevnext|prev=previous step}}
```

Both links resolve from the same two expressions:

| | |
|---|---|
| previous | `{{{prev}}}`, or the first argument when a second one follows |
| next | the second argument, or the first when it stands alone |

The previous link renders when either of those is present; the next link renders when there is a page for it. This falls out rather than being special-cased, which is why `prev=` beside a positional argument still reads as previous and next instead of becoming a fourth form to remember.

`Licenses` then gets `{{prevnext|prev=Writing an extension}}`, and the chain runs unbroken from `index` to it.

## Notes

- **No layout change needed.** A row with one link in it has been the first page's shape all along (`{{prevnext|Why wikitext}}` on `index`); a lone previous floats to the other side and the existing `overflow: hidden` container wraps it.
- **No new translation units.** A prevnext sits outside the `<translate>` tags, so it is copied whole into every translation; `translate check` reports every unit ok, unchanged.
- The template's `/doc` documents the third form and why it exists.
- Verified by hand against all three call forms; the smoke job bakes the site, which is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcBnCZ3Wf6FNdt8rD8Y4bP)_