### PR TITLE
fix(docs): paint the landing page's marks on its translations, and its buttons anywhere

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -134,6 +134,18 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 	white-space: nowrap;
 }
 
+/* The landing page's focus ring. Here because the sanitiser does not know :focus-visible and
+ * drops the whole rule -- the page's own stylesheet carried this and it never reached a reader.
+ * It was written there in its own rule so that the unknown pseudo-class could not take the hover
+ * rules down with it, which worked; what it could not do is survive at all.
+ *
+ * Stated rather than left to the browser, which draws a dark ring on the pale teal button in
+ * night mode. */
+.wikven-home-route a:focus-visible {
+	outline: 2px solid var(--color-emphasized, #101418);
+	outline-offset: 2px;
+}
+
 /* The diagram's file-type marks, and the caret in the command beside them.
  *
  * Both are here rather than in the page's own TemplateStyles because that file can carry

--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -26,6 +26,12 @@
 	 * apart again the way they did in night mode. */
 	--color-link: var(--color-progressive);
 	--color-visited: #0e5f70;
+	/* What reads on the accent when the accent is a background rather than text, for the
+	 * landing page's filled button and the command beside it. It has to invert with the accent:
+	 * white sits on the light theme's brand teal at 5.6:1 and on night's pale teal at 2.07:1,
+	 * so the two themes need opposite ends of the range. TemplateStyles can read a token but
+	 * cannot declare one, which is why it is here rather than in the page's own stylesheet. */
+	--wikven-cta-fg: #fff;
 }
 
 @media screen {
@@ -35,6 +41,7 @@
 		--color-progressive--active: #8ed8e6;
 		--color-progressive--focus: #4ec3da;
 		--color-visited: #a799cd;
+		--wikven-cta-fg: #101418;
 	}
 }
 
@@ -45,6 +52,7 @@
 		--color-progressive--active: #8ed8e6;
 		--color-progressive--focus: #4ec3da;
 		--color-visited: #a799cd;
+		--wikven-cta-fg: #101418;
 	}
 }
 
@@ -93,38 +101,6 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 	display: none;
 }
 
-/* The landing page's filled button, defined here because TemplateStyles drops a custom-property
- * declaration and so cannot make a token, only read one. It has to be a pair and it has to
- * invert: night mode moves --color-progressive to a pale teal that white text sits on at
- * 2.07:1, while the brand teal it replaces sits on the night ground at 3.2:1 -- so a button
- * pinned to either one stops being the loudest thing on the page in half the sessions. Light
- * teal with near-black text is 8.9:1 against both the text and the ground.
- *
- * Scoped to the landing page by its root-page class, which is the one the translations carry
- * too: the body of index/ko is page-index_ko, and only rootpage-index catches both. The
- * selectors are core's own darkmode-override() pair, the same as the tokens above. */
-.rootpage-index .mw-parser-output {
-	--wikven-cta-bg: #10707f;
-	--wikven-cta-bg--hover: #0d5c68;
-	--wikven-cta-fg: #fff;
-}
-
-@media screen {
-	html.skin-theme-clientpref-night .rootpage-index .mw-parser-output {
-		--wikven-cta-bg: #4ec3da;
-		--wikven-cta-bg--hover: #79d0e0;
-		--wikven-cta-fg: #101418;
-	}
-}
-
-@media screen and (prefers-color-scheme: dark) {
-	html.skin-theme-clientpref-os .rootpage-index .mw-parser-output {
-		--wikven-cta-bg: #4ec3da;
-		--wikven-cta-bg--hover: #79d0e0;
-		--wikven-cta-fg: #101418;
-	}
-}
-
 /* The landing page sets its own tagline where a page title would go, so the title is taken out
  * of the flow there and nowhere else.
  *
@@ -140,11 +116,16 @@ body:not(.skin-citizen) .mw-parser-output a.external {
  * the site name twice over.
  *
  * Here rather than in the page's own TemplateStyles because TemplateStyles prefixes every
- * selector with .mw-parser-output and the heading is outside the parser output. rootpage- so
- * that the translations (index/ko) are covered by the same rule as the source page; page- as
- * well, so the source page is covered even where the root class is not written. */
-.page-index #firstHeading,
-.rootpage-index #firstHeading {
+ * selector with .mw-parser-output and the heading is outside the parser output.
+ *
+ * Matched on a substring of the body class because neither of the two exact classes covers the
+ * translations. A page gets page-<title> and rootpage-<root title>, and Title::getRootText only
+ * strips a subpage where the namespace has them turned on, which the main namespace does not --
+ * so index/ko is one whole title and its classes are page-index_ko and rootpage-index_ko, which
+ * .page-index and .rootpage-index both miss. Module:Sequence matches the same names the same way
+ * and for the same reason. The substring catches all four, and can catch nothing else: the class
+ * is case-sensitive, so only a page whose title begins "index" reaches it. */
+[class*="page-index"] #firstHeading {
 	position: absolute;
 	overflow: hidden;
 	clip-path: inset(50%);
@@ -161,6 +142,11 @@ body:not(.skin-citizen) .mw-parser-output a.external {
  * sanitised, and the external-link arrow above is already a data-URI SVG, so the mechanism is one
  * the site has proven.
  *
+ * Not scoped to the landing page. The wikven-home- classes are written by that page's templates
+ * and nothing else uses them, so the class is the scope; a page selector on top of it only added
+ * a way to be wrong, which it was -- these rules named .rootpage-index and so painted nothing on
+ * index/ko, where the class is rootpage-index_ko.
+ *
  * Masks rather than images, and rather than a filter. An uploaded SVG placed with [[File:...]] is
  * a fixed-colour picture that cannot follow the theme -- the problem the arrow above solves by
  * carrying two copies of itself -- and a filter could only invert or rotate the colours the file
@@ -170,7 +156,7 @@ body:not(.skin-citizen) .mw-parser-output a.external {
  *
  * Only the four named types are marked. Anything else keeps the space, so the names in a tree
  * still start on the same edge, and nothing is drawn in it. */
-.rootpage-index .wikven-home-f::before {
+.wikven-home-f::before {
 	content: "";
 	display: inline-block;
 	inline-size: 1rem;
@@ -179,10 +165,10 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 	vertical-align: -0.18rem;
 }
 
-.rootpage-index .wikven-home-f--wikitext::before,
-.rootpage-index .wikven-home-f--html::before,
-.rootpage-index .wikven-home-f--css::before,
-.rootpage-index .wikven-home-f--dir::before {
+.wikven-home-f--wikitext::before,
+.wikven-home-f--html::before,
+.wikven-home-f--css::before,
+.wikven-home-f--dir::before {
 	-webkit-mask:
 		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'><path%20d='M9.4%201.6H4.2a.6.6%200%200%200-.6.6v11.6a.6.6%200%200%200%20.6.6h7.6a.6.6%200%200%200%20.6-.6V4.6zM9.4%201.6v3h3'%20fill='none'%20stroke='%23000'%20stroke-width='1.3'%20stroke-linejoin='round'/></svg>")
 		no-repeat center / contain;
@@ -191,7 +177,7 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 		no-repeat center / contain;
 }
 
-.rootpage-index .wikven-home-f--dir::before {
+.wikven-home-f--dir::before {
 	-webkit-mask-image: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'><path%20d='M1.7%203.4h4.1l1.6%202h6.9v7.2H1.7z'%20fill='none'%20stroke='%23000'%20stroke-width='1.3'%20stroke-linejoin='round'/></svg>");
 	mask-image: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'><path%20d='M1.7%203.4h4.1l1.6%202h6.9v7.2H1.7z'%20fill='none'%20stroke='%23000'%20stroke-width='1.3'%20stroke-linejoin='round'/></svg>");
 }
@@ -200,60 +186,54 @@ body:not(.skin-citizen) .mw-parser-output a.external {
  * pane: one kind of thing goes in and several come out, said in colour rather than in a sentence.
  * The other three are their own conventions, darkened for the light ground and lifted for the
  * night one. These are graphics and want 3:1, which every pair here clears on both grounds. */
-.rootpage-index .wikven-home-f--wikitext::before {
+.wikven-home-f--wikitext::before {
 	background-color: #10707f;
 }
 
-.rootpage-index .wikven-home-f--html::before {
+.wikven-home-f--html::before {
 	background-color: #b3541e;
 }
 
-.rootpage-index .wikven-home-f--css::before {
+.wikven-home-f--css::before {
 	background-color: #2b6cb0;
 }
 
-.rootpage-index .wikven-home-f--dir::before {
+.wikven-home-f--dir::before {
 	background-color: #54595d;
 }
 
 @media screen {
-	html.skin-theme-clientpref-night
-		.rootpage-index
-		.wikven-home-f--wikitext::before {
+	html.skin-theme-clientpref-night .wikven-home-f--wikitext::before {
 		background-color: #4ec3da;
 	}
 
-	html.skin-theme-clientpref-night
-		.rootpage-index
-		.wikven-home-f--html::before {
+	html.skin-theme-clientpref-night .wikven-home-f--html::before {
 		background-color: #e8a06a;
 	}
 
-	html.skin-theme-clientpref-night .rootpage-index .wikven-home-f--css::before {
+	html.skin-theme-clientpref-night .wikven-home-f--css::before {
 		background-color: #7fb3f0;
 	}
 
-	html.skin-theme-clientpref-night .rootpage-index .wikven-home-f--dir::before {
+	html.skin-theme-clientpref-night .wikven-home-f--dir::before {
 		background-color: #a2a9b1;
 	}
 }
 
 @media screen and (prefers-color-scheme: dark) {
-	html.skin-theme-clientpref-os
-		.rootpage-index
-		.wikven-home-f--wikitext::before {
+	html.skin-theme-clientpref-os .wikven-home-f--wikitext::before {
 		background-color: #4ec3da;
 	}
 
-	html.skin-theme-clientpref-os .rootpage-index .wikven-home-f--html::before {
+	html.skin-theme-clientpref-os .wikven-home-f--html::before {
 		background-color: #e8a06a;
 	}
 
-	html.skin-theme-clientpref-os .rootpage-index .wikven-home-f--css::before {
+	html.skin-theme-clientpref-os .wikven-home-f--css::before {
 		background-color: #7fb3f0;
 	}
 
-	html.skin-theme-clientpref-os .rootpage-index .wikven-home-f--dir::before {
+	html.skin-theme-clientpref-os .wikven-home-f--dir::before {
 		background-color: #a2a9b1;
 	}
 }
@@ -271,7 +251,7 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 	}
 }
 
-.rootpage-index .wikven-home-machine::after {
+.wikven-home-machine::after {
 	content: "";
 	display: inline-block;
 	inline-size: 0.55em;
@@ -283,7 +263,7 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.rootpage-index .wikven-home-machine::after {
+	.wikven-home-machine::after {
 		animation: none;
 	}
 }

--- a/docs/Template:home/doc.wikitext
+++ b/docs/Template:home/doc.wikitext
@@ -58,11 +58,20 @@ labels carry the direction for a reader who is not looking.
 
 == What is in MediaWiki:Common.css instead ==
 
-Three things the page needs and TemplateStyles cannot carry, all of them scoped to
-<code>rootpage-index</code>, which is the class the translations carry too:
+Three things the page needs and TemplateStyles cannot carry. None of them is scoped to the page:
+the <code>wikven-home-</code> classes are written by these templates and by nothing else, so the
+class is the scope. They were scoped once, to <code>rootpage-index</code>, and that was a bug —
+<code>Title::getRootText()</code> only strips a subpage where the namespace has them turned on,
+which the main namespace does not, so <code>index/ko</code> is one whole title whose classes are
+<code>page-index_ko</code> and <code>rootpage-index_ko</code>. Every one of these rules painted
+nothing on the translated page.
 
-; the filled button's two colours
+; the filled button's text colour
 : TemplateStyles drops a custom-property declaration, so a token can be read here but not made.
+The fill itself needs no token of its own: it is the brand accent, which the site already defines
+for both themes. What cannot be read off the accent is what goes on top of it — white sits on the
+light theme's teal at 5.6:1 and on night's pale teal at 2.07:1 — so the foreground inverts with it
+and is declared beside it, site-wide.
 ; the file-type marks
 : A <code>mask-image</code> is not colour-typed, so a <code>var()</code> in one cannot be checked
 and the declaration would be dropped. They are masks rather than images because an uploaded SVG is

--- a/docs/Template:home/styles.css
+++ b/docs/Template:home/styles.css
@@ -76,20 +76,21 @@
 	text-align: center;
 }
 
-/* The two colours come from MediaWiki:Common.css, which can declare a custom property where this
- * file cannot. They have to be a pair and they have to invert: night mode moves the accent to a
- * pale teal, which white text sits on at 2.07:1, and the brand teal it replaces sits on the night
- * ground at 3.2:1 -- a button that stops being the loudest thing on the page in half the
- * sessions. Pale teal with near-black text is 8.9:1 both ways. */
+/* The fill is the brand accent, which the skins already carry as a token in both themes. What
+ * cannot be read off it is the text on top: night mode moves the accent to a pale teal that
+ * white sits on at 2.07:1, so the foreground has to invert with it. That one token is declared
+ * in MediaWiki:Common.css, which can declare a custom property where this file cannot -- and
+ * declared site-wide beside the accent, not on the landing page, because a page class does not
+ * survive translation: the body of index/ko is page-index_ko. */
 .wikven-home-route-primary a {
-	border: 1px solid var(--wikven-cta-bg, #10707f);
-	background-color: var(--wikven-cta-bg, #10707f);
+	border: 1px solid var(--color-progressive, #10707f);
+	background-color: var(--color-progressive, #10707f);
 	color: var(--wikven-cta-fg, #fff);
 }
 
 .wikven-home-route-primary a:hover {
-	border-color: var(--wikven-cta-bg--hover, #0d5c68);
-	background-color: var(--wikven-cta-bg--hover, #0d5c68);
+	border-color: var(--color-progressive--hover, #0d5c68);
+	background-color: var(--color-progressive--hover, #0d5c68);
 }
 
 /* The secondary button has no background of its own, so it can read the accent token and be
@@ -352,9 +353,9 @@
 .wikven-home-machine {
 	flex: 0 0 auto;
 	padding: 1.25rem 1.75rem;
-	border: 1px solid var(--wikven-cta-bg, #10707f);
+	border: 1px solid var(--color-progressive, #10707f);
 	border-radius: 1rem;
-	background-color: var(--wikven-cta-bg, #10707f);
+	background-color: var(--color-progressive, #10707f);
 	font-family: monospace;
 	font-size: 1rem;
 	white-space: nowrap;

--- a/docs/Template:home/styles.css
+++ b/docs/Template:home/styles.css
@@ -89,7 +89,7 @@
 }
 
 .wikven-home-route-primary a:hover {
-	border-color: var(--color-progressive--hover, #0d5c68);
+	border: 1px solid var(--color-progressive--hover, #0d5c68);
 	background-color: var(--color-progressive--hover, #0d5c68);
 }
 
@@ -102,16 +102,8 @@
 }
 
 .wikven-home-route-secondary a:hover {
-	border-color: var(--color-progressive, #10707f);
+	border: 1px solid var(--color-progressive, #10707f);
 	background-color: var(--background-color-interactive-subtle, #f8f9fa);
-}
-
-/* Its own rule, so that a pseudo-class the sanitiser does not know cannot take the hover rules
- * down with it -- one bad selector drops the whole list. The ring is stated rather than left to
- * the browser, which would draw a dark one on the pale teal button in night mode. */
-.wikven-home-route a:focus-visible {
-	outline: 2px solid var(--color-emphasized, #101418);
-	outline-offset: 2px;
 }
 
 .wikven-home-section {


### PR DESCRIPTION
The file-type marks are missing from the diagram on [index/ko](https://chaotic-ground.github.io/wikven/index/ko.html). Chasing that turned up two separate faults: one that hits the translations, and one that hits every language.

## The translations: a page class that is not there

The marks, the caret, the button's night colours and the clipped page title were all scoped to `.rootpage-index`, on a claim written into the stylesheet: *"the body of index/ko is page-index_ko, and only rootpage-index catches both."* The first half is right and the second is not.

`Title::getRootText()` returns the whole title unless the namespace has subpages turned on, and the main namespace does not — this site sets no `NamespacesWithSubpages`, and MediaWiki's default omits `NS_MAIN`. So `index/ko` is one title, not a page with a subpage. The body element of the deployed page confirms it, class list quoted verbatim:

```
skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr
mw-hide-empty-elt ns-0 ns-subject mw-editable page-index_ko rootpage-index_ko
skin-vector-2022 action-view
```

`.rootpage-index` matches neither `page-index_ko` nor `rootpage-index_ko`. `Module:Sequence` states the same fact in its own comment and matches the sidebar's names as prefixes rather than asking a title for its root, for exactly this reason — the claim contradicted something the repository had already written down. The same page also renders its `firstHeading` unclipped, which is the fourth rule failing.

The button was the one thing that still looked right, which is why this went unnoticed: `styles.css` reads the tokens with fallbacks, so light mode painted from the fallback whatever the tokens did. Night mode kept the brand teal at 3.2:1 instead of switching to the pale teal.

**The marks and the caret lose the page scope rather than gain a better one.** The `wikven-home-` classes are written by the landing page's templates and by nothing else, so the class is already the scope; the page selector on top of it bought nothing and added a way to be wrong.

**The button's colours turned out to be the accent written twice.** `--wikven-cta-bg` and `--wikven-cta-bg--hover` held byte-identical values to `--color-progressive` and `--color-progressive--hover`, in both themes. The fill now reads the accent. Only the foreground stays a token — it cannot be read off the accent, white being 5.6:1 on the light theme's teal and 2.07:1 on night's — and it is declared beside the accent, site-wide, in the block that already defines the brand for all three theme states.

**The page title keeps a page selector**, because the heading is outside the content and has no class of its own. It matches a substring of the body class, catching `page-index`, `rootpage-index` and both `_ko` forms. It can catch nothing else: the class is case-sensitive, so only a page whose title begins `index` reaches it.

## Every language: three declarations the sanitiser was dropping

The built stylesheet on the deployed site carries an error block, which is how these were found:

```
Errors processing stylesheet [[:Template:home/styles.css]] (rev 90):
- Invalid or unsupported value for property border-color at line 91 character 16.
- Invalid or unsupported value for property border-color at line 104 character 16.
- Invalid selector list at line 111 character 1.
```

`border-color` takes one to four values, so a `var()` in it is not a colour the sanitiser can check and the declaration is dropped. Both hover rules used it, so neither button's border followed its background on hover — while the rule directly above, writing the same colour through the `border` shorthand with a width and style stated, passes and always has. The hover rules now say it the same way.

The focus ring moves to `MediaWiki:Common.css`. `:focus-visible` is not a pseudo-class the sanitiser knows, so the rule was dropped whole and the ring was never drawn, on any page, in any language. It had been put in a rule of its own so the unknown selector could not take the hover rules down with it; that much worked, but surviving was not something it could do there.

## Checked

`biome check` clean at the version `biome.json` pins (2.5.8). No reference to the two removed tokens survives anywhere in the repository. `Template:home/doc` carries no translate units, so its rewrite makes no translation stale.

The diagnosis is confirmed against the deployed HTML, quoted above. The **fix** is not verified in a browser — the site is unreachable from this environment and the Docker daemon is not running here, so the `preview` deployment is its first render. Worth a look at [the preview](https://chaotic-ground.github.io/wikven/pr-preview/pr-498/index/ko.html) before merging, in both themes.
