### PR TITLE
docs: order the sidebar as a walk, then a set of references

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -272,33 +272,27 @@ jobs:
             exit 1
           fi
 
-          # The two ends of the sequence get one link rather than two, which the old shape could not
-          # spell: a lone argument was the next step, so the last page had no way to say it had none.
-          #
-          # Matched on the div rather than the class name. TemplateStyles inlines prevnext/styles.css
-          # into every page that has a row, so both class names appear in the page's own stylesheet
-          # whether or not either link was rendered -- which is what the first draft of this check
-          # tripped over.
-          if grep -q 'class="wikven-prevnext-prev"' dist/Why_wikitext.html; then
-            echo "::error::Why wikitext heads the sequence and should have no previous link"
-            exit 1
-          fi
-          if grep -q 'class="wikven-prevnext-next"' dist/Licenses.html; then
-            echo "::error::Licenses ends the sequence and should have no next link"
-            exit 1
-          fi
-
           # A prevnext link is labelled with the target page's own title, so on a translated page it
           # must carry the translated one. The label is not in the calling page's source: the call
           # sits outside the translate tags and passes a page name, and the template reads the
           # title from the target's own title unit, which is the whole point -- a label restated in
           # the caller would be a second copy of a string that is already translated once.
           # Searching/ko is the fixture, and the expectation is read from the source rather than
-          # written here: any Korean at all would pass a string pinned in this file.
+          # written here: any Korean at all would pass a string pinned in this file. Which page
+          # follows Searching is read from the sidebar for the same reason the row itself is --
+          # naming it here would make this a check of a particular order rather than of the label.
+          following=$(sed -n 's@^\*\* *Special:MyLanguage/\([^|]*\).*@\1@p' 'docs/MediaWiki:Sidebar.wikitext' \
+            | awk '/^Searching$/ { if ((getline) > 0) print; exit }')
+          # Checked before the file is read: awk on docs//ko.wikitext would abort the step with its
+          # own error, which says nothing about the sidebar being what went wrong.
+          if [ -z "$following" ]; then
+            echo "::error::MediaWiki:Sidebar names no page after Searching, so this check has no pair to make"
+            exit 1
+          fi
           want=$(awk '/^<!--T:title[ -]/ { found = 1; next } found && NF { print; exit }' \
-            docs/Translating/ko.wikitext)
+            "docs/$following/ko.wikitext")
           if [ -z "$want" ]; then
-            echo "::error::docs/Translating/ko.wikitext has no translated title to expect"
+            echo "::error::docs/$following/ko.wikitext has no translated title to expect"
             exit 1
           fi
           # Newlines are flattened before the block is read: the template writes its markup over
@@ -310,7 +304,7 @@ jobs:
           case "$shown" in
             *"$want"*) ;;
             *)
-              echo "::error::Searching/ko's prevnext does not show Translating's Korean title ($want)"
+              echo "::error::Searching/ko's prevnext does not show $following's Korean title ($want)"
               echo "$shown"
               exit 1
               ;;

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -5,25 +5,25 @@
      offers its own Home besides -- fillMinervaMenu.php drops an entry leading there for that
      reason, so this section only ever reached the two skins that show the logo anyway. -->
 * sidebar-docs
-** Special:MyLanguage/Why wikitext|sidebar-why-wikitext
 ** Special:MyLanguage/Installation|sidebar-installation
 ** Special:MyLanguage/Getting Started|sidebar-getting-started
 ** Special:MyLanguage/Pages|sidebar-pages
-** Special:MyLanguage/Editing sidebar|sidebar-editing-sidebar
 ** Special:MyLanguage/Images|sidebar-images
 ** Special:MyLanguage/Skins|sidebar-skins
+** Special:MyLanguage/Searching|sidebar-searching
 ** Special:MyLanguage/Extensions|sidebar-extensions
 ** Special:MyLanguage/Lua modules|sidebar-lua-modules
 ** Special:MyLanguage/JavaScript|sidebar-javascript
-** Special:MyLanguage/Searching|sidebar-searching
 ** Special:MyLanguage/Translating|sidebar-translating
+** Special:MyLanguage/Editing sidebar|sidebar-editing-sidebar
 ** Special:MyLanguage/Deploying|sidebar-deploying
 ** Special:MyLanguage/Troubleshooting|sidebar-troubleshooting
 * sidebar-references
 ** Special:MyLanguage/Limitations|sidebar-limitations
+** Special:MyLanguage/Why wikitext|sidebar-why-wikitext
 ** Special:MyLanguage/Configuration|sidebar-configuration
 ** Special:MyLanguage/Standalone binary|sidebar-standalone-binary
 ** Special:MyLanguage/Commands|sidebar-commands
-** Special:MyLanguage/Development|sidebar-development
 ** Special:MyLanguage/Writing an extension|sidebar-writing-an-extension
+** Special:MyLanguage/Development|sidebar-development
 ** Special:MyLanguage/Licenses|sidebar-licenses


### PR DESCRIPTION
`MediaWiki:Sidebar` is the reading order as well as the menu — `Module:Sequence` reads it to build the prev/next row on every page (#487) — so its order is the order the documentation is read in, and it had never been chosen as one. It was the order the pages happened to be written in.

## The order

**Docs** — Installation, Getting Started, Pages, Images, Skins, Searching, Extensions, Lua modules, JavaScript, Translating, Editing sidebar, Deploying, Troubleshooting

**References** — Limitations, Why wikitext, Configuration, Standalone binary, Commands, Writing an extension, Development, Licenses

Docs is one walk: get the tool, build something, author it, shape the site, extend it, translate it, publish it, fix it.

## What moved, and why

**Why wikitext led the whole thing.** It argues wikitext against Markdown, which is a question a reader has before installing anything rather than a step they walk — and the front page now makes that argument itself, citing `Why wikitext` and `Limitations` together as its two read-more links. Both are appendices to the landing page, so both are in References, and they stay a pair.

**Searching moves up beside Skins.** It needs a skin to mount its typeahead, and both `Extensions` and `Skins` pointed forward to it from above; those two references now point backwards.

**Editing sidebar moves below Skins and Translating.** Two of its three sections presume translation — the labels are messages, so the Korean wording is a `/ko` file — and its logo and Minerva claims presume `Skins`. At fifth place it asked a reader who had just built a Hello World to write a Korean message file for a site with no translations, and to link pages they did not have.

**Deploying ends the walk, Troubleshooting follows it**, where a walk stops and lookup begins.

**References opens with the two short pages the landing page hangs off it.** They are also the ramp: `Troubleshooting` into `Configuration` is 78 lines into 225, and the three reference pages after it run to 557 without a break. `Configuration` leads those three, being the page the rest of the documentation links most — 17 of the other 20 pages link it.

**Standalone binary keeps its place before Commands.** `Commands`' examples are a bare `wikven build`, and it is `Standalone binary` that puts `wikven` on the `PATH`.

**Writing an extension now precedes Development.** `Development` sends readers to it in its opening lines, and is itself linked from nowhere else in the documentation.

## The CI change

Two smoke assertions named pages that only the old order made true: that `Why wikitext` has no previous link, because it was first, and that `Searching`'s next is `Translating`.

The ends-of-sequence assertion goes altogether. That the first page has no previous link and the last no next one is a detail of what `Template:prevnext` renders, and reading it back out of the built HTML is more of the docs' own furniture than a smoke check should be inspecting. What it was added for (#455) is the row being missing entirely, and the check above it already covers that — for every page the sidebar names, rather than for two of them.

The translated-label check stays, and now reads which page follows `Searching` from `MediaWiki:Sidebar`, the same place `Module:Sequence` reads it. It is about the label — that a link on a translated page carries the target's own translated title rather than a copy restated in the caller — so the pair it happens to use should follow the order rather than fix it.

## Checked

The sidebar diff is a pure reorder — the sorted entry sets before and after are identical, so nothing was added, dropped or duplicated. All 21 targets keep their `Special:MyLanguage/` prefix, without which `Module:Sequence` drops them from the chain silently and `Licenses` is eaten by the core `licenses` message. Every label message and target page exists; no entry is another entry plus a slash, so `positionOf`'s prefix match is still unambiguous. The file carries no translate units and there is no per-language sidebar, so nothing goes stale.

## Not done here

Three content defects the review turned up, all of them equally true on `main` and none fixed by reordering:

- `Troubleshooting`'s "Two configuration files, one of them ignored" says the first in precedence order wins, without naming the order or linking `Configuration` — and tells the reader to delete the others.
- `Writing an extension` puts `WikvenRepositories` at the top level, a sibling of `config:`; `Configuration` nests it under `config:`, and a top-level key is exactly what `Troubleshooting` says warns and is ignored. The same page writes `.wikven.yml` where every other page writes `.wikven.yaml`.
- `Editing sidebar` has no inbound prose link from any page — the sidebar is its only route in, which its move to eleventh makes slightly more so.
