### PR TITLE
ci: install Playwright's headless shell, not the whole of chromium

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -276,16 +276,23 @@ jobs:
       # The headless shell, not all of "chromium". Asking for chromium fetches Chrome for Testing
       # (379 MiB unpacked) as well as the shell (262 MiB), and these specs never start the former:
       # they run headless, which is what the shell is. ffmpeg (5 MiB) comes along either way, so what
-      # this saves is the 379 MiB, and --with-deps stays because the system libraries it installs are
-      # ones the shell needs as much as the full browser does.
+      # this saves is the 379 MiB.
       #
-      # Ran the suite locally against a real bake with nothing but the shell on disk: 57 passed. If it
-      # were ever not enough -- a spec asking for a headed browser, or for video -- Playwright fails
-      # naming the executable it cannot find, so this cannot quietly test the wrong thing.
+      # And no --with-deps, which is the apt call. The runner image already carries Google Chrome,
+      # Chromium, Edge and Firefox as installed packages, so the shared libraries the shell wants are
+      # on the machine before we ask for anything; --with-deps was buying nothing and paying for it.
+      # Twice -- 2026-08-18 and 2026-08-19 -- azure.archive.ubuntu.com answered nothing at all, apt
+      # fell back to archive.ubuntu.com, took the four InRelease files and then went quiet on the
+      # package indexes until the job was killed. A mirror that is not ours, on a path we do not need.
+      #
+      # Ran the suite locally against a real bake with nothing but the shell on disk: 57 passed. If
+      # either half were ever not enough -- a spec asking for a headed browser, or a library the image
+      # stops shipping -- Playwright says which executable or which .so it cannot find, so this cannot
+      # quietly test the wrong thing.
       - name: Install the browser test tooling
         run: |
           npm ci
-          npx playwright install --with-deps chromium-headless-shell
+          npx playwright install chromium-headless-shell
 
       # The static server and its readiness check live in playwright.config.js (webServer), so the
       # same command works on a developer's machine too.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -273,10 +273,19 @@ jobs:
       # Node.js is preinstalled on the runner; no setup-node (its caching trips
       # the cache-poisoning audit, and this job shares a build cache with the
       # image-publishing workflow).
+      # The headless shell, not all of "chromium". Asking for chromium fetches Chrome for Testing
+      # (379 MiB unpacked) as well as the shell (262 MiB), and these specs never start the former:
+      # they run headless, which is what the shell is. ffmpeg (5 MiB) comes along either way, so what
+      # this saves is the 379 MiB, and --with-deps stays because the system libraries it installs are
+      # ones the shell needs as much as the full browser does.
+      #
+      # Ran the suite locally against a real bake with nothing but the shell on disk: 57 passed. If it
+      # were ever not enough -- a spec asking for a headed browser, or for video -- Playwright fails
+      # naming the executable it cannot find, so this cannot quietly test the wrong thing.
       - name: Install the browser test tooling
         run: |
           npm ci
-          npx playwright install --with-deps chromium
+          npx playwright install --with-deps chromium-headless-shell
 
       # The static server and its readiness check live in playwright.config.js (webServer), so the
       # same command works on a developer's machine too.


### PR DESCRIPTION
> Stacked on #470, which is stacked on #469. Review the top commit; the bases merge first.

`playwright install chromium` fetches three things: Chrome for Testing (379 MiB unpacked), the headless shell (262 MiB) and ffmpeg (5 MiB). These specs run headless and record no video, so the shell is the one Playwright starts and the browser beside it is downloaded to be ignored. Asking for the shell by name skips it. ffmpeg arrives either way, so what this saves is the 379 MiB, about three fifths of the bytes in a 33s step.

## Checked, not reasoned

Installed the shell alone into a browser directory of its own, pointed `PLAYWRIGHT_BROWSERS_PATH` at it so Playwright could find nothing else, and ran the suite against a real bake:

```
57 passed (14.6s)
```

`--with-deps` stays. What it installs is system libraries, which the shell needs as much as the full browser.

If the shell were ever not enough -- a spec asking for a headed browser, or for video -- Playwright fails naming the executable it cannot find, so this cannot quietly test the wrong thing.

## Why not cache the browsers, as #461 suggested

zizmor refuses it. `actions/cache` in a job that also runs `docker/build-push-action` is its cache-poisoning audit, high severity:

```
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
 53 |         uses: docker/build-push-action@... runtime artifacts usually published here
246 |       - uses: actions/cache@...           enables caching by default
```

Tried it first and read that, which is the same objection the comment two lines below this change already records about setup-node's caching. Fetching less needs no exception.

Refs #461.
