### PR TITLE
fix: drop the discussion tab in every skin, Minerva included

### DIFF
--- a/includes/Hooks/Hider.php
+++ b/includes/Hooks/Hider.php
@@ -42,6 +42,22 @@ class Hider implements
 		// pointing at the login page, so ext.Wikven.styles still hides what it re-adds.
 		unset($links['actions']['watch'], $links['actions']['unwatch']);
 
+		// The discussion tab. A static export cannot carry a discussion -- there is nothing behind
+		// the tab to read and no way to post to it -- and MediaWiki has no setting that turns talk
+		// namespaces off (T35298), so it is dropped from the navigation every skin builds from.
+		// A `#ca-talk` rule in ext.Wikven.styles is not enough: that id is core's own on the tab,
+		// and Minerva renders the same data through a tab bar of its own that keeps no id to hide.
+		// Both menus, because a skin still asking core for the legacy `namespaces` one is rendered
+		// from that copy rather than from `associated-pages`.
+		foreach (['associated-pages', 'namespaces'] as $menu) {
+			foreach (array_keys($links[$menu] ?? []) as $key) {
+				// 'talk' in the main namespace, '<subject>_talk' everywhere else.
+				if ($key === 'talk' || str_ends_with((string)$key, '_talk')) {
+					unset($links[$menu][$key]);
+				}
+			}
+		}
+
 		// Edit/history tabs need configured external URLs and a source file; else they 404 or self-link.
 		global $wgWikvenEditUrl, $wgWikvenHistoryUrl;
 		$title = $sktemplate->getTitle();

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -8,9 +8,7 @@
 #footer-places-disclaimer,
 #footer-places-disclaimers,
 #footer-info-credits,
-#footer-info-lastmod,
-// There is not a option to disable some or all talk namespaces (T35298)
-#ca-talk {
+#footer-info-lastmod {
   display: none;
 }
 

--- a/tests/e2e/discussion-tab.spec.js
+++ b/tests/e2e/discussion-tab.spec.js
@@ -1,0 +1,38 @@
+// A static export carries no discussion: there is nothing behind the tab to read and no way to
+// post to it. The tab is taken out of the navigation in PHP (Hooks\Hider) rather than hidden in
+// CSS, because a `#ca-talk` rule only reaches the id core puts on its own tab: Minerva builds a tab
+// bar of its own out of the same data and keeps no id on it, so its Discussion tab stood through
+// every skin's stylesheet. Read in a browser, one skin at a time, so the next skin that draws the
+// tab its own way is caught by the page rather than by the rule that was supposed to cover it.
+
+const { test, expect } = require("@playwright/test");
+
+// The same article as each skin renders it. The default skin bakes to the root; the others to a
+// directory of their own.
+const PAGES = {
+	"the main skin": "Installation.html",
+	minerva: "minerva/Installation.html",
+	citizen: "citizen/Installation.html",
+};
+
+// Every shape the tab takes: core's own id on it, the rel core marks the link with -- which is what
+// Minerva carries into its tab bar in place of the id -- and the button Minerva puts at the foot of
+// a page on the sites where it shows talk there instead of at the top.
+const DISCUSSION =
+	'#ca-talk, [rel="discussion"], #page-secondary-actions .talk';
+
+for (const [skin, path] of Object.entries(PAGES)) {
+	test(`${skin} offers no discussion tab`, async ({ page, request }) => {
+		const response = await request.get(path).catch(() => null);
+		test.skip(!response?.ok(), `this export does not render ${skin}`);
+
+		await page.goto(path);
+
+		// Absent, not merely invisible: the export ships the markup it renders, and a tab hidden by
+		// a stylesheet is one skin update away from being visible again.
+		await expect(page.locator(DISCUSSION)).toHaveCount(0);
+		// And the page rendered, so a skin copy that stopped being written cannot pass the check
+		// above as chrome that went. The heading is the one element every skin here draws.
+		await expect(page.locator("#firstHeading")).toBeVisible();
+	});
+}

--- a/tests/phpunit/integration/HiderTest.php
+++ b/tests/phpunit/integration/HiderTest.php
@@ -65,6 +65,17 @@ class HiderTest extends MediaWikiIntegrationTestCase {
 		$this->assertArrayHasKey('view', $generated['views']);
 	}
 
+	/**
+	 * The discussion tab goes, wherever a skin reads it from: a static export carries no
+	 * discussion, and core has no setting that turns talk namespaces off (T35298). The subject
+	 * tab beside it stays, as it does in every skin the export renders.
+	 */
+	public function testNavigationDropsTheDiscussionTab() {
+		$links = $this->navigationFor('Real');
+		$this->assertSame(['main'], array_keys($links['associated-pages']));
+		$this->assertSame(['user'], array_keys($links['namespaces']), 'the legacy copy too');
+	}
+
 	private function navigationFor(string $titleText): array {
 		$sktemplate = $this->createMock(SkinTemplate::class);
 		$sktemplate->method('getTitle')->willReturn(Title::newFromText($titleText));
@@ -80,7 +91,11 @@ class HiderTest extends MediaWikiIntegrationTestCase {
 				'viewsource' => ['x'],
 				'history' => ['x']
 			],
-			'actions' => ['watch' => ['x'], 'unwatch' => ['x']]
+			'actions' => ['watch' => ['x'], 'unwatch' => ['x']],
+			// The tab menus, in both the shapes core fills: the modern one, and the legacy copy a
+			// skin still asking for `namespaces` is rendered from.
+			'associated-pages' => ['main' => ['keep'], 'talk' => ['x']],
+			'namespaces' => ['user' => ['keep'], 'user_talk' => ['x']]
 		];
 		( new Hider() )->onSkinTemplateNavigation__Universal($sktemplate, $links);
 		return $links;


### PR DESCRIPTION
Minerva renders a Discussion tab on every article it exports, and no stylesheet reaches it.

## Why it escaped

The tab was hidden by a `#ca-talk` rule in `ext.Wikven.styles.less`. That id is core's own: `SkinTemplate` stamps it on the talk entry of the content navigation *after* the `SkinTemplateNavigation::Universal` hook, and only skins that render core's portlet markup carry it into the page. Minerva does not — it maps the same `associated-pages` data into its own tab bar (`skin.mustache`, `.minerva__tab`), and `mapPortletData()` drops the item id on the way, leaving `rel="discussion"` as the only mark on the link.

The bar is drawn because a bake renders as the registered `Maintenance script` user and MobileFrontend's `RequestContextCreateSkinMobile` hook never fires, so Minerva's compiled `TALK_AT_TOP` default (`true`) stands. The same data also feeds the skin's secondary "Discussion" button at the foot of a page on sites where talk sits at the bottom.

## What changed

`Hooks\Hider::onSkinTemplateNavigation__Universal()` now drops the talk entry from the navigation itself, before any skin reads it — `'talk'` in the main namespace, `'<subject>_talk' `elsewhere. Both the `associated-pages` menu and the legacy `namespaces` copy core still fills for skins that ask for it. That is one place rather than one selector per skin that draws the tab its own way, which is what this bug was.

The `#ca-talk` rule goes with it: it now describes an element the export no longer renders. The subject tab beside it stays, as it already does in the other skins (Vector has shown a lone "Page" tab all along).

A static export carrying no discussion is not new behaviour — `docs/index.wikitext` already lists "Discussion pages as a workflow" as unsupported, and the tab has been hidden since the rule was written. This makes the hiding hold in a skin that renders its own chrome.

## Tests

- `HiderTest::testNavigationDropsTheDiscussionTab` — the entry is gone from both menus, the subject tab is not.
- `tests/e2e/discussion-tab.spec.js` — the baked article in each skin the docs site renders (main skin, Minerva, Citizen) carries no `#ca-talk`, no `[rel="discussion"]` and no secondary talk button, and still renders its heading. Absence in the DOM, not `display: none`, so the next skin that draws the tab its own way is caught by the page rather than by the rule meant to cover it.

## Verification

`mago format --check`, `mago lint` and `biome ci` are clean. The PHPUnit and browser suites were not run here: this environment has no Docker daemon, so neither a MediaWiki install nor a bake could be produced locally — CI's smoke job is what exercises both. The reasoning above was read off MinervaNeue and MediaWiki core at `REL1_46`, the branch this image builds from.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JQywRDDMDbiBaUExTpYxZ)_