### PR TITLE
ci: give each quibble job the dependencies and database it needs

### DIFF
--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -18,6 +18,12 @@ permissions: {}
 env:
   QUIBBLE_DEPENDENCIES: Gadgets Translate UniversalLanguageSelector
 
+# quibble-action is pinned to an unreleased main commit, not a tag, for its `db` input. The newest
+# release, v2.0.2, does not have it, and a composite action answers an input it does not declare with
+# a warning rather than an error -- so moving back would leave `db: sqlite` below reading as a line
+# that does something while the wiki quietly returns to MySQL. Dependabot will offer exactly that
+# move; decline it until a release carries the input, then pin to the tag.
+
 # Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -35,7 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: femiwiki/quibble-action@3ce3d15fc42e28f2b4a01da22957f263286b4361  # v2.0.2
+      - uses: femiwiki/quibble-action@19c1e829d09dbbd4b5a2267cd2b7637482acabca  # main, unreleased
         with:
           stage: phan
           dependencies: ${{ env.QUIBBLE_DEPENDENCIES }}
@@ -53,10 +59,16 @@ jobs:
         with:
           persist-credentials: false
       - id: quibble
-        uses: femiwiki/quibble-action@3ce3d15fc42e28f2b4a01da22957f263286b4361  # v2.0.2
+        uses: femiwiki/quibble-action@19c1e829d09dbbd4b5a2267cd2b7637482acabca  # main, unreleased
         with:
           stage: coverage
           dependencies: ${{ env.QUIBBLE_DEPENDENCIES }}
+          # The backend wikven builds on: bin/build.php installs with --dbtype sqlite, and
+          # maintenance/build.php has paths that exist only there -- one writer at a time, a database
+          # file per pass, SQLITE_BUSY. Quibble defaults to MySQL, which wikven never runs on, so
+          # this is the one job standing where the product stands: its database and its extensions.
+          # The phpunit jobs cover SQLite without the extensions, on both MediaWiki versions.
+          db: sqlite
           # Coverage tooling lives only on MediaWiki master.
           mediawiki-version: master
           quibble-docker-image: quibble-bookworm-php83

--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -8,6 +8,16 @@ on:
 
 permissions: {}
 
+# What CI clones and installs beside wikven. Two lists are in play and they are not the same one:
+# phan wants the directories whose symbols this code reaches for (.phan/config.php), while the wiki
+# wants whatever will not load without it. UniversalLanguageSelector is the difference -- Translate
+# refuses to install without it, and phan has no use for it, which is why Translate's own phan config
+# does not name it either. Setting this also settles which source the action reads: it resolves from
+# the first that answers, and an extensions entry appearing in extension.json would otherwise take
+# the phan config's place without a word.
+env:
+  QUIBBLE_DEPENDENCIES: Gadgets Translate UniversalLanguageSelector
+
 # Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -28,6 +38,7 @@ jobs:
       - uses: femiwiki/quibble-action@3ce3d15fc42e28f2b4a01da22957f263286b4361  # v2.0.2
         with:
           stage: phan
+          dependencies: ${{ env.QUIBBLE_DEPENDENCIES }}
           mediawiki-version: ${{ matrix.mediawiki-version }}
           # PHP 8.3 image so the container resolves wikven's dev deps (>= 8.2); phan runs in the action's testrun image.
           quibble-docker-image: quibble-bookworm-php83
@@ -45,6 +56,7 @@ jobs:
         uses: femiwiki/quibble-action@3ce3d15fc42e28f2b4a01da22957f263286b4361  # v2.0.2
         with:
           stage: coverage
+          dependencies: ${{ env.QUIBBLE_DEPENDENCIES }}
           # Coverage tooling lives only on MediaWiki master.
           mediawiki-version: master
           quibble-docker-image: quibble-bookworm-php83

--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -8,15 +8,23 @@ on:
 
 permissions: {}
 
-# What CI clones and installs beside wikven. Two lists are in play and they are not the same one:
-# phan wants the directories whose symbols this code reaches for (.phan/config.php), while the wiki
-# wants whatever will not load without it. UniversalLanguageSelector is the difference -- Translate
-# refuses to install without it, and phan has no use for it, which is why Translate's own phan config
-# does not name it either. Setting this also settles which source the action reads: it resolves from
-# the first that answers, and an extensions entry appearing in extension.json would otherwise take
-# the phan config's place without a word.
+# What CI clones beside wikven, which is two questions rather than one. phan wants the directories
+# whose symbols this code reaches for; the wiki wants whatever will not load without it. Wikimedia
+# keeps the answers in two files for this reason -- zuul/dependencies.yaml against
+# zuul/phan_dependencies.yaml, chosen by whether the job name carries `-phan` -- and their entries
+# for Translate share two of the ten names between them: the install side has UniversalLanguageSelector,
+# the phan side does not, and the phan side has AbuseFilter and Echo and Elastica, which the install
+# side does not. Same shape here, one name apart.
+#
+# Naming these also settles which source the action reads. It resolves from the first that answers --
+# this input, then extension.json's requires, then the phan config -- so an extensions entry
+# appearing in extension.json would otherwise take the phan config's place without a word.
 env:
-  QUIBBLE_DEPENDENCIES: Gadgets Translate UniversalLanguageSelector
+  # Mirrors .phan/config.php. Nothing is gained by cloning what phan will not parse.
+  PHAN_DEPENDENCIES: Gadgets Translate
+  # Translate refuses to install without UniversalLanguageSelector, and phan has no use for it --
+  # which is why Translate's own phan config does not name it either.
+  WIKI_DEPENDENCIES: Gadgets Translate UniversalLanguageSelector
 
 # quibble-action is pinned to an unreleased main commit, not a tag, for its `db` input. The newest
 # release, v2.0.2, does not have it, and a composite action answers an input it does not declare with
@@ -44,7 +52,7 @@ jobs:
       - uses: femiwiki/quibble-action@19c1e829d09dbbd4b5a2267cd2b7637482acabca  # main, unreleased
         with:
           stage: phan
-          dependencies: ${{ env.QUIBBLE_DEPENDENCIES }}
+          dependencies: ${{ env.PHAN_DEPENDENCIES }}
           mediawiki-version: ${{ matrix.mediawiki-version }}
           # PHP 8.3 image so the container resolves wikven's dev deps (>= 8.2); phan runs in the action's testrun image.
           quibble-docker-image: quibble-bookworm-php83
@@ -62,7 +70,7 @@ jobs:
         uses: femiwiki/quibble-action@19c1e829d09dbbd4b5a2267cd2b7637482acabca  # main, unreleased
         with:
           stage: coverage
-          dependencies: ${{ env.QUIBBLE_DEPENDENCIES }}
+          dependencies: ${{ env.WIKI_DEPENDENCIES }}
           # The backend wikven builds on: bin/build.php installs with --dbtype sqlite, and
           # maintenance/build.php has paths that exist only there -- one writer at a time, a database
           # file per pass, SQLITE_BUSY. Quibble defaults to MySQL, which wikven never runs on, so

--- a/tests/phpunit/integration/Hooks/IndexerTest.php
+++ b/tests/phpunit/integration/Hooks/IndexerTest.php
@@ -7,7 +7,13 @@ use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 
 /**
+ * The database is for the one test below that lets the handler ask Translate for real: the answer
+ * comes from whether the page above the one asked about is marked for translation, which is a
+ * question for the database. MediaWiki reads this group from the class comment and nowhere else,
+ * so it is declared here rather than on that test.
+ *
  * @covers \MediaWiki\Extension\Wikven\Hooks\Indexer
+ * @group Database
  */
 class IndexerTest extends MediaWikiIntegrationTestCase {
 	/**
@@ -49,11 +55,15 @@ class IndexerTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
-	 * Built the way MediaWiki builds it, the handler asks Translate, which this suite does not
-	 * install -- so it finds no translation pages and leaves the index alone. That is also what a
-	 * wiki without content translation gets, and it must not be a wiki that loses pages.
+	 * Built the way MediaWiki builds it, the handler asks Translate rather than a stand-in. Neither
+	 * answer may cost a page its place: where Translate is absent the lookup says so and stops, and
+	 * where it is installed, a page nobody marked for translation is not a translation page. A wiki
+	 * without content translation must not be a wiki that loses pages.
+	 *
+	 * Both answers are reached, because the jobs differ in what they install: the quibble jobs bring
+	 * Translate along (quibble.yml names it), the phpunit jobs install MediaWiki alone.
 	 */
-	public function testWithoutTranslateNothingIsLeftOut() {
+	public function testTheHandlerAsBuiltLeavesAnUnmarkedPageAlone() {
 		$index = true;
 		( new Indexer() )->onSifterSearchIndexPage(Title::makeTitle(NS_MAIN, 'Installation/en'), $index);
 


### PR DESCRIPTION
Not stacked on #468 — this stands on `main` on its own, and #468 wants it underneath rather than on top. See "Order" below.

## What was wrong

`femiwiki/quibble-action` resolves what to clone from the first source that answers: the `dependencies` input, then `extension.json`'s `requires`, then `.phan/config.php`'s directory list. wikven names no extensions in `requires`, so the phan config was the source in use — which made one file answer two questions that have different answers:

- **phan** wants the directories whose symbols this code reaches for.
- **the wiki** wants whatever will not load without it.

Translate is both. `UniversalLanguageSelector` is only the second, and it was missing. So naming Translate for phan's benefit handed it to the installer too, and the installer refused it:

```
Error: A dependency error was encountered while installing the extension "Translate":
Could not find the registration file for the extension "UniversalLanguageSelector"
```

Translate itself confirms these are different lists: its `.phan/config.php` names AbuseFilter, AdminLinks, cldr, Echo, Elastica, Scribunto and TranslationNotifications — the optional integrations it reaches for — and does **not** name ULS, its one hard `requires.extensions` dependency.

## Two lists, one per job

The install list moves to `quibble.yml`, where someone looking for "what does CI install" would look, and `.phan/config.php` is left alone to be about phan. Each job then gets the list it actually needs:

```yaml
PHAN_DEPENDENCIES: Gadgets Translate
WIKI_DEPENDENCIES: Gadgets Translate UniversalLanguageSelector
```

Wikimedia splits this the same way and for the same reason — `zuul/dependencies.yaml` against `zuul/phan_dependencies.yaml`, chosen by whether the job name carries `-phan`, with `parameter_functions.py` recursing over the first and never the second ("since for Phan we never processed them recursively"). Their two entries for Translate share two of the ten names between them.

What is not copied is the mechanism. Wikimedia needs two maps because its dependency data lives away from the job definition and a job cannot pass its own list; a workflow job is written where its list is written, so a value per job is enough and the action needs no second input.

Naming the input also settles the resolution order: an `extensions` entry appearing in `extension.json` would otherwise take the phan config's place silently, and Gadgets/Translate would stop being cloned with nothing said.

## The database

Quibble installs on MySQL unless told otherwise, and wikven never runs there — `bin/build.php` installs with `--dbtype sqlite`, and `maintenance/build.php` carries paths that exist only under it (one writer at a time, a database file per pass, `SQLITE_BUSY`). So the job with the extensions installed was standing on a backend the product does not use, while the `phpunit` jobs stood on the right backend without the extensions. Neither was where wikven runs. `db: sqlite` makes `coverage` the one that is.

The pin moves to an unreleased `main` commit because no release carries the `db` input yet. A composite action answers an undeclared input with a warning rather than an error, so a move back to v2.0.2 would leave the line reading as though it does something while the wiki quietly returned to MySQL — noted in the workflow for whoever reviews the dependabot pull request that offers exactly that.

## The test

Installing Translate makes the handler in `IndexerTest` reach the real lookup, which asks the database whether the page above the one under test is marked for translation — and the test had not asked for a database, so it errored with `RuntimeException: Database backend disabled`.

The contract holds either way: absent, Translate cannot report a translation page; installed, a page nobody marked is not one. So the test asks for a database, and is named after the contract instead of after one of the two environments. `MediaWikiGroupValidator::isTestInDatabaseGroup()` matches `@group Database` against the class doc comment and nothing else, so it is declared there.

Both sides stay exercised, because the jobs differ in what they install: the quibble jobs bring Translate along, the `phpunit` jobs install MediaWiki alone.

## Where CI stands now

| job | database | extensions | MediaWiki |
|---|---|---|---|
| `phpunit` | SQLite | none | REL1_46 + master |
| `coverage` | SQLite | Gadgets, Translate, ULS | master |
| `phan` | — | Gadgets, Translate | REL1_46 + master |

## Order

This wants to land **before** #468, not after:

- On `main` today `.phan/config.php` names only Gadgets, so phan does not parse Translate and #468's suppressions are still live and still used — phan stays green with this merged.
- With the install list explicit, #468 becomes a pure static-analysis change: naming Translate in the phan config no longer moves what CI installs, so its `coverage` job goes green.

Merging this first turns #468 green without #468 having to change.