### PR TITLE
fix: bundle the modules core loads by looking at the rendered page

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -166,6 +166,21 @@ jobs:
             exit 1
           fi
 
+          # A sortable table needs jquery.tablesorter, and core does not queue it while rendering:
+          # mediawiki.page.ready looks for table.sortable in the browser and fetches the module from
+          # load.php, which an export does not have (#483). The build makes that decision instead, so
+          # what this checks is that it made it -- the module has to be in the bundle, and the page
+          # that asked for it has to still be there to ask.
+          if ! grep -q 'class="[^"]*\bsortable\b' dist/Licenses.html; then
+            echo "::error::dist/Licenses.html no longer has a sortable table for this to be about"
+            exit 1
+          fi
+          if ! grep -q 'jquery.tablesorter' dist/modules-static.js; then
+            echo "::error::a page has a sortable table and jquery.tablesorter is not in the bundle"
+            echo "::error::the table will publish with headers that do nothing"
+            exit 1
+          fi
+
           # A Lua module runs at build time and its answer is baked into the page that invoked it
           # (#465). Module:Example answers with the title of the page it ran on, so this says both
           # that Scribunto rendered at all -- without it the invocation is left in the page as

--- a/docs/Licenses.wikitext
+++ b/docs/Licenses.wikitext
@@ -6,7 +6,7 @@ __TOC__
 {{SITENAME}} itself is licensed [https://github.com/chaotic-ground/wikven/blob/main/LICENSE GPL-3.0-or-later]. The Docker image and the standalone binary it produces redistribute third-party software under that software's own licenses, acknowledged here. (GPL-2.0-or-later and GPL-3.0-or-later are compatible, so this is attribution, not a conflict.)
 
 <!--T:2-->
-{| class="wikitable"
+{| class="wikitable sortable"
 ! Component !! License !! Bundled in
 |-
 | [<tvar name="1">https://www.mediawiki.org/</tvar> MediaWiki], with its bundled skins and extensions || GPL-2.0-or-later || image, binary

--- a/docs/Licenses/ko.wikitext
+++ b/docs/Licenses/ko.wikitext
@@ -4,8 +4,8 @@
 <!--T:1 @3a090f24-->
 {{SITENAME}} 자체는 [https://github.com/chaotic-ground/wikven/blob/main/LICENSE GPL-3.0-or-later]로 라이선스됩니다. Docker 이미지와 그것이 만들어 내는 단독 실행 바이너리는 서드파티 소프트웨어를 그 소프트웨어 자체의 라이선스에 따라 재배포하며, 이를 여기서 밝힙니다. (GPL-2.0-or-later와 GPL-3.0-or-later는 호환되므로, 이는 충돌이 아니라 출처 표시입니다.)
 
-<!--T:2 @40a9db65-->
-{| class="wikitable"
+<!--T:2 @2ba7478a-->
+{| class="wikitable sortable"
 ! 구성 요소 !! 라이선스 !! 번들 위치
 |-
 | [$1 MediaWiki]와 그 번들 스킨 및 확장 기능 || GPL-2.0-or-later || 이미지, 바이너리

--- a/includes/LazyModules.php
+++ b/includes/LazyModules.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * The modules MediaWiki loads by looking at a rendered page, decided here instead of in a browser.
+ *
+ * Core queues most of a page's JavaScript while rendering it, and the build reads that queue out of
+ * the HTML. Two features are not queued. mediawiki.page.ready waits until the page is in a browser,
+ * searches the DOM, and asks load.php for what it finds:
+ *
+ *     if ( config.collapsible ) {
+ *         $collapsible = $content.find( '.mw-collapsible' );
+ *         if ( $collapsible.length ) { modules.push( 'jquery.makeCollapsible' ); }
+ *     }
+ *     if ( config.sortable ) {
+ *         $sortable = $content.find( 'table.sortable' );
+ *         if ( $sortable.length ) { modules.push( 'jquery.tablesorter' ); }
+ *     }
+ *     if ( modules.length ) { mw.loader.using( modules ).then( ... ); }
+ *
+ * An export has no load.php, so that request fails and the feature is silently absent: no toggle on
+ * a collapsible, no sorting on a sortable table, and content marked mw-collapsed shown rather than
+ * hidden (#483). Nothing else about the page is wrong, which is what makes it easy to miss.
+ *
+ * The decision itself is kept: same flags, same selectors, same "only if the page has one". Only its
+ * timing moves, from the browser to the build, because that is the one thing a static site cannot
+ * do the way MediaWiki does. Whatever core adds to that list next is another line in MODULES.
+ */
+class LazyModules {
+	/**
+	 * mediawiki.page.ready config flag => the module it loads, and the selector it looks for.
+	 *
+	 * 'tag' narrows the search to one element, as 'table.sortable' does; null matches any element,
+	 * as '.mw-collapsible' does.
+	 */
+	public const MODULES = [
+		'collapsible' => ['module' => 'jquery.makeCollapsible', 'class' => 'mw-collapsible', 'tag' => null],
+		'sortable' => ['module' => 'jquery.tablesorter', 'class' => 'sortable', 'tag' => 'table']
+	];
+
+	/**
+	 * The lazy modules a rendered page needs.
+	 *
+	 * @param string $html One page's rendered HTML.
+	 * @param array $readyConfig mediawiki.page.ready's config, for the flags that gate each feature.
+	 * @return string[] Module names, in the order MODULES lists them.
+	 */
+	public static function forPage(string $html, array $readyConfig): array {
+		$needed = [];
+		foreach (self::MODULES as $flag => $feature) {
+			if (( $readyConfig[$flag] ?? false ) && self::hasClass($html, $feature['class'], $feature['tag'])) {
+				$needed[] = $feature['module'];
+			}
+		}
+		return $needed;
+	}
+
+	/**
+	 * Whether the HTML carries an element with this class, optionally only on one tag.
+	 *
+	 * Read off the markup rather than parsed, because the caller has one string per page and a DOM
+	 * for each would cost more than the question is worth. The class is matched as a whole token, so
+	 * "mw-collapsible" does not answer for "mw-collapsible-content" -- the toggle and content
+	 * wrappers core generates carry names that a substring match would take for the thing itself.
+	 *
+	 * @param string $html
+	 * @param string $class The class to look for.
+	 * @param ?string $tag Only look at this element, or null for any.
+	 */
+	public static function hasClass(string $html, string $class, ?string $tag = null): bool {
+		$open = $tag === null ? '<[a-zA-Z][^>]*' : '<' . preg_quote($tag, '/') . '\b[^>]*';
+		$pattern = '/' . $open . '\sclass\s*=\s*(["\'])([^"\']*)\1/i';
+		if (!preg_match_all($pattern, $html, $matches)) {
+			return false;
+		}
+		foreach ($matches[2] as $value) {
+			if (in_array($class, preg_split('/\s+/', trim($value)) ?: [], true)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -55,13 +55,17 @@ class BuildScripts extends Maintenance {
 		$seeds[] = 'site';
 		// Seed default-on gadgets; the Gadgets hook adds them per-request, not in static render.
 		$seeds = array_merge($seeds, $this->defaultGadgetModules());
+		$readyConfig = $this->readyConfig($rl, $wgLanguageCode, $wgDefaultSkin);
 		// Seed the lazy search module (loaded on focus, never in page queue) so its closure bundles.
 		if (Search::isActive()) {
-			$searchModule = $this->resolveSearchModule($rl, $wgLanguageCode, $wgDefaultSkin);
+			$searchModule = $this->resolveSearchModule($readyConfig);
 			if ($searchModule !== null && $rl->isModuleRegistered($searchModule)) {
 				$seeds[] = $searchModule;
 			}
 		}
+		// Same for the modules core decides on by looking at the rendered page rather than by
+		// queueing them, which is collapsibles and sortable tables. See LazyModules.
+		$seeds = array_merge($seeds, $this->collectLazyModules($htmlDir, $readyConfig));
 		// Same for Citizen's preferences panel (theme, font size, page width), lazy-loaded when the
 		// dropdown is first opened. Seeding it is what makes the panel work statically; unseeded it
 		// reports "Couldn't load preferences". Vue and its Codex components come along with it.
@@ -161,15 +165,52 @@ class BuildScripts extends Maintenance {
 	}
 
 	/** @return string|null Search module page.ready lazy-loads on focus, or null if search is off. */
-	private function resolveSearchModule(ResourceLoader $rl, string $lang, string $skin): ?string {
+	private function resolveSearchModule(array $readyConfig): ?string {
+		return $readyConfig['search'] ?? false ? $readyConfig['searchModule'] ?? null : null;
+	}
+
+	/**
+	 * mediawiki.page.ready's own configuration, which decides what it will go looking for.
+	 *
+	 * Core builds this in the module's config.json callback: these defaults, then the
+	 * SkinPageReadyConfig hook, which is where a skin turns a feature off. Read here rather than
+	 * assumed, so a site that switches one off gets the same answer from a bake as from a wiki.
+	 */
+	private function readyConfig(ResourceLoader $rl, string $lang, string $skin): array {
 		$query = ResourceLoader::makeLoaderQuery([], $lang, $skin, null, null, Context::DEBUG_OFF, null);
 		$context = new Context($rl, new FauxRequest($query));
-		$config = ['search' => true, 'searchModule' => 'mediawiki.searchSuggest'];
+		$config = [
+			'search' => true,
+			'searchModule' => 'mediawiki.searchSuggest',
+			'collapsible' => true,
+			'sortable' => true,
+			'selectorLogoutLink' => '#pt-logout a[data-mw-interface]'
+		];
 		( new HookRunner(MediaWikiServices::getInstance()->getHookContainer()) )->onSkinPageReadyConfig(
 			$context,
 			$config
 		);
-		return $config['search'] ?? false ? $config['searchModule'] ?? null : null;
+		return $config;
+	}
+
+	/**
+	 * The lazy modules any rendered page needs, from the same pass over the same HTML.
+	 *
+	 * Top-level pages only, as collectPageModules() reads them: a translation is rendered from the
+	 * source page's wikitext, so a collapsible on one is a collapsible on the other, and the source
+	 * page is not in a subdirectory. Scanning deeper would also reach the per-skin copies, which
+	 * this skin's bundle has no business reading.
+	 *
+	 * @return string[]
+	 */
+	private function collectLazyModules(string $htmlDir, array $readyConfig): array {
+		$modules = [];
+		foreach (glob("$htmlDir/*.html") as $file) {
+			foreach (LazyModules::forPage(file_get_contents($file), $readyConfig) as $module) {
+				$modules[$module] = true;
+			}
+		}
+		return array_keys($modules);
 	}
 
 	/** @return string[] The full dependency closure, including the base modules. */

--- a/tests/phpunit/unit/LazyModulesTest.php
+++ b/tests/phpunit/unit/LazyModulesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\LazyModules;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\LazyModules
+ */
+class LazyModulesTest extends MediaWikiUnitTestCase {
+	private const ON = ['collapsible' => true, 'sortable' => true];
+
+	public function testAPageWithNeitherNeedsNothing() {
+		$this->assertSame([], LazyModules::forPage('<p>Ordinary prose.</p>', self::ON));
+	}
+
+	public function testACollapsibleNeedsTheCollapsibleModule() {
+		$this->assertSame(
+			['jquery.makeCollapsible'],
+			LazyModules::forPage('<div class="mw-collapsible mw-collapsed">hidden</div>', self::ON)
+		);
+	}
+
+	public function testASortableTableNeedsTheSorter() {
+		$this->assertSame(
+			['jquery.tablesorter'],
+			LazyModules::forPage('<table class="wikitable sortable"><tr><td>a</td></tr></table>', self::ON)
+		);
+	}
+
+	public function testAPageWithBothNeedsBoth() {
+		$html = '<table class="sortable"></table><div class="mw-collapsible"></div>';
+		$this->assertSame(['jquery.makeCollapsible', 'jquery.tablesorter'], LazyModules::forPage($html, self::ON));
+	}
+
+	/**
+	 * The flag is what a skin turns off through SkinPageReadyConfig. With it off core never looks,
+	 * so neither does this: bundling the module would ship a feature the site asked not to have.
+	 */
+	public function testAFlagTurnedOffIsObeyed() {
+		$html = '<table class="sortable"></table><div class="mw-collapsible"></div>';
+		$this->assertSame(
+			['jquery.makeCollapsible'],
+			LazyModules::forPage($html, ['collapsible' => true, 'sortable' => false])
+		);
+		$this->assertSame([], LazyModules::forPage($html, []), 'an absent flag is an off flag');
+	}
+
+	/**
+	 * Core's own toggle and content wrappers are named after the class that makes them, so a
+	 * substring match would find a collapsible in a page that has none of its own.
+	 */
+	public function testAWrapperClassIsNotTheClassItself() {
+		$this->assertFalse(LazyModules::hasClass('<div class="mw-collapsible-content">x</div>', 'mw-collapsible'));
+		$this->assertTrue(LazyModules::hasClass('<div class="a mw-collapsible b">x</div>', 'mw-collapsible'));
+	}
+
+	public function testTheTagIsPartOfTheSelector() {
+		$onADiv = '<div class="sortable">not a table</div>';
+		$this->assertSame([], LazyModules::forPage($onADiv, self::ON), 'core looks for table.sortable');
+		$this->assertTrue(LazyModules::hasClass($onADiv, 'sortable'), 'and for the class on anything');
+	}
+
+	/**
+	 * @dataProvider provideMarkup
+	 */
+	public function testItReadsTheClassOutOfRealMarkup(string $html, bool $expected) {
+		$this->assertSame($expected, LazyModules::hasClass($html, 'sortable', 'table'));
+	}
+
+	public static function provideMarkup(): array {
+		return [
+			'class first' => ['<table class="sortable">', true],
+			'class after other attributes' => ['<table id="t" class="wikitable sortable">', true],
+			'single quotes' => ["<table class='sortable jquery-tablesorter'>", true],
+			'uppercase tag' => ['<TABLE CLASS="sortable">', true],
+			// The word appears, but not as a class of a table, which is what core searches for.
+			'the word in prose' => ['<p>A sortable table</p><table class="wikitable">', false],
+			'a longer class that contains it' => ['<table class="unsortable">', false],
+			'on the row rather than the table' => ['<table><tr class="sortable">', false]
+		];
+	}
+}


### PR DESCRIPTION
Closes #483.

## What was broken

A collapsible got no toggle, content marked `mw-collapsed` was shown rather than hidden, and a sortable table's headers did nothing. The bake was green and the HTML was correct in every case, which is what made it invisible.

`mediawiki.page.ready` does not queue either module while rendering. It waits until the page is in a browser, searches the DOM, and asks `load.php`:

```js
if ( config.collapsible ) {
    $collapsible = $content.find( '.mw-collapsible' );
    if ( $collapsible.length ) { modules.push( 'jquery.makeCollapsible' ); }
}
if ( config.sortable ) {
    $sortable = $content.find( 'table.sortable' );
    if ( $sortable.length ) { modules.push( 'jquery.tablesorter' ); }
}
if ( modules.length ) { mw.loader.using( modules ).then( ... ); }
```

An export has no `load.php`.

## Following core rather than working around it

Of the options #483 laid out, this is the one that keeps MediaWiki's own behaviour:

* **the same flags**, read through the `SkinPageReadyConfig` hook exactly as core's `config.json` callback builds them — so a skin that turns a feature off gets the same answer from a bake as from a wiki, rather than a module it asked not to have;
* **the same selectors**, `.mw-collapsible` on any element and `sortable` on a `table`;
* **the same condition** — only a page that has one gets the module. Always bundling both would have been simpler and is the one thing core never does.

Only the timing moves, from read time to build time, and that is the single thing a static site cannot do MediaWiki's way. `buildScripts.php` already read the rendered HTML for what pages queue; this is another question asked of the same files, in the same pass. `resolveSearchModule()` was already building the ready config to answer a related question, so that is now built once and shared.

Whatever core adds to that list next is another line in `LazyModules::MODULES`.

## What holds it

The detection is string work with no MediaWiki in it, so it sits in `includes/` and is unit-tested directly, over the markup that actually turns up:

| | |
|---|---|
| `<table id="t" class="wikitable sortable">` | class after other attributes |
| `<table class='sortable'>` | single quotes |
| `<TABLE CLASS="sortable">` | case |
| `<p>A sortable table</p>` | the word in prose, no class |
| `<table class="unsortable">` | a longer class that contains it |
| `<table><tr class="sortable">` | the class on the row, not the table |
| `<div class="mw-collapsible-content">` | core's own wrapper, which a substring match would take for the thing itself |

`docs/Licenses` gains `sortable` — its component/license/bundled-in table wanted it anyway, and a reader who wants everything under GPL-2.0, or everything in the binary, now gets it. `smoke` asserts both halves of the claim: that the page still has a sortable table for this to be about, and that `jquery.tablesorter` reached `modules-static.js`.

## What is not covered

The collapsible half has no natural home in these docs, and inventing a fold to test one would be a worse page. It rests on the unit tests, which cover the same code path — `forPage()` runs both features through one loop, and the only difference between them is a row of `MODULES`. Draft until CI has run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv1RzRurUH6wrgV5E9PESQ)_