### PR TITLE
docs: name both documentation gates, not one

### DIFF
--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -181,7 +181,7 @@ The e2e run serves <code>dist/</code> under a <code>/wikven/</code> path prefix,
 == Continuous integration ==
 
 <!--T:23-->
-* <code>lint.yml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, yamllint, zizmor, and phpcs), and checks that every {{SITENAME}} configuration variable is documented.
+* <code>lint.yml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, yamllint, zizmor, and phpcs), and checks that this site documents every {{SITENAME}} configuration variable and every step of the build.
 * <code>test.yml</code> and <code>quibble.yml</code> run the PHPUnit suites and MediaWiki's own structure tests.
 * <code>smoke.yml</code> bakes this site and asserts the output, in a browser and byte for byte.
 * <code>translations.yml</code> reports out-of-date translations in <code>docs/</code>, through the [[<tvar name="2">Special:MyLanguage/Commands#check-translations</tvar>|check-translations action]].

--- a/docs/Development/ko.wikitext
+++ b/docs/Development/ko.wikitext
@@ -142,8 +142,8 @@ e2e 실행은 GitHub Pages가 그러하듯 <code>dist/</code>를 <code>/wikven/<
 <!--T:22 @9c7c0fee-->
 == 지속적 통합 ==
 
-<!--T:23 @2079509e-->
-* <code>lint.yml</code>은 포매터와 린터(Biome, mago, rumdl, taplo, typos, yamllint, zizmor, phpcs)를 실행하고, {{SITENAME}}의 모든 설정 변수가 문서화되어 있는지 검사합니다.
+<!--T:23 @0b9d15f8-->
+* <code>lint.yml</code>은 포매터와 린터(Biome, mago, rumdl, taplo, typos, yamllint, zizmor, phpcs)를 실행하고, 이 사이트가 {{SITENAME}}의 모든 설정 변수와 빌드의 모든 단계를 문서화하고 있는지 검사합니다.
 * <code>test.yml</code>과 <code>quibble.yml</code>은 PHPUnit 스위트와 MediaWiki 자체의 구조 테스트를 실행합니다.
 * <code>smoke.yml</code>은 이 사이트를 굽고 그 출력을 브라우저에서, 그리고 바이트 단위로 검증합니다.
 * <code>translations.yml</code>은 [[$2|check-translations 액션]]을 통해 <code>docs/</code>의 오래된 번역을 보고합니다.


### PR DESCRIPTION
The Development page lists what CI enforces, and said `lint.yml` checks that every configuration variable is documented. Since #452 it checks the build steps too, so the one page whose job is to describe the gates was out of date about them.

Noticed while closing #463. Korean translation updated and restamped, so `translate check --gate` still reports everything up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)