### PR TITLE
fix: index a translated page once, not once per title it has

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -114,11 +114,23 @@ jobs:
             fi
           done
 
-          # The counts above also carry #454: marking a page for translation gives it a translation
-          # page in the source language too, so "Installation" and "Installation/en" hold the same
-          # English text under two titles and English was counted twice for every translated page.
-          # Only the source page is indexed now. What that leaves is not asserted yet -- the number
-          # is read off this run first, since a figure guessed here would gate every future bake.
+          # Marking a page for translation gives it a translation page in the source language too,
+          # so "Installation" and "Installation/en" hold the same English text under two titles and
+          # English was counted twice for every translated page (#454). Only the source page is
+          # indexed now, and what says so is the absence of any "/en.html" from the English index --
+          # a count would not, since the pages indexed are not the source files: the build generates
+          # Settings, which has no file, and the search results page has a file but is not indexed.
+          # Those two cancelled out the day this was written, so a count read off the source tree
+          # would have passed by luck and broken on the next page added.
+          #
+          # This reads Pagefind's fragments, which are gzipped JSON carrying the page's url.
+          if for f in dist/pagefind/fragment/en_*; do
+               gzip -dc "$f" 2>/dev/null || cat "$f"
+             done | grep -q '"url":"[^"]*/en\.html"'; then
+            echo "::error::the en index holds a /en.html page, which restates its source page"
+            echo "::error::a source-language translation page is being indexed beside its source"
+            exit 1
+          fi
 
           # Every printfooter "Retrieved from" link must resolve from the page that carries it
           # (#394). Core builds it from the page's own URL and expands away the "./" wikven writes,

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -114,6 +114,12 @@ jobs:
             fi
           done
 
+          # The counts above also carry #454: marking a page for translation gives it a translation
+          # page in the source language too, so "Installation" and "Installation/en" hold the same
+          # English text under two titles and English was counted twice for every translated page.
+          # Only the source page is indexed now. What that leaves is not asserted yet -- the number
+          # is read off this run first, since a figure guessed here would gate every future bake.
+
           # Every printfooter "Retrieved from" link must resolve from the page that carries it
           # (#394). Core builds it from the page's own URL and expands away the "./" wikven writes,
           # so a page exported into a subdirectory needs the "../" per level rename.php adds; the

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 ARG TARGETARCH
-ARG SIFTERSEARCH_VERSION=v0.7.2
+ARG SIFTERSEARCH_VERSION=v0.8.0
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \
  && curl -fsSL "https://github.com/chaotic-ground/SifterSearch/releases/download/${SIFTERSEARCH_VERSION}/SifterSearch-linux-${arch}.tar.gz" \

--- a/extension.json
+++ b/extension.json
@@ -54,7 +54,8 @@
 		"BeforePageDisplay": "adder",
 		"GetLocalURL": "main",
 		"OutputPageAfterGetHeadLinksArray": "main",
-		"SetupAfterCache": ["retrier", "main"]
+		"SetupAfterCache": ["retrier", "main"],
+		"SifterSearchIndexPage": "indexer"
 	},
 	"HookHandlers": {
 		"main": {
@@ -66,6 +67,9 @@
 		},
 		"hider": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Hider"
+		},
+		"indexer": {
+			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Indexer"
 		},
 		"retrier": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Retrier"

--- a/includes/Hooks/Indexer.php
+++ b/includes/Hooks/Indexer.php
@@ -31,7 +31,10 @@ class Indexer {
 	 * test suite does not install, and asking it is a static call there is otherwise no way past.
 	 * The rule is the part worth testing; the lookup is one question put to somebody else.
 	 *
-	 * @var callable(Title):?string
+	 * Phan wants the nullable return parenthesised; without that it reads the annotation as far as
+	 * "callable(Title)", gives up on the rest, and then calls the assignment below void.
+	 *
+	 * @var callable(Title):(?string)
 	 */
 	private $sourceLanguageOf;
 

--- a/includes/Hooks/Indexer.php
+++ b/includes/Hooks/Indexer.php
@@ -1,16 +1,13 @@
 <?php
 /**
- * SifterSearch and Translate are optional, image-bundled dependencies that phan does not analyse,
- * so their symbols are undeclared to static analysis here. The hook below is only reached when
- * SifterSearch runs it, and only asks Translate anything once it has said it is loaded.
+ * Translate is an optional, image-bundled dependency that phan does not analyse, so its symbols
+ * are undeclared to static analysis here. It is only asked anything once it has said it is loaded.
  *
- * @phan-file-suppress PhanUndeclaredInterface
  * @phan-file-suppress PhanUndeclaredClassMethod
  */
 
 namespace MediaWiki\Extension\Wikven\Hooks;
 
-use MediaWiki\Extension\SifterSearch\Hook\SifterSearchIndexPageHook;
 use MediaWiki\Extension\Translate\PageTranslation\TranslatablePage;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Title\Title;
@@ -18,9 +15,15 @@ use MediaWiki\Title\Title;
 /**
  * What the search index is asked to leave out.
  *
- * @see \MediaWiki\Extension\SifterSearch\Hook\SifterSearchIndexPageHook
+ * SifterSearch declares SifterSearchIndexPageHook for this, and this does not implement it: the
+ * interface is only on disk where SifterSearch is installed, and a class that implements a missing
+ * one cannot be loaded at all -- not by the test suite, which installs neither. MediaWiki dispatches
+ * a hook by method name regardless, so what the interface buys is a signature check, and what it
+ * costs here is the class being unloadable wherever the optional dependency is absent.
+ *
+ * @see \MediaWiki\Extension\SifterSearch\Hook\SifterSearchIndexPageHook for the signature.
  */
-class Indexer implements SifterSearchIndexPageHook {
+class Indexer {
 	/**
 	 * How the source language of a translation page is looked up.
 	 *
@@ -32,7 +35,10 @@ class Indexer implements SifterSearchIndexPageHook {
 	 */
 	private $sourceLanguageOf;
 
-	/** @param ?callable(Title):?string $sourceLanguageOf Defaults to asking Translate. */
+	/**
+	 * @param callable|null $sourceLanguageOf Takes a Title, answers its source language or null.
+	 *   Defaults to asking Translate.
+	 */
 	public function __construct(?callable $sourceLanguageOf = null) {
 		$this->sourceLanguageOf = $sourceLanguageOf ?? [self::class, 'translateSourceLanguage'];
 	}

--- a/includes/Hooks/Indexer.php
+++ b/includes/Hooks/Indexer.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * SifterSearch and Translate are optional, image-bundled dependencies that phan does not analyse,
+ * so their symbols are undeclared to static analysis here. The hook below is only reached when
+ * SifterSearch runs it, and only asks Translate anything once it has said it is loaded.
+ *
+ * @phan-file-suppress PhanUndeclaredInterface
+ * @phan-file-suppress PhanUndeclaredClassMethod
+ */
 
 namespace MediaWiki\Extension\Wikven\Hooks;
 

--- a/includes/Hooks/Indexer.php
+++ b/includes/Hooks/Indexer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Hooks;
+
+use MediaWiki\Extension\SifterSearch\Hook\SifterSearchIndexPageHook;
+use MediaWiki\Extension\Translate\PageTranslation\TranslatablePage;
+use MediaWiki\Registration\ExtensionRegistry;
+use MediaWiki\Title\Title;
+
+/**
+ * What the search index is asked to leave out.
+ *
+ * @see \MediaWiki\Extension\SifterSearch\Hook\SifterSearchIndexPageHook
+ */
+class Indexer implements SifterSearchIndexPageHook {
+	/**
+	 * Leave out a translation page written in the language it was translated from.
+	 *
+	 * Marking a page for translation gives it a translation page per language, the source language
+	 * included, so "Installation" and "Installation/en" carry the same English text under two
+	 * titles. Both are pages of the export and both are indexed, so an English reader searching is
+	 * offered the same thing twice (#454). Indexing per language cannot separate them, being one
+	 * language by construction, and neither can $wgSifterSearchNamespaces, both being NS_MAIN.
+	 *
+	 * The source page is the one kept. It is where the site's own links land -- resolveTranslationLinks
+	 * sends a Special:MyLanguage link from an untranslated page to the source page, and the export's
+	 * front door, index.html, is the source page of the main page -- and it is the only one of the
+	 * two that a page nobody marked for translation has at all.
+	 *
+	 * What is asked of Translate is whether this is a translation page, not whether the title looks
+	 * like one: isTranslationPage() answers no for a subpage somebody merely named after a language,
+	 * since it checks that the page above it is marked. A wiki that keeps a page called "Foo/en" of
+	 * its own therefore keeps it in the index.
+	 */
+	public function onSifterSearchIndexPage(Title $title, bool &$index) {
+		if (!ExtensionRegistry::getInstance()->isLoaded('Translate')) {
+			// No Translate, no translation pages, and so nothing here duplicating a source page.
+			return;
+		}
+		$translatable = TranslatablePage::isTranslationPage($title);
+		if (!$translatable) {
+			return;
+		}
+		// Safe to read the last segment as the language now that Translate has said this is a
+		// translation page, which is what makes that segment its language code.
+		if ($title->getSubpageText() === $translatable->getSourceLanguageCode()) {
+			$index = false;
+		}
+	}
+}

--- a/includes/Hooks/Indexer.php
+++ b/includes/Hooks/Indexer.php
@@ -22,11 +22,27 @@ use MediaWiki\Title\Title;
  */
 class Indexer implements SifterSearchIndexPageHook {
 	/**
+	 * How the source language of a translation page is looked up.
+	 *
+	 * A seam, so the rule below can be tested without Translate: it is an optional dependency the
+	 * test suite does not install, and asking it is a static call there is otherwise no way past.
+	 * The rule is the part worth testing; the lookup is one question put to somebody else.
+	 *
+	 * @var callable(Title):?string
+	 */
+	private $sourceLanguageOf;
+
+	/** @param ?callable(Title):?string $sourceLanguageOf Defaults to asking Translate. */
+	public function __construct(?callable $sourceLanguageOf = null) {
+		$this->sourceLanguageOf = $sourceLanguageOf ?? [self::class, 'translateSourceLanguage'];
+	}
+
+	/**
 	 * Leave out a translation page written in the language it was translated from.
 	 *
 	 * Marking a page for translation gives it a translation page per language, the source language
 	 * included, so "Installation" and "Installation/en" carry the same English text under two
-	 * titles. Both are pages of the export and both are indexed, so an English reader searching is
+	 * titles. Both are pages of the export and both were indexed, so an English reader searching was
 	 * offered the same thing twice (#454). Indexing per language cannot separate them, being one
 	 * language by construction, and neither can $wgSifterSearchNamespaces, both being NS_MAIN.
 	 *
@@ -34,25 +50,43 @@ class Indexer implements SifterSearchIndexPageHook {
 	 * sends a Special:MyLanguage link from an untranslated page to the source page, and the export's
 	 * front door, index.html, is the source page of the main page -- and it is the only one of the
 	 * two that a page nobody marked for translation has at all.
+	 */
+	public function onSifterSearchIndexPage(Title $title, bool &$index) {
+		$sourceLanguage = ( $this->sourceLanguageOf )($title);
+		if ($sourceLanguage !== null && self::translationLanguage($title) === $sourceLanguage) {
+			$index = false;
+		}
+	}
+
+	/**
+	 * The language a translation page is in: the segment after its source page's title.
+	 *
+	 * Cut here rather than asked of Title::getSubpageText(), which answers with the whole title
+	 * unless subpages are switched on for the namespace -- and nothing switches them on for NS_MAIN,
+	 * where these pages live. Translate names a translation page "<source>/<language>" whatever
+	 * MediaWiki thinks a subpage is, so the last segment is the language either way, and reading it
+	 * as one is safe only because the lookup above has already said this is a translation page.
+	 */
+	private static function translationLanguage(Title $title): ?string {
+		$text = $title->getText();
+		$cut = strrpos($text, '/');
+		return $cut === false ? null : substr($text, $cut + 1);
+	}
+
+	/**
+	 * The language a translation page was translated from, or null where it is not one.
 	 *
 	 * What is asked of Translate is whether this is a translation page, not whether the title looks
 	 * like one: isTranslationPage() answers no for a subpage somebody merely named after a language,
-	 * since it checks that the page above it is marked. A wiki that keeps a page called "Foo/en" of
-	 * its own therefore keeps it in the index.
+	 * since it checks that the page above it is marked for translation. A wiki that keeps a page of
+	 * its own called "Foo/en" therefore keeps it in the index.
 	 */
-	public function onSifterSearchIndexPage(Title $title, bool &$index) {
+	private static function translateSourceLanguage(Title $title): ?string {
 		if (!ExtensionRegistry::getInstance()->isLoaded('Translate')) {
 			// No Translate, no translation pages, and so nothing here duplicating a source page.
-			return;
+			return null;
 		}
 		$translatable = TranslatablePage::isTranslationPage($title);
-		if (!$translatable) {
-			return;
-		}
-		// Safe to read the last segment as the language now that Translate has said this is a
-		// translation page, which is what makes that segment its language code.
-		if ($title->getSubpageText() === $translatable->getSourceLanguageCode()) {
-			$index = false;
-		}
+		return $translatable ? $translatable->getSourceLanguageCode() : null;
 	}
 }

--- a/tests/phpunit/integration/Hooks/IndexerTest.php
+++ b/tests/phpunit/integration/Hooks/IndexerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration\Hooks;
+
+use MediaWiki\Extension\Wikven\Hooks\Indexer;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Hooks\Indexer
+ */
+class IndexerTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * The rule, with the lookup stood in for: a translation page in the language it was translated
+	 * from restates its source page and is left out; anything else stays (#454).
+	 *
+	 * @dataProvider provideTranslationPages
+	 */
+	public function testOnlyASourceLanguageTranslationIsLeftOut(
+		string $title,
+		?string $sourceLanguage,
+		bool $expected
+	) {
+		$indexer = new Indexer(static fn(): ?string => $sourceLanguage);
+
+		$index = true;
+		$indexer->onSifterSearchIndexPage(Title::makeTitle(NS_MAIN, $title), $index);
+
+		$this->assertSame($expected, $index);
+	}
+
+	public static function provideTranslationPages(): array {
+		return [
+			// The duplicate: same English text as "Installation", under a second title.
+			'a translation into the source language' => ['Installation/en', 'en', false],
+			// A reader searching in Korean has nowhere else to find this one.
+			'a translation into another language' => ['Installation/ko', 'en', true],
+			'a translation of a Korean-sourced page' => ['설치/ko', 'ko', false],
+			// null is the lookup saying "not a translation page", which is every ordinary page --
+			// including a subpage somebody merely named after a language.
+			'a page that is not a translation' => ['Installation', null, true],
+			'a subpage named after a language, but not marked' => ['Installation/en', null, true],
+			// A source page keeps its place even where its own language is the one being asked
+			// about: it has no subpage segment to match, so nothing here can catch it.
+			'a source page whose language matches' => ['Installation', 'en', true]
+		];
+	}
+
+	/**
+	 * Built the way MediaWiki builds it, the handler asks Translate, which this suite does not
+	 * install -- so it finds no translation pages and leaves the index alone. That is also what a
+	 * wiki without content translation gets, and it must not be a wiki that loses pages.
+	 */
+	public function testWithoutTranslateNothingIsLeftOut() {
+		$index = true;
+		( new Indexer() )->onSifterSearchIndexPage(Title::makeTitle(NS_MAIN, 'Installation/en'), $index);
+
+		$this->assertTrue($index);
+	}
+}

--- a/tests/phpunit/integration/Hooks/IndexerTest.php
+++ b/tests/phpunit/integration/Hooks/IndexerTest.php
@@ -21,7 +21,9 @@ class IndexerTest extends MediaWikiIntegrationTestCase {
 		?string $sourceLanguage,
 		bool $expected
 	) {
-		$indexer = new Indexer(static fn(): ?string => $sourceLanguage);
+		$indexer = new Indexer(static function () use ($sourceLanguage): ?string {
+			return $sourceLanguage;
+		});
 
 		$index = true;
 		$indexer->onSifterSearchIndexPage(Title::makeTitle(NS_MAIN, $title), $index);


### PR DESCRIPTION
Closes #454. Bumps SifterSearch to **v0.8.0** for the hook it adds (chaotic-ground/SifterSearch#71) and answers it.

## The duplication

Marking a page for translation gives it a translation page in every language, **the source language included**, so the export carries the same English text under two titles:

```
/Installation.html      the source page
/Installation/en.html   the same text, from Translate
```

Both were indexed, so an English reader searching was offered each translated page twice.

Indexing per language (#400) cannot separate them — they are one language by construction — and neither can `$wgSifterSearchNamespaces`, both being `NS_MAIN`. Only the wiki knows one is a restatement of the other, which is why SifterSearch grew a hook to ask.

## Which of the two is kept

The **source page**. Three reasons, in order of weight:

1. It is where the site's own links land. `resolveTranslationLinks` sends a `Special:MyLanguage` link from an untranslated page to the source page, and `/` — the export's front door — is the source page of the main page.
2. It is the only one of the two that a page nobody marked for translation has at all, so keeping it needs no special case for pages like the search results page.
3. Nothing is lost either way: the two hold the same text.

The cost is that a reader browsing the `/en` copy who searches is moved to the source page — the same text, at the title the rest of the site links to.

## Asking Translate rather than guessing

`TranslatablePage::isTranslationPage()` is the authority, not the shape of the title. It checks that the page above is marked:

```php
if ( $page->getMarkedTag() === null ) {
    return false;
}
```

So a wiki that keeps a page of its own called `Foo/en` keeps it in the index — the case a "last segment is a language tag" heuristic would have got wrong. Nothing is asked at all where Translate is not loaded, there being no translation pages to duplicate anything.

## What a local bake says

Baked with this pin, on this branch:

| | before | after |
|---|---|---|
| `en` index | 39 | **22** |
| `ko` index | 19 | 21 |
| `km` index | 1 | 1 |

(`ko` grew because the site gained translated pages meanwhile, not because of this.) Every url in the English index is a source page; **no `/en.html` is left**.

## The assertion is the rule, not the count

22 is also what the source tree has, and asserting that would have been wrong. The two sets are not the same 22:

- the build generates `Settings`, which has no source file (+1);
- the search results page has a source file and is not indexed (−1).

They cancel out today, so a figure derived from `docs/` would have passed by luck and broken on the next page added or removed. What the fix actually promises is that no page restating its source page is indexed, so `smoke` asserts exactly that: **no url under the English index ends in `/en.html`**. That holds however many pages the site grows to.

Checked both ways against the local bake — it passes on the fixed output, and fails when a single `/en.html` fragment is planted in it, so it is an assertion that can fail rather than one that always passes.

## Two faults caught before this ran anywhere

- `Title::getSubpageText()` answers with the whole title unless subpages are enabled for the namespace, and nothing enables them for `NS_MAIN`. The comparison was `"Installation/en"` against `"en"` and never matched, so the rule would have shipped doing nothing at all — and the bake would have looked exactly as it did before.
- Implementing `SifterSearchIndexPageHook` made the class unloadable wherever the interface is absent, which is every environment but a wiki with SifterSearch installed, the test suite included. MediaWiki dispatches a hook by method name, so the interface bought a signature check and cost the class its ability to load.

`mago`, `phpcs` and `phan` were run locally against a MediaWiki checkout for the rest.

---
_Generated by [Claude Code](https://claude.ai/code)_
