### PR TITLE
fix(docs): make the brand teal and the note box legible in dark mode

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -24,7 +24,7 @@
 	--color-progressive--focus: #10707f;
 	/* A reference rather than a literal, so the accent and the links cannot drift
 	 * apart again the way they did in night mode. */
-	--color-link: var( --color-progressive );
+	--color-link: var(--color-progressive);
 	--color-visited: #0e5f70;
 }
 
@@ -38,7 +38,7 @@
 	}
 }
 
-@media screen and ( prefers-color-scheme: dark ) {
+@media screen and (prefers-color-scheme: dark) {
 	html.skin-theme-clientpref-os {
 		--color-progressive: #4ec3da;
 		--color-progressive--hover: #79d0e0;
@@ -52,7 +52,7 @@
  * token above, so they need recolouring here as well -- but from the token, not
  * from a literal, or they keep the light theme's teal on a dark ground. */
 a:visited {
-	color: var( --color-visited );
+	color: var(--color-visited);
 }
 
 /* The external-link arrow is a fixed-colour background image in the skin; swap it
@@ -67,13 +67,19 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 /* The arrow is an image, so it cannot read the token: night mode needs its own copy,
  * or the light theme's dark teal sits on the dark ground beside a light-teal link. */
 @media screen {
-	html.skin-theme-clientpref-night body:not( .skin-citizen ) .mw-parser-output a.external {
+	html.skin-theme-clientpref-night
+		body:not(.skin-citizen)
+		.mw-parser-output
+		a.external {
 		background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'%3E%3Cpath%20fill='%234ec3da'%20d='M17%2017H3V3h5V1H3a2%202%200%2000-2%202v14a2%202%200%20002%202h14a2%202%200%20002-2v-5h-2zM11%201v2h4.6L7.3%2011.3l1.4%201.4L17%204.4V9h2V1z'/%3E%3C/svg%3E");
 	}
 }
 
-@media screen and ( prefers-color-scheme: dark ) {
-	html.skin-theme-clientpref-os body:not( .skin-citizen ) .mw-parser-output a.external {
+@media screen and (prefers-color-scheme: dark) {
+	html.skin-theme-clientpref-os
+		body:not(.skin-citizen)
+		.mw-parser-output
+		a.external {
 		background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'%3E%3Cpath%20fill='%234ec3da'%20d='M17%2017H3V3h5V1H3a2%202%200%2000-2%202v14a2%202%200%20002%202h14a2%202%200%20002-2v-5h-2zM11%201v2h4.6L7.3%2011.3l1.4%201.4L17%204.4V9h2V1z'/%3E%3C/svg%3E");
 	}
 }

--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -1,19 +1,58 @@
 /* Wikven uses a teal brand colour, so replace the skin's default Wikimedia blue
  * (the Codex "progressive" colour) with teal. Links and interactive accents read
- * these tokens, so overriding them recolours them site-wide. */
+ * these tokens, so overriding them recolours them site-wide.
+ *
+ * Stated once per theme, because a bare :root loses. Every skin here redefines the
+ * whole Codex set for night mode under html.skin-theme-clientpref-night (0,1,1) or
+ * :root.skin-theme-clientpref-night (0,2,0), and a bare :root is (0,1,0), so it is
+ * out-specified whatever the link order. Before this, night mode took the accent
+ * back to Codex blue while the links stayed teal -- 3.95:1 on the dark ground, and
+ * 2.55:1 for the visited colour, which the rule below had pinned rather than read.
+ *
+ * The selectors are core's own, from the darkmode-override() mixin in
+ * mediawiki.mixins.less: the class the appearance menu writes, and the OS query for
+ * a reader who left it on Automatic. Theme here is a class on <html>, not
+ * prefers-color-scheme -- a reader who picks Dark on a light OS gets the class and
+ * no media match, so handling only the query would miss exactly the people who asked.
+ */
 :root {
-	--color-progressive: #157f93;
-	--color-progressive--hover: #0f6173;
-	--color-progressive--active: #0c4d5b;
-	--color-progressive--focus: #157f93;
-	--color-link: #157f93;
+	/* #157f93 darkened a little: it was 4.44:1 on the #f8f9fa the skins use for a
+	 * subtle background, just under AA. Same hue, so it reads as the same brand. */
+	--color-progressive: #10707f;
+	--color-progressive--hover: #0d5c68;
+	--color-progressive--active: #0a4954;
+	--color-progressive--focus: #10707f;
+	/* A reference rather than a literal, so the accent and the links cannot drift
+	 * apart again the way they did in night mode. */
+	--color-link: var( --color-progressive );
 	--color-visited: #0e5f70;
 }
 
+@media screen {
+	html.skin-theme-clientpref-night {
+		--color-progressive: #4ec3da;
+		--color-progressive--hover: #79d0e0;
+		--color-progressive--active: #8ed8e6;
+		--color-progressive--focus: #4ec3da;
+		--color-visited: #a799cd;
+	}
+}
+
+@media screen and ( prefers-color-scheme: dark ) {
+	html.skin-theme-clientpref-os {
+		--color-progressive: #4ec3da;
+		--color-progressive--hover: #79d0e0;
+		--color-progressive--active: #8ed8e6;
+		--color-progressive--focus: #4ec3da;
+		--color-visited: #a799cd;
+	}
+}
+
 /* Visited links are coloured by a hard-coded a:visited rule in the skin, not the
- * token above, so recolour them to a darker teal here as well. */
+ * token above, so they need recolouring here as well -- but from the token, not
+ * from a literal, or they keep the light theme's teal on a dark ground. */
 a:visited {
-	color: #0e5f70;
+	color: var( --color-visited );
 }
 
 /* The external-link arrow is a fixed-colour background image in the skin; swap it
@@ -23,6 +62,20 @@ a:visited {
  * makes teal, so an image with no size or position of its own would tile over it. */
 body:not(.skin-citizen) .mw-parser-output a.external {
 	background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'%3E%3Cpath%20fill='%23157f93'%20d='M17%2017H3V3h5V1H3a2%202%200%2000-2%202v14a2%202%200%20002%202h14a2%202%200%20002-2v-5h-2zM11%201v2h4.6L7.3%2011.3l1.4%201.4L17%204.4V9h2V1z'/%3E%3C/svg%3E");
+}
+
+/* The arrow is an image, so it cannot read the token: night mode needs its own copy,
+ * or the light theme's dark teal sits on the dark ground beside a light-teal link. */
+@media screen {
+	html.skin-theme-clientpref-night body:not( .skin-citizen ) .mw-parser-output a.external {
+		background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'%3E%3Cpath%20fill='%234ec3da'%20d='M17%2017H3V3h5V1H3a2%202%200%2000-2%202v14a2%202%200%20002%202h14a2%202%200%20002-2v-5h-2zM11%201v2h4.6L7.3%2011.3l1.4%201.4L17%204.4V9h2V1z'/%3E%3C/svg%3E");
+	}
+}
+
+@media screen and ( prefers-color-scheme: dark ) {
+	html.skin-theme-clientpref-os body:not( .skin-citizen ) .mw-parser-output a.external {
+		background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'%3E%3Cpath%20fill='%234ec3da'%20d='M17%2017H3V3h5V1H3a2%202%200%2000-2%202v14a2%202%200%20002%202h14a2%202%200%20002-2v-5h-2zM11%201v2h4.6L7.3%2011.3l1.4%201.4L17%204.4V9h2V1z'/%3E%3C/svg%3E");
+	}
 }
 
 /* A cleaner syntax-highlight palette in place of the default Pygments theme,

--- a/docs/Template:note/styles.css
+++ b/docs/Template:note/styles.css
@@ -1,12 +1,21 @@
+/* Colours read from the skin's Codex tokens rather than written here. The box used to
+ * pin background-color: #f8f9fa and set no colour at all, so night mode put the
+ * inherited --color-base (#eaecf0) on a near-white box: 1.12:1, which is text you
+ * cannot see. Seven pages use {{note}}.
+ *
+ * The literal in each var() is the light value, a fallback for a skin that defines no
+ * tokens. Defining a token here is not an option -- TemplateStyles drops a custom
+ * property declaration -- which is the whole reason these are read and not made. */
 .wikven-note {
 	display: flex;
 	align-items: center;
 	column-gap: 0.75em;
 	margin: 1em 0;
 	padding: 0.75em 1em;
-	border: 1px solid #c8ccd1;
+	border: 1px solid var( --border-color-subtle, #c8ccd1 );
 	border-radius: 2px;
-	background-color: #f8f9fa;
+	background-color: var( --background-color-neutral-subtle, #f8f9fa );
+	color: var( --color-base, #202122 );
 }
 
 .wikven-note-text p {

--- a/docs/Template:note/styles.css
+++ b/docs/Template:note/styles.css
@@ -12,10 +12,10 @@
 	column-gap: 0.75em;
 	margin: 1em 0;
 	padding: 0.75em 1em;
-	border: 1px solid var( --border-color-subtle, #c8ccd1 );
+	border: 1px solid var(--border-color-subtle, #c8ccd1);
 	border-radius: 2px;
-	background-color: var( --background-color-neutral-subtle, #f8f9fa );
-	color: var( --color-base, #202122 );
+	background-color: var(--background-color-neutral-subtle, #f8f9fa);
+	color: var(--color-base, #202122);
 }
 
 .wikven-note-text p {


### PR DESCRIPTION
Two contrast failures on the live docs site, both invisible in the theme they were written for. Found while working out how a landing page should source its colours; the landing page has to stand on this, so it comes first.

## `{{note}}` in night mode is text you cannot see

`Template:note/styles.css` pinned `background-color: #f8f9fa` and set no `color` at all, so the box kept the light theme's near-white ground while the text took the skin's inherited `--color-base`, `#eaecf0`.

**1.12:1.** Seven pages use `{{note}}` — Getting Started, Installation, Translating and others.

## The brand teal splits in two

`MediaWiki:Common.css` stated the teal on a bare `:root`, which loses. Every skin here redefines the whole Codex set for night mode under `html.skin-theme-clientpref-night` (0,1,1) or `:root.skin-theme-clientpref-night` (0,2,0), against a bare `:root`'s (0,1,0) — out-specified whatever the link order.

So in night mode:

| | what happened | ratio on `#101418` |
|---|---|---|
| `--color-progressive` | reverted to Codex blue | — |
| `--color-link` | not redefined in the dark file, so stayed teal | **3.95:1** |
| `a:visited` | pinned to a literal rather than reading its token | **2.55:1** |

The accent went blue while the links stayed teal, and both failed AA.

## What changed

Stated once per theme, under core's own `darkmode-override()` selectors from `mediawiki.mixins.less`: the class the appearance menu writes, and the OS query for a reader left on Automatic. Theme here is a class on `<html>`, not `prefers-color-scheme` — a reader who picks Dark on a light OS gets the class and no media match, so handling only the query would miss exactly the people who asked for dark.

The light teal is darkened from `#157f93` to `#10707f` too. Same hue, so it reads as the same brand, but the old one was **4.44:1** on the `#f8f9fa` the skins use for a subtle background — just under AA. It only ever passed on pure white.

`--color-link` now references `--color-progressive` rather than restating it, so the accent and the links cannot drift apart again. The external-link arrow is a background image and cannot read a token, so night mode gets its own copy.

## Measured

Computed here rather than taken on faith, against Codex's dark ground `#101418` and the light backgrounds the skins actually use:

| | before | after |
|---|---|---|
| accent on `#f8f9fa` (light) | 4.44 ✗ | 5.46 ✓ |
| accent on white (light) | 4.68 ✓ | 5.76 ✓ |
| link on `#101418` (night) | 3.95 ✗ | 8.93 ✓ |
| visited on `#101418` (night) | 2.55 ✗ | 7.12 ✓ |
| note text on its own box (night) | 1.12 ✗ | reads the token ✓ |

## Why the tokens are read and never written

`MediaWiki:Common.css` is `site.styles` and is not sanitised, so it can *define* custom properties. `Template:note/styles.css` goes through TemplateStyles, which **drops a custom-property declaration** — verified by running the extension's own sanitiser. That forces the split this change follows: define in Common.css, consume with `var()` in TemplateStyles. Worth writing down, because the failure is silent: the declaration vanishes, the rule stays, and the page looks half-styled.

## Not verified

Nobody has looked at this in a browser — there is no MediaWiki in this container. The ratios are computed from the shipped hex values and are exact; what wants an eye is how the darker teal sits beside the rest of the palette, in all three skins and both themes. `preview` will have it.

Draft until then.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv1RzRurUH6wrgV5E9PESQ)_