### PR TITLE
ci: stop building a Node tree the coverage run never reads

### DIFF
--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -71,6 +71,10 @@ jobs:
           # this is the one job standing where the product stands: its database and its extensions.
           # The phpunit jobs cover SQLite without the extensions, on both MediaWiki versions.
           db: sqlite
+          # The coverage command runs PHPUnit and nothing else, so the standalone npm install
+          # Quibble adds for it builds a Node tree no command here reads. Quibble's own help names
+          # this case; composer dependencies are installed either way.
+          skip-npm-install: true
           # Coverage tooling lives only on MediaWiki master.
           mediawiki-version: master
           quibble-docker-image: quibble-bookworm-php83


### PR DESCRIPTION
Follow-up to #476, which brought the input in.

Quibble adds a standalone `npm install` for the stages that need Node and for a `-c` command. The coverage command is `mwext-phpunit-coverage`, which runs PHPUnit and nothing else, so that install ran on every coverage job and nothing read what it produced. It is visible in the job log as the second half of the parallel step:

```
Run Post-dependency install, pre-database dependent steps in parallel (concurrency=2):
* Install MediaWiki, db=<...>
* npm install in /workspace/src
```

quibble-action v2.1.0 exposes `--skip-npm-install` for exactly this. Quibble's own help names the case:

> Do not run the standalone "npm install" dependency step … Intended for jobs whose commands do not need Node.js dependencies, for example PHP-only PHPUnit coverage runs. Unlike `--skip-deps`, composer …

Composer dependencies are installed either way, so nothing PHPUnit needs is affected. The action also warns when the input is combined with a stage that does run Node tests — `all`, `npm-test`, `qunit`, `api-testing` — and `coverage` is none of them, so no warning here.

Only the `coverage` job takes it. `phan` installs no wiki and does not reach that step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv1RzRurUH6wrgV5E9PESQ)_