### PR TITLE
fix: clear the title cache once the translation units exist

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -85,6 +85,16 @@ class BuildTranslations extends Maintenance {
 		// inline per page let the page marked just before another (the main page sorts last) render before
 		// the shared message index caught up, silently producing no <Page>/<lang> page for it.
 		$this->drainJobs();
+		// Deferring the renders is not enough on its own, because the drains above have already done
+		// some: saving a unit page queues a RenderTranslationPageJob for its page, and the drain
+		// inside the next page's prepare() runs it. Those renders asked #ifexist whether units that
+		// did not exist yet existed -- a prevnext label finds its target's translated title that way
+		// -- and Title::newFromText() keeps the instance it answered with, whose "no such page" is
+		// memoized for the life of the process. Creating the page afterwards does not undo it: the
+		// units are made with Title::makeTitle(), which never touches that cache. So every later
+		// render in this process, including the search index's, would go on being told the title is
+		// untranslated and fall back to the English page name (#460, #464).
+		Title::clearCaches();
 		foreach ($prepared as $title) {
 			$this->render($title);
 		}


### PR DESCRIPTION
Two bakes of one source have not been byte-identical since #449, and the whole of the difference was the Korean search index (#460). Under it sat a plainer bug: the search index held English titles where the exported pages held Korean ones (#464), for pages nobody would think to check.

## Where it actually was

Neither Pagefind nor Translate. `Title::newFromText()` keeps its `Title` instances in a process-static LRU, and an instance memoizes `mArticleID = 0` once it has answered "no such page". So the first parse in the process to ask `#ifexist` about a translation unit that does not exist yet binds that title to "missing" for the rest of the run. Creating the unit afterwards does not undo it, because units are written with `Title::makeTitle()`, which never touches that cache.

Measured from inside a running build, same process, same instant:

```
Title::newFromText('Translations:Translating/Page display title/ko')   -> articleID 0
Title::makeTitle(NS_TRANSLATIONS, 'Translating/Page_display_title/ko') -> articleID 760
```

`{{prevnext}}` reaches that path through ParserFunctions, which falls back to `$title->exists()` when LinkCache holds neither a good nor a bad link, so a poisoned title renders as the untranslated page name.

The premature question comes from drains this script already does: saving a unit page queues a `RenderTranslationPageJob` for its page, and the drain inside the *next* page's `prepare()` runs it, so a page renders while units belonging to pages later in the order are still unwritten. #449 deferring our own renders was necessary but not sufficient for this reason.

`dist/` looks right only because the skin passes `proc_open` and get fresh processes. The search index job does not fork, which is why it, alone, kept the stale answers.

## The fix

Clear the caches once every unit is in place, before anything renders for keeps. One line, in the one place where "the wiki is now complete" is true.

## Verified

* Every `{{prevnext}}` label in the search index now matches the exported page: 0 mismatches across 21 Korean pages and every English one, where 6 disagreed before.
* Two consecutive bakes are byte-identical (`diff -rq` silent). Index hashes `en_93af1ecbd2 km_5de7682e9c ko_86b39f6691`.
* Cross-checked against the alternative fix (run the index job in a forked process): identical output, hash for hash. That approach costs an extra MediaWiki boot, leaves the cause in place, and would collide with #461, so it is not what landed.

## Note for #464

The issue frames this as a Korean-index problem. It is not language-specific: the `en` index hash changed too. Any language's parse can be the one that poisons a title.

## Ruled out along the way

Three of my own hypotheses, each disproved by patching the image and rebaking rather than by argument: parser-cache staleness (`OPT_NO_CHECK_CACHE|OPT_NO_UPDATE_CACHE` changed nothing), LinkCache negatives (`clear()` changed nothing, and removes a path that sometimes rescues the lookup), and the units simply being absent (a probe showed every one `exists=YES`).

Closes #460.
Closes #464.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
