### PR TITLE
ci: put a clock on every job

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         arch: ${{ case(inputs.tag != '', fromJSON('["x86_64", "aarch64"]'), fromJSON('["x86_64"]')) }}
     runs-on: ${{ case(matrix.arch == 'aarch64', 'ubuntu-24.04-arm', 'ubuntu-latest') }}
+    timeout-minutes: 60
     permissions:
       contents: write  # gh release upload
       id-token: write  # sign the build provenance attestation

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,6 +28,7 @@ concurrency:
 jobs:
   deploy-pages:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   docker-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   biome:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -57,6 +58,7 @@ jobs:
 
   rumdl:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -65,6 +67,7 @@ jobs:
 
   taplo:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -77,6 +80,7 @@ jobs:
 
   yamllint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -86,6 +90,7 @@ jobs:
 
   mago:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -104,6 +109,7 @@ jobs:
 
   zizmor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       security-events: write
     steps:
@@ -114,6 +120,7 @@ jobs:
 
   typos:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -123,6 +130,7 @@ jobs:
   # MediaWiki coding-standard checks mago doesn't cover: docs, naming, and forbidden patterns.
   phpcs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -142,6 +150,7 @@ jobs:
   # silence someone inherits.
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -197,6 +206,7 @@ jobs:
   # reads the working tree. Keeping the job name keeps the required check.
   composer-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,7 @@ jobs:
   # Build only when a feat/fix landed since the last nightly; skip a run with only chores/CI.
   gate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
     steps:
@@ -40,6 +41,7 @@ jobs:
     needs: gate
     if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write  # create the dated pre-release
     outputs:
@@ -80,6 +82,7 @@ jobs:
   publish:
     needs: [prepare, binary]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write  # publish (un-draft) the release
     steps:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,6 +38,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
       && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -35,6 +35,7 @@ jobs:
   # phan needs a full MediaWiki environment to resolve core symbols; mago and phpcs can't provide one.
   phan:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +54,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -51,6 +52,7 @@ jobs:
     needs: [release-please, binary, docker]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write  # publish (un-draft) the release
     steps:

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   semantic-pull-request:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,6 +39,15 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    # Every job in this repository carries one of these, and this is the job that earned them. On
+    # 2026-08-18 the runner's Ubuntu mirror stopped answering during `playwright install
+    # --with-deps`; apt fell back to archive.ubuntu.com, fetched the release files and then sat
+    # there. With no timeout the job waited out GitHub's six-hour default before anyone was told
+    # anything. The mirror is not ours to fix; how long we wait to hear about it is.
+    #
+    # Three times what the job takes -- around ten minutes, two bakes and a browser install -- so a
+    # stall is reported in minutes while a slow but healthy run never trips it.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
   # Compile the Caddy plugin so a Go build error is caught on the PR, not later in the binary build.
   caddy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -33,6 +34,7 @@ jobs:
   # Run the extension's PHPUnit tests against a real MediaWiki: the 1.46 base the build ships on, and master.
   phpunit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   plan:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   check-translations:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   updatecli:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Not one job in this repository carried `timeout-minutes`, so each of them was free to wait out GitHub's six-hour default. On 2026-08-18 one did.

## What happened

The `smoke` job on #469 ran for six hours and was killed by the platform. It did not fail — it stalled, in `playwright install --with-deps`, which runs apt. The runner's Ubuntu mirror stopped answering:

```
15:56:12  Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
15:56:14  Ign:2 ...                                        (retrying)
15:56:18  Ign:2 ...                                        (retrying)
15:56:19  Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
15:56:20  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
21:51:59  ##[error]The operation was canceled.
```

apt fell back to `archive.ubuntu.com`, fetched the release files, and then produced nothing for the next five hours and fifty-five minutes. The orphan the runner reaped on the way out names the culprit:

```
Terminate orphan process: pid (4405) (npm exec playwright install --with-deps chromium)
```

Whether a mirror answers is not ours to decide. How long we wait to hear that it did not is.

## What this changes

Every job gets roughly three times what it has been taking, so a stall is reported in minutes while a slow but healthy run never trips it.

| job | minutes | recently takes |
|---|---|---|
| the ten linters, `semantic-pull-request` | 10 | 5–25 s |
| `caddy`, `check-translations`, `deploy-pages`, `release-please`, `prepare` | 15 | under a minute |
| `phpunit`, `plan`, `updatecli` | 20 | 35–90 s |
| `phan`, `coverage`, `preview`, `docker-image`, `smoke`, `publish` | 30 | 2–10 min |
| `binary` | 60 | ~9 min per arch, on native runners |

The rationale lives in `smoke.yml`, next to the job that earned it, rather than repeated fourteen times.

## Not changed

The three jobs that call a reusable workflow — `nightly.yml`'s `binary`, `release-please.yml`'s `binary` and `docker` — are left alone. A job with `uses:` cannot carry `timeout-minutes`; they take the timeout of the job they call, which `binary.yml` and `docker-image.yml` now have.

This does not stop the stall, and it is not a retry. It is only the difference between hearing about one in twenty minutes and in six hours.

## Checked

`uv run --frozen --group lint yamllint --strict .` passes, which is the command the `yamllint` job runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv1RzRurUH6wrgV5E9PESQ)_