### PR TITLE
ci: probe branch, arm only, reporting what the bundled lua does

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -177,8 +177,36 @@ jobs:
 
           chmod +x "wikven-linux-$ARCH"
 
+      # First, and before anything is installed, because that is the whole claim: somebody downloads
+      # the binary onto a machine with no Lua on it and bakes a site with a module in it. Scribunto
+      # carries its own lua binaries and falls back to them when luaPath is null, so where it ships
+      # one for the architecture, this should work with nothing configured and nothing installed.
+      #
+      # Ordering matters more than it looks. Run after the install step and this passes for the wrong
+      # reason: wikven's own luaEngineAvailable() would find the interpreter on PATH, and the bake
+      # would never be asked whether it can manage without one.
+      #
+      # Asserted on x86_64 only, and not because the arm tarball is missing the files -- it carries
+      # exactly the same ones. LuaStandaloneInterpreter chooses by PHP_OS and PHP_INT_SIZE and never
+      # looks at the architecture, so on arm it picks lua5_1_5_linux_64_generic/lua, an x86-64 ELF,
+      # passes its own is_executable() check on it, and fails only when the process will not start.
+      # Asserting this on arm would be asserting somebody else's bug.
+      - name: Bake with Scribunto's own bundled lua
+        if: matrix.arch == 'x86_64'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          cat > work/src/.wikven.yaml <<'EOF'
+          extensions:
+            - Scribunto
+          EOF
+          ( cd work && WIKVEN_WORKDIR=. "$GITHUB_WORKSPACE/wikven-linux-$ARCH" build )
+          test -s work/dist/index.html
+          grep -q 'lua ran on' work/dist/index.html
+
       # A Lua interpreter the host provides, which is the arrangement that works on any
-      # architecture. The step after this one covers the arrangement that does not.
+      # architecture -- and the only one arm has, per the step above.
       #
       # luajit is a real fallback and not a consolation: Scribunto's standalone engine reads
       # `lua -v` and takes `LuaJIT ...` as readily as `Lua ...`, and LuaJIT is Lua 5.1, which is the
@@ -199,6 +227,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
+          rm -rf work/dist
           cat > work/src/.wikven.yaml <<EOF
           extensions:
             - Scribunto
@@ -214,26 +243,3 @@ jobs:
             grep -o '{{#invoke[^}]*}}' work/dist/index.html || true
             exit 1
           fi
-
-      # Scribunto carries its own lua binaries and falls back to them when luaPath is null, so where
-      # it ships one for the architecture, the binary should render Lua with nothing configured.
-      #
-      # Asserted on x86_64 only, and not because the arm tarball is missing the files -- it carries
-      # exactly the same ones. LuaStandaloneInterpreter chooses by PHP_OS and PHP_INT_SIZE and never
-      # looks at the architecture, so on arm it picks lua5_1_5_linux_64_generic/lua, an x86-64 ELF,
-      # passes its own is_executable() check on it, and fails only when the process will not start.
-      # Asserting this on arm would be asserting somebody else's bug.
-      - name: Bake with Scribunto's own bundled lua
-        if: matrix.arch == 'x86_64'
-        env:
-          ARCH: ${{ matrix.arch }}
-        run: |
-          set -euo pipefail
-          rm -rf work/dist
-          cat > work/src/.wikven.yaml <<'EOF'
-          extensions:
-            - Scribunto
-          EOF
-          ( cd work && WIKVEN_WORKDIR=. "$GITHUB_WORKSPACE/wikven-linux-$ARCH" build )
-          test -s work/dist/index.html
-          grep -q 'lua ran on' work/dist/index.html

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -177,6 +177,28 @@ jobs:
 
           chmod +x "wikven-linux-$ARCH"
 
+      # A bake that refuses has to say so in its exit code, or a caller scripting on `wikven build`
+      # -- a Makefile, a CI job, a deploy script -- reads the refusal as a success and ships nothing.
+      # caddy/wikven.go goes to some trouble to propagate the child's status and says so in a
+      # comment; this is the assertion that the whole chain, Caddy command to php-cli to the inner
+      # maintenance run, actually delivers it.
+      #
+      # Checked with the cheapest refusal there is, a workdir with no src, so what is asserted is the
+      # exit code and not any particular diagnosis.
+      - name: A refused bake exits non-zero
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -uo pipefail
+          mkdir -p empty
+          status=0
+          ( cd empty && WIKVEN_WORKDIR=. "$GITHUB_WORKSPACE/wikven-linux-$ARCH" build ) || status=$?
+          echo "a bake with no source directory exited $status"
+          if [ "$status" -eq 0 ]; then
+            echo "::error::the binary refused the bake and still exited 0"
+            exit 1
+          fi
+
       # First, and before anything is installed, because that is the whole claim: somebody downloads
       # the binary onto a machine with no Lua on it and bakes a site with a module in it. Scribunto
       # carries its own lua binaries and falls back to them when luaPath is null, so where it ships

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -99,6 +99,16 @@ jobs:
             printf '| PHP | `%s` |\n' "$php"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # Handed to the bake job below, which is a separate job because it needs a runner without a
+      # Docker build on it -- the point is to exercise the binary the way somebody who downloaded it
+      # would, on a machine that has nothing of wikven's installed.
+      - name: Hand the binary to the bake job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: wikven-linux-${{ matrix.arch }}
+          path: wikven-linux-${{ matrix.arch }}
+          retention-days: 1
+
       # Sign the build provenance so users can `gh attestation verify` the binary.
       - name: Attest the binary
         if: inputs.tag != ''
@@ -117,3 +127,113 @@ jobs:
           "wikven-linux-$ARCH"
           "wikven-linux-$ARCH.sha256"
           --clobber
+
+  # Nothing else bakes anything with the binary. This workflow built it and ran `./wikven version`,
+  # which proves the static link but not that the product works, and smoke.yml only ever uses the
+  # Docker image. So a site the image can bake and the binary cannot has never been caught by
+  # anything -- which is how this repository's own documentation came to hold a Lua module the
+  # binary may not be able to render (#465, #473).
+  #
+  # Deliberately not folded into smoke.yml: that job belongs to the image, it is a required check,
+  # and Lua is a niche of a niche. This one hangs off `binary`, so it runs exactly when a binary was
+  # built and stays out of the way otherwise. It also runs on a plain runner with the binary
+  # downloaded as an artifact, which is how somebody who fetched a release would meet it.
+  bake:
+    needs: binary
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ case(inputs.tag != '', fromJSON('["x86_64", "aarch64"]'), fromJSON('["x86_64"]')) }}
+    runs-on: ${{ case(matrix.arch == 'aarch64', 'ubuntu-24.04-arm', 'ubuntu-latest') }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: wikven-linux-${{ matrix.arch }}
+
+      - name: Make a source tree to bake
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          mkdir -p work/src
+          cat > work/src/index.wikitext <<'EOF'
+          Baked by the standalone binary.
+
+          {{#invoke:Greet|thisPage}}
+          EOF
+
+          cat > 'work/src/Module:Greet' <<'EOF'
+          local p = {}
+
+          function p.thisPage()
+            return 'lua ran on ' .. mw.title.getCurrentTitle().text
+          end
+
+          return p
+          EOF
+
+          chmod +x "wikven-linux-$ARCH"
+
+      # A Lua interpreter the host provides, which is the arrangement that works on any
+      # architecture. The step after this one covers the arrangement that does not.
+      #
+      # luajit is a real fallback and not a consolation: Scribunto's standalone engine reads
+      # `lua -v` and takes `LuaJIT ...` as readily as `Lua ...`, and LuaJIT is Lua 5.1, which is the
+      # version Scribunto wants. Which of the two the runner has is recorded either way, because the
+      # documentation this test exists to justify has to name something a reader can install.
+      - name: Install a Lua interpreter
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends lua5.1 \
+            || sudo apt-get install -y --no-install-recommends luajit
+          lua=$(command -v lua5.1 || command -v luajit)
+          echo "LUA_INTERPRETER=$lua" >> "$GITHUB_ENV"
+          echo "Using $lua: $("$lua" -v 2>&1 | head -1)"
+
+      - name: Bake with a Lua interpreter the host provides
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          cat > work/src/.wikven.yaml <<EOF
+          extensions:
+            - Scribunto
+          config:
+            ScribuntoEngineConf:
+              luastandalone:
+                luaPath: $LUA_INTERPRETER
+          EOF
+          ( cd work && WIKVEN_WORKDIR=. "$GITHUB_WORKSPACE/wikven-linux-$ARCH" build )
+          test -s work/dist/index.html
+          if ! grep -q 'lua ran on' work/dist/index.html; then
+            echo "::error::the binary baked a site, but the module's answer is not in it"
+            grep -o '{{#invoke[^}]*}}' work/dist/index.html || true
+            exit 1
+          fi
+
+      # Scribunto carries its own lua binaries and falls back to them when luaPath is null, so where
+      # it ships one for the architecture, the binary should render Lua with nothing configured.
+      #
+      # Asserted on x86_64 only, and not because the arm tarball is missing the files -- it carries
+      # exactly the same ones. LuaStandaloneInterpreter chooses by PHP_OS and PHP_INT_SIZE and never
+      # looks at the architecture, so on arm it picks lua5_1_5_linux_64_generic/lua, an x86-64 ELF,
+      # passes its own is_executable() check on it, and fails only when the process will not start.
+      # Asserting this on arm would be asserting somebody else's bug.
+      - name: Bake with Scribunto's own bundled lua
+        if: matrix.arch == 'x86_64'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          rm -rf work/dist
+          cat > work/src/.wikven.yaml <<'EOF'
+          extensions:
+            - Scribunto
+          EOF
+          ( cd work && WIKVEN_WORKDIR=. "$GITHUB_WORKSPACE/wikven-linux-$ARCH" build )
+          test -s work/dist/index.html
+          grep -q 'lua ran on' work/dist/index.html

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ case(inputs.tag != '', fromJSON('["x86_64", "aarch64"]'), fromJSON('["x86_64"]')) }}
+        arch: ["aarch64"]  # PROBE BRANCH: arm only. Not for merge.
     runs-on: ${{ case(matrix.arch == 'aarch64', 'ubuntu-24.04-arm', 'ubuntu-latest') }}
     timeout-minutes: 60
     permissions:
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ case(inputs.tag != '', fromJSON('["x86_64", "aarch64"]'), fromJSON('["x86_64"]')) }}
+        arch: ["aarch64"]  # PROBE BRANCH: arm only. Not for merge.
     runs-on: ${{ case(matrix.arch == 'aarch64', 'ubuntu-24.04-arm', 'ubuntu-latest') }}
     timeout-minutes: 20
     permissions:
@@ -213,19 +213,27 @@ jobs:
       # looks at the architecture, so on arm it picks lua5_1_5_linux_64_generic/lua, an x86-64 ELF,
       # passes its own is_executable() check on it, and fails only when the process will not start.
       # Asserting this on arm would be asserting somebody else's bug.
+      # PROBE BRANCH: the x86_64 guard is off and the assertion only reports, so arm can say what it
+      # does here. Now that reexec() exits rather than returning the status, this is also where the
+      # refusal's exit code is read on arm.
       - name: Bake with Scribunto's own bundled lua
-        if: matrix.arch == 'x86_64'
         env:
           ARCH: ${{ matrix.arch }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           cat > work/src/.wikven.yaml <<'EOF'
           extensions:
             - Scribunto
           EOF
-          ( cd work && WIKVEN_WORKDIR=. "$GITHUB_WORKSPACE/wikven-linux-$ARCH" build )
-          test -s work/dist/index.html
-          grep -q 'lua ran on' work/dist/index.html
+          status=0
+          ( cd work && WIKVEN_WORKDIR=. "$GITHUB_WORKSPACE/wikven-linux-$ARCH" build ) \
+            > probe.log 2>&1 || status=$?
+          echo "PROBE exit: $status"
+          echo "PROBE index.html: $(test -s work/dist/index.html && echo present || echo absent)"
+          echo "PROBE module answer: $(grep -c 'lua ran on' work/dist/index.html 2>/dev/null || echo 0)"
+          echo '--- last 10 lines of the bake ---'
+          tail -10 probe.log
+          exit 0
 
       # A Lua interpreter the host provides, which is the arrangement that works on any
       # architecture -- and the only one arm has, per the step above.

--- a/bin/build.php
+++ b/bin/build.php
@@ -18,7 +18,15 @@ $work = getenv('WIKVEN_WORKDIR');
 if ($work === false || $work === '') {
 	$work = getcwd();
 }
-$work = rtrim($work, '/');
+// Resolved to an absolute path before anything else reads it. The skin passes are spawned with the
+// MediaWiki root as their working directory -- inside the binary that is the temporary directory the
+// embedded app is unpacked into -- and they inherit this variable. A relative value, which is what
+// the documented `WIKVEN_WORKDIR=. ./wikven build` gives, therefore means something different in a
+// pass than it did here: the pass opens an empty database beside the unpacked app rather than the
+// one the orchestrator just filled, and dies on "no such table: page". Under Docker the workdir is
+// /workspace and this never came up.
+$resolved = realpath($work);
+$work = $resolved !== false ? $resolved : rtrim($work, '/');
 putenv("WIKVEN_WORKDIR=$work");
 $_ENV['WIKVEN_WORKDIR'] = $work;
 

--- a/caddy/wikven.go
+++ b/caddy/wikven.go
@@ -56,15 +56,29 @@ func reexec(args ...string) (int, error) {
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
 	if err := cmd.Run(); err != nil {
-		// Propagate the child's own exit code so a caller scripting on `wikven build` can tell one
-		// failure from another, and return a nil error so Caddy does not also print "exit status N"
-		// on top of the diagnostic the child already wrote. A signalled child reports -1; call that 1.
+		// Propagate the child's own exit code, so a caller scripting on `wikven build` -- a
+		// Makefile, a CI job, a deploy script -- can tell a refusal from a success.
+		//
+		// By exiting here rather than returning the code, because returning it does not work for
+		// the code that matters most. Caddy's cobra wrapper turns a CommandFunc's status into a
+		// process exit status only when it is greater than one:
+		//
+		//     status, err := f(Flags{cmd.Flags()})
+		//     if status > 1 { ... return &exitError{ExitCode: status, Err: err} }
+		//     return err
+		//
+		// so returning (1, nil) -- an ordinary failed build, which is every failed build -- exits
+		// 0. Returning (1, err) would exit 1 but print Caddy's own error line on top of the
+		// diagnostic the child already wrote to the stderr it shares with us. The child has
+		// finished and nothing else here has anything left to do, so exiting is the honest answer.
+		//
+		// A signalled child reports -1; call that 1.
 		var exit *exec.ExitError
 		if errors.As(err, &exit) {
 			if code := exit.ExitCode(); code > 0 {
-				return code, nil
+				os.Exit(code)
 			}
-			return 1, nil
+			os.Exit(1)
 		}
 		return 1, err
 	}

--- a/includes/Scribunto.php
+++ b/includes/Scribunto.php
@@ -7,9 +7,11 @@ namespace MediaWiki\Extension\Wikven;
  *
  * Scribunto is ordinary equipment on a MediaWiki wiki, and wikven's two products disagree about it.
  * The image compiles luasandbox into its PHP and bundles the extension, so a site that lists
- * Scribunto bakes Lua there. The standalone binary has neither: static-php-cli, which builds its PHP,
- * offers no Lua extension among the hundred and thirty it supports, and Scribunto's other engine
- * shells out to a lua binary that a single executable does not carry.
+ * Scribunto bakes Lua there. The standalone binary has no such extension -- static-php-cli, which
+ * builds its PHP, offers no Lua extension among the hundred and thirty it supports -- and reaches
+ * Lua only through Scribunto's other engine, which shells out to a lua binary. It gets one on 64-bit
+ * x86 Linux, where the interpreter Scribunto itself ships will run; anywhere else the site has to
+ * name one of its own.
  *
  * Until now that disagreement was silent, and silence was the worst of it. Measured on a bake of one
  * page invoking one module, every one of these exited 0:
@@ -78,8 +80,13 @@ class Scribunto {
 				'Wikven: this site lists '
 				. self::EXTENSION
 				. ' and no Lua engine is available here.'
-				. ' The Docker image has one; the standalone binary has none, so it cannot bake a site'
-				. ' that uses Lua modules. Bake this one with the image, or drop '
+				. ' The Docker image compiles luasandbox into its PHP. The standalone binary carries no'
+				. ' engine of its own and falls back to the lua interpreter '
+				. self::EXTENSION
+				. ' ships, which is built for 64-bit x86 Linux and did not run here.'
+				. ' Install a Lua 5.1 interpreter and name it under'
+				. ' ScribuntoEngineConf.luastandalone.luaPath, bake this site with the Docker image, or'
+				. ' drop '
 				. self::EXTENSION
 				. ' from extensions and the Module: pages with it.'
 			);

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -10,6 +10,7 @@ use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\RevisionStore;
 use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Shell\Shell;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleValue;
 use MediaWiki\User\User;
@@ -132,8 +133,10 @@ class Build extends Maintenance {
 	/**
 	 * Whether anything here can run Lua.
 	 *
-	 * luasandbox is the engine the image carries. Scribunto's other engine runs an external lua, which
-	 * the standalone binary has no way to ship but a hand-rolled install may well have.
+	 * Four ways, in the order Scribunto would find them. luasandbox is the engine the image carries.
+	 * Failing that, Scribunto's standalone engine runs an external lua: the one this site configured,
+	 * one on PATH, or -- and this is the case that is easy to forget -- one Scribunto ships itself,
+	 * which is what it falls back to when luaPath is null.
 	 */
 	private static function luaEngineAvailable(): bool {
 		if (extension_loaded('luasandbox')) {
@@ -150,7 +153,29 @@ class Build extends Maintenance {
 				}
 			}
 		}
-		return false;
+		return self::bundledLuaRuns();
+	}
+
+	/**
+	 * Whether the lua binary Scribunto carries can run here.
+	 *
+	 * Existing is not enough, which is why this runs it. LuaStandaloneInterpreter picks among the
+	 * bundled binaries by PHP_OS and PHP_INT_SIZE and never looks at the architecture, so on arm it
+	 * selects the x86-64 one, passes its own is_executable() check on it, and only finds out when
+	 * the process will not start. The path below mirrors that choice for 64-bit Linux, which is the
+	 * only platform either wikven product runs on; executing it is what makes the mirror safe, since
+	 * a wrong guess answers no rather than promising Lua that never arrives.
+	 */
+	private static function bundledLuaRuns(): bool {
+		$lua =
+			$GLOBALS['IP']
+			. '/extensions/'
+			. Scribunto::EXTENSION
+			. '/includes/Engines/LuaStandalone/binaries/lua5_1_5_linux_64_generic/lua';
+		if (PHP_OS !== 'Linux' || PHP_INT_SIZE !== 8 || !is_executable($lua)) {
+			return false;
+		}
+		return Shell::command($lua, '-v')->includeStderr()->execute()->getExitCode() === 0;
 	}
 
 	/**

--- a/tests/phpunit/unit/ScribuntoTest.php
+++ b/tests/phpunit/unit/ScribuntoTest.php
@@ -46,6 +46,7 @@ class ScribuntoTest extends MediaWikiUnitTestCase {
 		$this->assertNotNull($problem);
 		$this->assertStringContainsString('no Lua engine', $problem);
 		$this->assertStringContainsString('standalone binary', $problem, 'the message names the product');
+		$this->assertStringContainsString('luaPath', $problem, 'and what the site can do about it');
 	}
 
 	/**


### PR DESCRIPTION
**Not for merge. Throwaway.** Branched off #481 to get the arm evidence that branch cannot produce on its own.

## Why not just wait for the nightly

The nightly runs `binary.yml` on `main`, and `main` has no `bake` job — #481 is what adds it. So no nightly that has already run tells us anything, and waiting for one means waiting until after #481 merges, which is after the point where the answer is wanted: #481's whole purpose is to decide what `Lua modules` and `Standalone binary` should say.

## What this branch changes, and only this branch

1. Both matrices forced to `["aarch64"]`. A pull request otherwise builds x86_64 only, which is exactly the leg already covered on #481.
2. The `if: matrix.arch == 'x86_64'` guard removed from the bundled-lua bake, and its assertion downgraded to a report. The point is to see what arm does, not to be right about it in advance.

## The two questions

**Does the arm runner have a Lua 5.1 interpreter to install?** `lua5.1 (5.1.5-9build2)` installs on `ubuntu-latest`; whether `ubuntu-24.04-arm` has it, or falls through to `luajit`, is untested. The documentation that #481 exists to justify has to name something an arm user can actually install.

**What does the bundled interpreter do on arm?** `LuaStandaloneInterpreter` picks among Scribunto's bundled binaries by `PHP_OS` and `PHP_INT_SIZE` and never by architecture, so on arm it selects `lua5_1_5_linux_64_generic/lua`, an x86-64 ELF. Two outcomes are possible and they are not equally good:

* wikven refuses with "no Lua engine is available here" — which is what #481's `bundledLuaRuns()` is meant to produce now that it executes the interpreter rather than trusting `is_executable()`. Correct.
* the bake goes ahead and breaks later, or worse, publishes a page with `{{#invoke:}}` showing in it. That would mean the new guard does not catch the case it was written for.

The probe prints the exit status, whether `index.html` was produced, whether the module's answer is in it, and the last 40 lines of the bake, so the log says which.

Closing this once it has reported.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv1RzRurUH6wrgV5E9PESQ)_