### PR TITLE
feat(docs): stop the sidebar linking to the page you are reading

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -134,6 +134,22 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 	white-space: nowrap;
 }
 
+/* The sidebar entry for the page the reader is already on. The SidebarCurrentPage gadget marks
+ * it, because MediaWiki does not: Skin::createSidebarItem() sets every sidebar item's "active" to
+ * false and nothing sets it otherwise, so the entry for the current page is an ordinary link to
+ * where the reader is standing.
+ *
+ * Bold rather than a colour, which is how the skin list already marks the skin the page is
+ * rendered in. The entry has stopped being a link by then, so it has left the link colour behind
+ * and is not competing with one.
+ *
+ * On the attribute rather than on a class: it is the same thing the gadget sets for a reader who
+ * is not looking, so there is one mark and not two that could disagree. */
+.mw-portlet a[aria-current="page"],
+.wikven-nav-item a[aria-current="page"] {
+	font-weight: bold;
+}
+
 /* The landing page's focus ring. Here because the sanitiser does not know :focus-visible and
  * drops the whole rule -- the page's own stylesheet carried this and it never reached a reader.
  * It was written there in its own rule so that the unknown pseudo-class could not take the hover

--- a/docs/MediaWiki:Gadget-SidebarCurrentPage.js
+++ b/docs/MediaWiki:Gadget-SidebarCurrentPage.js
@@ -1,0 +1,73 @@
+/**
+ * Mark the sidebar entry for the page the reader is already on, and stop it
+ * being a link.
+ *
+ * MediaWiki does not do this itself, and Special:MyLanguage is not the reason:
+ * Skin::createSidebarItem() builds every sidebar item with "active" => false,
+ * with nothing to set it otherwise, so no entry is ever the current one. The
+ * tabs and the personal tools do compare the item's URL with the page's --
+ * 'active' => ( $href == $pageurl ) -- and the sidebar alone skips that. An
+ * entry written as a plain [[Page]] would go unmarked the same way.
+ *
+ * The href is dropped rather than the <a> swapped for a <span>, which is what
+ * the skin list does where it marks the skin the page is already rendered in.
+ * An <a> without an href is already not a link -- not clickable, not focusable,
+ * and outside a:link, so it loses the link colour on its own -- and leaving the
+ * element as it is keeps whatever each skin styles it with. Minerva lays its
+ * rows out from a rule on the anchor, which a <span> would fall out of.
+ *
+ * aria-current="page" is what says "this one" to a reader who is not looking at
+ * it. MediaWiki:Common.css marks it for one who is.
+ *
+ * ResourceLoader parses a wiki-page script as ES2016 before it serves it, and
+ * replaces a module it cannot parse with a console error -- the script then
+ * never runs, and nothing else reports it. Keep to that vintage: no optional
+ * catch binding, no optional chaining, no nullish coalescing.
+ */
+(() => {
+	// The documentation groups alone. Every group in MediaWiki:Sidebar is named
+	// sidebar-<something>, and the name becomes the portlet's class, so a group
+	// added later is covered without touching this. wikven-nav-item is the same
+	// set in Minerva, whose menu fillMinervaMenu.php writes from the sidebar.
+	//
+	// Deliberately not every link on the page: the tabs above the article point
+	// at the page you are on because that is what they are for -- "Read" is one
+	// -- and a fragment link goes somewhere even on its own page.
+	const SELECTOR =
+		'[class*="mw-portlet-sidebar-"] a[href], .wikven-nav-item a[href]';
+
+	// Compared as paths, not as written. The sidebar's links are relative and
+	// their depth differs by where the page sits, and a translated page reaches
+	// its own entry through Special:MyLanguage, which the build resolves to the
+	// translation's own file. Both sides come out of the same URL parser, so a
+	// percent-escaped title matches a percent-escaped title.
+	const pathOf = (url) => {
+		try {
+			return new URL(url, location.href).pathname;
+		} catch (_e) {
+			// Not a URL this browser will read; leave the link alone.
+			return null;
+		}
+	};
+
+	const markCurrent = () => {
+		const here = location.pathname;
+		for (const link of document.querySelectorAll(SELECTOR)) {
+			if (link.hash || pathOf(link.href) !== here) {
+				continue;
+			}
+			link.removeAttribute("href");
+			link.setAttribute("aria-current", "page");
+		}
+	};
+
+	// The sidebar is chrome, not content: it is in the document from the start
+	// and nothing re-renders it, so this runs once. Vector moves the menu
+	// between its pinned and unpinned containers, which carries the same
+	// elements and so the same attributes with it.
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", markCurrent);
+	} else {
+		markCurrent();
+	}
+})();

--- a/docs/MediaWiki:Gadgets-definition.wikitext
+++ b/docs/MediaWiki:Gadgets-definition.wikitext
@@ -1,1 +1,2 @@
 * PersistTabber[ResourceLoader|default]|PersistTabber.js
+* SidebarCurrentPage[ResourceLoader|default]|SidebarCurrentPage.js


### PR DESCRIPTION
Every sidebar entry is a link, including the one for the page already on screen.

## Why it happens

Not `Special:MyLanguage`. MediaWiki has no such feature for the sidebar at all — `Skin::createSidebarItem()` (`includes/Skin/Skin.php`) ends:

```php
return $extraAttribs + [
    'text' => $parsedText,
    'href' => $href,
    'icon' => $this->getSidebarIcon( $id ),
    'id'   => Sanitizer::escapeIdForAttribute( 'n-' . $id ),
    'active' => false,
];
```

`false` unconditionally, with nothing downstream to set it otherwise. Core does make the comparison elsewhere — `'active' => ( $href == $pageurl )` for the tabs and the personal tools — and the sidebar alone skips it. An entry written as a plain `[[Page]]` would go unmarked in exactly the same way, so resolving through `Special:MyLanguage` changes nothing here.

## What this does

A gadget, so it stays this site's own: wikven keeps behaving as MediaWiki does for everyone else building with it.

It drops the `href` rather than swapping the anchor for a `span`, which is what wikven does server-side where it marks the skin a page is already rendered in. An anchor with no `href` is already not a link — not clickable, not focusable, and outside `a:link`, so it gives up the link colour by itself — and leaving the element alone keeps whatever each skin styles it with. Minerva lays its rows out from a rule on `a.toggle-list-item__anchor`, which a `span` would fall out of.

`aria-current="page"` says the same thing to a reader who is not looking at it, and is what the stylesheet marks for one who is — bold, matching how the skin list already marks the current skin.

Scoped to the sidebar groups (`mw-portlet-sidebar-*`, so a group added to `MediaWiki:Sidebar` later is covered without touching the gadget) and to `.wikven-nav-item`, the same set in Minerva. Deliberately not every link on the page: the article tabs point at the page you are on because that is what they are for — "Read" is one — and a link carrying a fragment goes somewhere even on its own page.

## Checked

Run in Chromium against a fixture carrying both skins' sidebar markup plus decoys:

| element | `href` | `aria-current` | `font-weight` |
| --- | --- | --- | --- |
| sidebar entry for this page (Vector shape) | removed | `page` | 700 |
| sidebar entry for another page | kept | — | 400 |
| same-page entry carrying `#Docker` | kept | — | 400 |
| sidebar entry for this page (Minerva shape) | removed | `page` | 700 |
| Minerva entry for another page | kept | — | 400 |
| "Read" tab, which points at this page | kept | — | 400 |
| self-link in the article body | kept | — | 400 |

No page errors. `biome check` clean at the version `biome.json` pins, and the script parses as the ES2016 vintage ResourceLoader serves wiki-page scripts as — no optional chaining, nullish coalescing, or optional catch binding.

Confirmed against the preview build as well. `Licenses.html` loads the gadget:

```
mw.loader.load([…,"ext.gadget.PersistTabber","ext.gadget.SidebarCurrentPage","ext.uls.interface"]);
```

and its own sidebar entry is still an ordinary link at rest, which is what a client-side gadget should leave behind:

```
<li id="n-sidebar-licenses" class="mw-list-item"><a href="./Licenses.html"><span>Licenses</span></a></li>
```

The decoys are real too: `ca-view` ("Read") and `ca-nstab-main` both point at `./Licenses.html` from outside the gadget's scope. Not opened in a browser against the preview itself — no egress from where this was built — so the fixture run is what stands behind the behaviour.

## Note

The behaviour needs JavaScript: with it off the entry stays an ordinary link, as it is today. Doing it at build time is possible — `Adder::onSidebarBeforeOutput` already sets `'active' => true` and omits `href` for the skin list — but that would change wikven's own behaviour for every site built with it, which is a bigger decision than this page needs.
