### PR TITLE
docs: drop the syntax-highlight palette from MediaWiki:Common.css

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -61,7 +61,7 @@ a:visited {
  * arrow and draws its own as a currentColor mask, which the token above already
  * makes teal, so an image with no size or position of its own would tile over it. */
 body:not(.skin-citizen) .mw-parser-output a.external {
-	background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'%3E%3Cpath%20fill='%23157f93'%20d='M17%2017H3V3h5V1H3a2%202%200%2000-2%202v14a2%202%200%20002%202h14a2%202%200%20002-2v-5h-2zM11%201v2h4.6L7.3%2011.3l1.4%201.4L17%204.4V9h2V1z'/%3E%3C/svg%3E");
+	background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'%3E%3Cpath%20fill='%2310707f'%20d='M17%2017H3V3h5V1H3a2%202%200%2000-2%202v14a2%202%200%20002%202h14a2%202%200%20002-2v-5h-2zM11%201v2h4.6L7.3%2011.3l1.4%201.4L17%204.4V9h2V1z'/%3E%3C/svg%3E");
 }
 
 /* The arrow is an image, so it cannot read the token: night mode needs its own copy,
@@ -82,89 +82,6 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 		a.external {
 		background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'%3E%3Cpath%20fill='%234ec3da'%20d='M17%2017H3V3h5V1H3a2%202%200%2000-2%202v14a2%202%200%20002%202h14a2%202%200%20002-2v-5h-2zM11%201v2h4.6L7.3%2011.3l1.4%201.4L17%204.4V9h2V1z'/%3E%3C/svg%3E");
 	}
-}
-
-/* A cleaner syntax-highlight palette in place of the default Pygments theme,
- * tuned for the light background with teal as the keyword accent. */
-.mw-highlight .c,
-.mw-highlight .ch,
-.mw-highlight .cm,
-.mw-highlight .cp,
-.mw-highlight .cpf,
-.mw-highlight .c1,
-.mw-highlight .cs {
-	color: #6a737d;
-	font-style: italic;
-}
-.mw-highlight .k,
-.mw-highlight .kc,
-.mw-highlight .kd,
-.mw-highlight .kn,
-.mw-highlight .kp,
-.mw-highlight .kr,
-.mw-highlight .kt {
-	color: #157f93;
-	font-weight: bold;
-}
-.mw-highlight .o,
-.mw-highlight .ow {
-	color: #0c4d5b;
-}
-.mw-highlight .s,
-.mw-highlight .sa,
-.mw-highlight .sb,
-.mw-highlight .sc,
-.mw-highlight .dl,
-.mw-highlight .sd,
-.mw-highlight .s2,
-.mw-highlight .se,
-.mw-highlight .sh,
-.mw-highlight .si,
-.mw-highlight .sx,
-.mw-highlight .sr,
-.mw-highlight .s1,
-.mw-highlight .ss {
-	color: #15803d;
-}
-.mw-highlight .m,
-.mw-highlight .mb,
-.mw-highlight .mf,
-.mw-highlight .mh,
-.mw-highlight .mi,
-.mw-highlight .mo,
-.mw-highlight .il,
-.mw-highlight .nb,
-.mw-highlight .bp {
-	color: #0b6eb8;
-}
-.mw-highlight .nf,
-.mw-highlight .fm {
-	color: #8250df;
-}
-.mw-highlight .nc,
-.mw-highlight .nn,
-.mw-highlight .ne {
-	color: #8250df;
-	font-weight: bold;
-}
-.mw-highlight .nt {
-	color: #157f93;
-	font-weight: bold;
-}
-.mw-highlight .na {
-	color: #6f42c1;
-}
-.mw-highlight .nv,
-.mw-highlight .vc,
-.mw-highlight .vg,
-.mw-highlight .vi {
-	color: #953800;
-}
-.mw-highlight .gd {
-	color: #b31d28;
-}
-.mw-highlight .gi {
-	color: #15803d;
 }
 
 /* MobileFrontend's footer toggle between the mobile and desktop views. It is a supported MediaWiki


### PR DESCRIPTION
`MediaWiki:Common.css` replaced SyntaxHighlight's palette with nine literal colours picked for a light code block. They stayed literal when the theme changed, so on the `#202122` ground a code block gets in night mode all nine failed AA:

| role | colour | on `#202122` |
| --- | --- | --- |
| comment | `#6a737d` | 3.35 |
| keyword | `#157f93` | 3.45 |
| operator | `#0c4d5b` | **1.71** |
| string | `#15803d` | 3.22 |
| number | `#0b6eb8` | 3.02 |
| function | `#8250df` | 3.20 |
| class | `#6f42c1` | 2.48 |
| name | `#953800` | 2.18 |
| error | `#b31d28` | 2.40 |

The first version of this PR gave the palette a dark half. That was the wrong fix: it left this site maintaining its own nine colours in step with a theme it does not control, for no gain over the palette the extension already ships. So the override goes instead, and code blocks render in SyntaxHighlight's default.

The **external-link arrow** is unrelated and stays in. It is a fixed-colour SVG data URI, so it could not follow `--color-progressive` when #489 moved the brand teal to `#10707f` — it was still drawing the old `#157f93` beside links that had already moved. Now it matches again.

The diff is therefore: the whole `.mw-highlight` block deleted, one hex changed in the light arrow's SVG.

Not verified here: there is no MediaWiki in this container, so I have not seen what SyntaxHighlight's default looks like in night mode on this site — `preview` will show it. If it turns out the default has no dark handling, the answer is upstream in the extension rather than a second palette here.