### PR TITLE
docs: gate the prevnext chain on MediaWiki:Sidebar's order

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,10 +136,10 @@ jobs:
       - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
       - run: composer phpcs
 
-  # Documentation the code has outgrown reads as documentation, which is worse than none: the two
-  # checks here are the drift that has actually happened, turned into a gate. Both carry an
-  # allowlist rather than a pattern, so a new entry is a decision someone makes rather than a
-  # silence someone inherits.
+  # Documentation the code has outgrown reads as documentation, which is worse than none: every
+  # check here is drift that has actually happened, turned into a gate. The two that carry an
+  # allowlist carry one rather than a pattern, so a new entry is a decision someone makes rather
+  # than a silence someone inherits.
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -187,6 +187,76 @@ jobs:
               echo "::error file=$script::$step is a build step no page under docs/ mentions." \
                    "Describe it in docs/Development.wikitext, or add it to the helper list in" \
                    ".github/workflows/lint.yml if it is documented by command name."
+              status=1
+            fi
+          done
+          exit "$status"
+
+      # The documentation pages are a sequence, and the sequence was written down twice: as the
+      # order of docs/MediaWiki:Sidebar.wikitext, and as the arguments of the {{prevnext}} call at
+      # the bottom of each page. The two had already drifted (#455): three pages reached the sidebar
+      # without ever being wired into the chain, so a reader following it arrived at a page with no
+      # navigation on it at all. Adding a page means editing the sidebar, the new page and the page
+      # before it, and forgetting the third was invisible.
+      #
+      # The sidebar is the order of record because it is the one that cannot read the other: the
+      # skin parses it line by line, so it holds no template that would expand into entries. This
+      # derives the call each page should carry from it and compares, which leaves the order stated
+      # twice but no longer unwatched. Deriving the calls themselves would need string work no
+      # parser function does, and the two ways to get it -- a Lua module, or a build step writing a
+      # lookup page -- cost a Scribunto engine the standalone binary cannot carry, or a wikven
+      # feature that exists for this site alone. See the issue for both.
+      - name: Check every prevnext follows the sidebar order
+        run: |
+          set -euo pipefail
+          # The order of record, read as the skin reads it: one page per "**" entry, with the
+          # Special:MyLanguage/ prefix and the |message-key label cut off. index heads the chain
+          # without being an entry -- the sidebar names it through mainpage, and every skin's logo
+          # leads there -- so it is prepended.
+          chain=(index)
+          while IFS= read -r page; do
+            chain+=("$page")
+          done < <(sed -n 's#^\*\* Special:MyLanguage/\([^|]*\)|.*#\1#p' docs/MediaWiki:Sidebar.wikitext)
+          if [ "${#chain[@]}" -lt 3 ]; then
+            echo "::error file=docs/MediaWiki:Sidebar.wikitext::no page entries read from the sidebar."
+            exit 1
+          fi
+          last=$(( ${#chain[@]} - 1 ))
+          status=0
+          for i in "${!chain[@]}"; do
+            page=${chain[i]}
+            file="docs/$page.wikitext"
+            if [ ! -f "$file" ]; then
+              echo "::error file=docs/MediaWiki:Sidebar.wikitext::the sidebar lists $page, which has" \
+                   "no page under docs/. Add docs/$page.wikitext, or drop the entry."
+              status=1
+              continue
+            fi
+            # Which form the position takes: the last page names prev=, since no positional form
+            # spells a previous with no next; the others pass positional arguments, the next being
+            # the last of them. The first sidebar page has a next alone too, because what precedes
+            # it is index, which readers reach from the logo rather than from the chain.
+            if [ "$i" -eq "$last" ]; then
+              want="{{prevnext|prev=${chain[i - 1]}}}"
+            elif [ "$i" -le 1 ]; then
+              want="{{prevnext|${chain[i + 1]}}}"
+            else
+              want="{{prevnext|${chain[i - 1]}|${chain[i + 1]}}}"
+            fi
+            got=$(grep -F '{{prevnext' "$file" || true)
+            if [ "$got" != "$want" ]; then
+              echo "::error file=$file::MediaWiki:Sidebar puts this page where its navigation should" \
+                   "read $want, and it reads ${got:-nothing}. Fix whichever of the two is wrong."
+              status=1
+            fi
+          done
+          # Navigation on a page the sidebar leaves out points along a sequence it is not part of.
+          for file in docs/*.wikitext; do
+            page=$(basename "$file" .wikitext)
+            case "$page" in Template:*) continue ;; esac
+            if grep -qF '{{prevnext' "$file" && ! printf '%s\n' "${chain[@]}" | grep -qxF "$page"; then
+              echo "::error file=$file::this page has bottom navigation but is not in" \
+                   "MediaWiki:Sidebar. List it there, or drop the call."
               status=1
             fi
           done

--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -181,7 +181,7 @@ The e2e run serves <code>dist/</code> under a <code>/wikven/</code> path prefix,
 == Continuous integration ==
 
 <!--T:23-->
-* <code>lint.yml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, yamllint, zizmor, and phpcs), and checks that every {{SITENAME}} configuration variable is documented.
+* <code>lint.yml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, yamllint, zizmor, and phpcs), and checks that the documentation has kept up: every {{SITENAME}} configuration variable documented, every build step described, and every page's bottom navigation in the order <code>MediaWiki:Sidebar</code> gives.
 * <code>test.yml</code> and <code>quibble.yml</code> run the PHPUnit suites and MediaWiki's own structure tests.
 * <code>smoke.yml</code> bakes this site and asserts the output, in a browser and byte for byte.
 * <code>translations.yml</code> reports out-of-date translations in <code>docs/</code>, through the [[<tvar name="2">Special:MyLanguage/Commands#check-translations</tvar>|check-translations action]].

--- a/docs/Development/ko.wikitext
+++ b/docs/Development/ko.wikitext
@@ -142,8 +142,8 @@ e2e 실행은 GitHub Pages가 그러하듯 <code>dist/</code>를 <code>/wikven/<
 <!--T:22 @9c7c0fee-->
 == 지속적 통합 ==
 
-<!--T:23 @2079509e-->
-* <code>lint.yml</code>은 포매터와 린터(Biome, mago, rumdl, taplo, typos, yamllint, zizmor, phpcs)를 실행하고, {{SITENAME}}의 모든 설정 변수가 문서화되어 있는지 검사합니다.
+<!--T:23 @f98a3d90-->
+* <code>lint.yml</code>은 포매터와 린터(Biome, mago, rumdl, taplo, typos, yamllint, zizmor, phpcs)를 실행하고, 문서가 코드를 따라왔는지 검사합니다. {{SITENAME}}의 모든 설정 변수가 문서화되어 있는지, 모든 빌드 단계가 설명되어 있는지, 그리고 각 문서의 아래쪽 둘러보기가 <code>MediaWiki:Sidebar</code>가 정한 순서를 따르는지입니다.
 * <code>test.yml</code>과 <code>quibble.yml</code>은 PHPUnit 스위트와 MediaWiki 자체의 구조 테스트를 실행합니다.
 * <code>smoke.yml</code>은 이 사이트를 굽고 그 출력을 브라우저에서, 그리고 바이트 단위로 검증합니다.
 * <code>translations.yml</code>은 [[$2|check-translations 액션]]을 통해 <code>docs/</code>의 오래된 번역을 보고합니다.

--- a/docs/Template:prevnext/doc.wikitext
+++ b/docs/Template:prevnext/doc.wikitext
@@ -14,6 +14,21 @@ a next. The last page of the chain is the one form that leaves out: it has a pre
 and an empty second argument reads the same as an absent one, so there is no positional way to say
 it. That page names <code>prev=</code> instead, which is otherwise the same previous link.
 
+== The order ==
+
+Which pages a call names is not the calling page's own decision. The sequence is the one
+<code>MediaWiki:Sidebar</code> lists, and each call restates the two entries on either side of its
+own. <code>index</code> heads the chain without being a sidebar entry, because every skin's logo
+already leads there, so the sidebar's first page has a next alone just as its last page has a
+previous alone.
+
+That leaves the order written down twice, so something has to hold the two copies together: the
+<code>docs</code> job of <code>.github/workflows/lint.yml</code> derives the call each page should
+carry from the sidebar and fails on any page carrying a different one. Adding a page means editing
+the sidebar, the new page and the page before it, and the check is there because forgetting the
+third is otherwise invisible: it once left three pages in the sidebar with no navigation at all, and
+a reader who followed the chain into the first of them had no way onward and no way back.
+
 == Translated pages ==
 
 A prevnext sits outside the <code>&lt;translate&gt;</code> tags, so it is copied whole into every


### PR DESCRIPTION
Takes the middle option of #455 rather than its proposal, and says why below. Refs #455; it does not close it, since the order is still written down twice.

## What the tree looks like now

The drift the issue documents has been repaired by hand in the meantime, so the starting point is different from the one it describes. `Extensions` and `Commands` were added to both the sidebar and the chain; #452 gave `Development` and `Writing an extension` their calls, and #456 gave `Licenses` its `prev=`. The 19 sidebar entries and the chain agree today, entry for entry, and the new check passes on the tree unchanged. What is still missing is anything that keeps them agreeing, which is the half of the issue this fixes.

## The check

One step in `lint.yml`'s `docs` job, beside the two gates #452 added there. It reads `docs/MediaWiki:Sidebar.wikitext` the way the skin does (one page per `**` entry, with the `Special:MyLanguage/` prefix and the `|message-key` label cut off), prepends `index`, then derives the exact call each position should carry and compares it with the one the page has: a next alone at the head, `prev=` alone at the tail, a previous and a next in between. It also fails on a sidebar entry with no page under `docs/`, and on a page that carries navigation without being in the sidebar.

`index` stays the one-way head: the sidebar deliberately has no main-page entry, since every skin's logo leads there, so the first sidebar page keeps its next-alone call rather than gaining a `← Wikven` link. That is the shape the tree has, not a new decision.

## Why a check and not the derivation

Deriving prev and next inside wikitext needs the sidebar's lines split and its prefixes and labels stripped, which no parser function does. The two ways to get that both cost more than the duplication does.

**A Lua module.** The issue asked whether Scribunto runs in the image, and it does: `luasandbox` is compiled into `mediawiki:1.46.0-fpm-alpine`, so that half of the trade is better than the issue assumed. The standalone binary is where it fails. Its PHP is compiled from the extension list in `binary.Dockerfile`, which has no `luasandbox`, and one static executable cannot offer the `lua` binary the standalone engine wants either. The docs site would become a site the binary cannot bake, which is a strange thing for the site that documents the binary.

**A build step writing a lookup page.** This runs in both products, and `build.php` already generates `{{Wikven software}}`, so the shape exists. But it is a wikven feature carried for one site's documentation, it needs its own configuration, its own entry in `Configuration` and `Development`, and its own tests, and it moves "where does this page lead" out of the page source, which is where someone editing the page reads it.

So the order stays written down twice, and the check moves the second copy from unwatched to watched. That is a smaller claim than #455 makes, and it is the honest one.

## Also here

`Development`'s continuous-integration section named one docs gate and there have been two since #452; it now names all three. `Template:prevnext`'s own documentation gains a section on where the order comes from, since that is the file someone editing a call has open. Neither template page is exported, so that one is source-only documentation.

## Verified

The check was run against the tree at 76af7055 (#446, before the repairs), where it reports exactly the three pages the issue names, with the call each one should have carried. It was also run against five synthetic drifts: two sidebar entries swapped, a page added to the sidebar and to itself but not to the page before it, a sidebar entry with no source file, and a `{{prevnext}}` on a page the sidebar leaves out. Each fails with the position named; the unmodified tree passes.

The docs site was baked locally with the image and the whole `smoke.yml` assertion step run over the output: it passes, including the `<languages/>` entry count derived from the source tree and the assertion that `Searching/ko`'s prevnext carries Translating's Korean title. `translate check` in the image reports every translation up to date.

CI is green, `smoke` included. The two-bakes-identical assertion did fail on my machine, in the Korean Pagefind bundle alone and in no HTML file, which is #460 as #456 recorded it; it passed on the runner, so that non-determinism reads as intermittent rather than gone. Nothing here goes near it.
