### PR TITLE
ci: measure whether a second static build reuses the first one's libphp.a

### DIFF
--- a/binary.Dockerfile
+++ b/binary.Dockerfile
@@ -28,15 +28,34 @@ RUN find /var/www/html -type d -name tests -prune -exec rm -rf {} + \
 # but not the build: build-static.sh fetches a nightly static-php-cli, which picks the library versions.
 FROM dunglas/frankenphp:static-builder-musl-1.12.6@sha256:e83b6dc244b8e170c5324cb8db32817b88703da495d40d14ce7751456e448a0d AS builder
 WORKDIR /go/src/app
+ENV PHP_VERSION=8.3
+ENV PHP_EXTENSIONS="gd,intl,pdo_sqlite,sqlite3,mbstring,dom,xml,simplexml,xmlreader,xmlwriter,fileinfo,iconv,ctype,filter,tokenizer,phar,session,calendar,opcache,openssl,sodium,zlib,bcmath,exif"
+ENV PHP_EXTENSION_LIBS="libpng,libjpeg,freetype,libwebp"
+
+# EXPERIMENT, not a change to keep as it stands. See #479.
+#
+# Measured on run 32203489763, the 449s build divides into 272s that cannot depend on this
+# repository -- fetching 21 sources and compiling libphp.a, decided by the three ENV lines above and
+# the pinned toolchain and by nothing else -- and the rest, which links the app in. The app first
+# appears 279.5s into the run, at "Creating app.tar".
+#
+# So the expensive part could live in a layer above the app COPY, keyed on those ENV lines alone and
+# cached across runs. Whether that is worth building depends on one fact nobody knows: does a second
+# build-static.sh reuse the libphp.a the first one left in buildroot, or does it "make clean" and
+# spend the 186s again? This run answers it. Compare "building embed" in the two RUNs below.
+#
+# CI is cleared because build-static.sh deletes downloads/ and source/ when it is set, which would
+# throw away the half of the answer this is asking about.
+RUN --mount=type=secret,id=github-token \
+    CI= GITHUB_TOKEN="$(cat /run/secrets/github-token 2>/dev/null || true)" \
+    ./build-static.sh
+
 COPY --from=app /var/www/html ./dist/app
 # A small Caddy module registers the `build` subcommand, so the binary can be run
 # as `./wikven build` instead of `./wikven php-cli build.php`. It is linked into
 # the FrankenPHP binary alongside FrankenPHP's own default Caddy modules.
 COPY caddy /go/wikven-caddy
 ENV SPC_CMD_VAR_FRANKENPHP_XCADDY_MODULES="--with github.com/dunglas/mercure/caddy --with github.com/dunglas/vulcain/caddy --with github.com/dunglas/caddy-cbrotli --with github.com/chaotic-ground/wikven/caddy=/go/wikven-caddy"
-ENV PHP_VERSION=8.3
-ENV PHP_EXTENSIONS="gd,intl,pdo_sqlite,sqlite3,mbstring,dom,xml,simplexml,xmlreader,xmlwriter,fileinfo,iconv,ctype,filter,tokenizer,phar,session,calendar,opcache,openssl,sodium,zlib,bcmath,exif"
-ENV PHP_EXTENSION_LIBS="libpng,libjpeg,freetype,libwebp"
 # static-php-cli resolves most sources through api.github.com, which is 60 requests/hour per IP when
 # anonymous and shared with every other runner on that IP. The token raises it to 1000/hour per repo.
 RUN --mount=type=secret,id=github-token \


### PR DESCRIPTION
**Not for merge.** One CI run to settle one fact, so #479 can be decided by a measurement instead of an argument.

## The question

#479 measured where `binary`'s 504s goes. 272s of it is fetching 21 sources and compiling `libphp.a`, and none of that can depend on this repository: it is decided by `binary.Dockerfile`'s `PHP_VERSION` / `PHP_EXTENSIONS` / `PHP_EXTENSION_LIBS` and the pinned toolchain image. The app tree first appears 279.5s into the run:

```
[01:09:10] [I] Creating app.tar from /go/src/app/dist/app
```

So that work could sit in a layer **above** the app `COPY`, keyed on those three `ENV` lines alone, and be cached across runs — a pull request would then pay it only when it changes the extension list or the PHP version.

Whether that is worth building turns on one unknown. `build-static.sh` runs `make clean` before `make -j4`, so a second run may spend the 186s over again rather than reuse what the first left in `buildroot`.

## The experiment

Run `build-static.sh` twice in one build: once with no `EMBED` above the app `COPY`, then the real one below it. Then read the two runs' phase timings out of the log.

`CI` is cleared on the warm run because `build-static.sh` deletes `downloads/` and `source/` when it is set, which would throw away half of what this is asking about.

## What each outcome means

| second run's "building embed" | verdict |
|---|---|
| near zero | the split works. Finish it: move the warm work into its own cached layer, exported from the nightly (which runs on `main`, so a pull request can read it) under its own scope. |
| still ~186s | the split saves only the 65s download and whatever the Go build cache holds for `xcaddy`. Record that in #479 and probably stop there. |

Either way this branch is thrown away — a build that runs `build-static.sh` twice is slower than what we have, which is the point of it being a draft.

## Known cost

This run will take longer than the usual 504s, since it does the expensive part twice. `binary.yml` carries `timeout-minutes: 60`, so there is room.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv1RzRurUH6wrgV5E9PESQ)_