### PR TITLE
docs: give the last step of the prevnext chain its way back

### DIFF
--- a/docs/Licenses.wikitext
+++ b/docs/Licenses.wikitext
@@ -23,3 +23,5 @@ __TOC__
 <!--T:3-->
 The standalone binary is compiled with [https://frankenphp.dev/ FrankenPHP], which also links several Caddy modules; see the FrankenPHP project for their licenses. The Docker image keeps MediaWiki's own <code>COPYING</code>, and each component's full license text is available from its project.
 </translate>
+
+{{prevnext|Writing an extension|}}

--- a/docs/Template:prevnext.wikitext
+++ b/docs/Template:prevnext.wikitext
@@ -1,8 +1,6 @@
 <templatestyles src="prevnext/styles.css" /><div class="wikven-prevnext"><!--
-  -->{{#if:{{{2|}}}|
-    <div class="wikven-prevnext-prev">&larr;&nbsp;[[Special:MyLanguage/{{{1|}}}|{{prevnext/label|{{{1|}}}}}]]</div>
-  }}<!--
-  --><div class="wikven-prevnext-next">[[Special:MyLanguage/{{{2|{{{1|}}}}}}|{{prevnext/label|{{{2|{{{1|}}}}}}}}]]&nbsp;&rarr;</div><!--
+  -->{{#if:{{{1|}}}|<div class="wikven-prevnext-prev">&larr;&nbsp;[[Special:MyLanguage/{{{1}}}|{{prevnext/label|{{{1}}}}}]]</div>}}<!--
+  -->{{#if:{{{2|}}}|<div class="wikven-prevnext-next">[[Special:MyLanguage/{{{2}}}|{{prevnext/label|{{{2}}}}}]]&nbsp;&rarr;</div>}}<!--
 --></div><noinclude>
 {{prevnext/doc}}
 </noinclude>

--- a/docs/Template:prevnext/doc.wikitext
+++ b/docs/Template:prevnext/doc.wikitext
@@ -2,11 +2,14 @@ Bottom-of-page navigation between the steps of the documentation, as a row of on
 
 == Usage ==
 
- <nowiki>{{prevnext|next step}}
-{{prevnext|previous step|next step}}</nowiki>
+ <nowiki>{{prevnext|previous step|next step}}
+{{prevnext||next step}}
+{{prevnext|previous step|}}</nowiki>
 
-Each argument is a page name, not a link label: it is the link target, and the link text is the
-target's own title.
+The first argument is always the step before this page and the second always the step after it, so
+an end of the chain leaves its own side empty: the first page has nothing before it, the last has
+nothing after it. Both are page names rather than link labels — the name is the link target, and
+the link text is the target's own title.
 
 == Translated pages ==
 

--- a/docs/Why wikitext.wikitext
+++ b/docs/Why wikitext.wikitext
@@ -30,4 +30,4 @@ __TOC__
 That last cost, running MediaWiki, is the one {{SITENAME}} removes: it renders your wikitext through MediaWiki once, at build time, and ships plain static HTML. You get templates, parser functions and the rest with nothing to run in production. Reach for {{SITENAME}} when that trade is worth it, typically when your content is already wikitext, or when templates and transclusion would save real work.
 </translate>
 
-{{prevnext|Installation}}
+{{prevnext||Installation}}

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -54,5 +54,5 @@ These need a live wiki, so they are not part of the static export:
 What replaces some of them is written down: the reader's own display choices are on a [[<tvar name="1">Special:MyLanguage/Skins#Settings</tvar>|Settings page]] the build writes, and searching is [[<tvar name="2">Special:MyLanguage/Searching</tvar>|done in the browser]].
 </translate>
 
-{{prevnext|Why wikitext}}
+{{prevnext||Why wikitext}}
 {{DISPLAYTITLE:Wikven}}


### PR DESCRIPTION
Closes the one gap left in #455's evidence. Most of what that issue reported was fixed hours earlier by #452, which wired `Commands`, `Development` and `Writing an extension` into the chain; the issue has been corrected to say so. What #452 could not reach is the end of the chain.

## The gap

`Writing an extension`'s next link points at `Licenses`, and `Licenses` carries no navigation at all. A reader who follows that link arrives at the last page of the documentation with no way back and nothing telling them they have reached the end.

It could not have one. The template read a single argument as the *next* step, so the two ends of the chain were not symmetrical:

| | before | |
| --- | --- | --- |
| first page | `{{prevnext|Installation}}` | nothing before it — expressible |
| last page | — | nothing after it — **not expressible** |

## The change

The first argument is the previous step and the second is the next, each side left empty where the chain ends:

```wikitext
{{prevnext|previous step|next step}}
{{prevnext||next step}}
{{prevnext|previous step|}}
```

That drops the template's `{{{2|{{{1}}}}}}` fallback — the one that made a lone argument mean "next" — so both edges now read the same way, and the template is shorter than it was.

Rendering changes for exactly one page. `index` and `Why wikitext` move to the empty-first-argument form and come out byte-identical; `Licenses` gains the row it was missing.

## What it looks like now

The chain walks the sidebar's 19 entries in the sidebar's order and stops where the sidebar does:

```
index → Why wikitext → Installation → Getting Started → Pages → Editing sidebar → Images
      → Skins → Extensions → JavaScript → Searching → Translating → Deploying
      → Troubleshooting → Configuration → Standalone binary → Commands → Development
      → Writing an extension → Licenses ∎
```

Every sidebar entry has a prevnext, every back-link points at the page that links forward to it, and `index` remains the head that the sidebar does not list.

## Not in this change

The order is still written twice, once here and once as `MediaWiki:Sidebar`. This fixes the drift, not its cause — #455 holds the proposal for the cause, including the cheaper half of it: a check that the chain and the sidebar agree, which is what would have caught both this gap and the one #452 closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MF7PF8rEfvLS4z1jpsGgsL)_