### PR TITLE
docs: give the template example a note a wikven site would carry

### DIFF
--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -115,7 +115,7 @@ Templates, the main reason to reach for {{SITENAME}} over Markdown, let you reus
 
 <syntaxhighlight lang="shell" copy>
 echo "'''Note:''' {{{1}}}" > "src/Template:Note.wikitext"
-echo '{{Note|Back up your wiki first.}}' >> src/index.wikitext
+echo '{{Note|Rebuild the site after every edit.}}' >> src/index.wikitext
 </syntaxhighlight>
 
 <translate>

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -113,10 +113,13 @@ Build again: the home page now links to <code>Help.html</code>, and the link wor
 Templates, the main reason to reach for {{SITENAME}} over Markdown, let you reuse content. Put a <code>Template:</code> page in your source and transclude it with <code><nowiki>{{...}}</nowiki></code>:
 </translate>
 
+<translate nowrap>
+<!--T:20-->
 <syntaxhighlight lang="shell" copy>
-echo "'''Note:''' {{{1}}}" > "src/Template:Note.wikitext"
-echo '{{Note|Rebuild the site after every edit.}}' >> src/index.wikitext
+<tvar name="1">echo "</tvar>'''Note:'''<tvar name="2"> {{{1}}}" > "src/Template:Note.wikitext"
+echo '{{Note|</tvar>Rebuild the site after every edit.<tvar name="3">}}' >> src/index.wikitext</tvar>
 </syntaxhighlight>
+</translate>
 
 <translate>
 <!--T:19-->

--- a/docs/Getting Started/ko.wikitext
+++ b/docs/Getting Started/ko.wikitext
@@ -52,5 +52,10 @@
 <!--T:18 @fa79b63c-->
 Markdown 대신 {{SITENAME}}을 택하는 주된 이유인 틀은 콘텐츠를 재사용할 수 있게 해 줍니다. 소스에 <code>Template:</code> 문서를 두고 <code><nowiki>{{...}}</nowiki></code>로 끼워 넣습니다:
 
+<!--T:20 @f68ebb27-->
+<syntaxhighlight lang="shell" copy>
+$1'''참고:'''$2편집할 때마다 사이트를 다시 빌드하세요.$3
+</syntaxhighlight>
+
 <!--T:19 @6bcab64a-->
 다시 빌드하면 홈 문서에 이제 알림이 표시됩니다. 매개변수 등에 대해서는 [[$1|문서의 틀 섹션]]을 참고하십시오.

--- a/docs/Pages.wikitext
+++ b/docs/Pages.wikitext
@@ -79,12 +79,12 @@ saved as <code>Template:Note.wikitext</code> and used on a page as:
 </translate>
 
 <syntaxhighlight lang="wikitext" copy>
-{{Note|Back up your wiki first.}}
+{{Note|Rebuild the site after every edit.}}
 </syntaxhighlight>
 
 <translate>
 <!--T:21-->
-renders as "'''Note:''' Back up your wiki first." Templates take positional (<code><nowiki>{{{1}}}</nowiki></code>) and named parameters and run [<tvar name="1">https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Parser_functions</tvar> parser functions] exactly as in MediaWiki. The syntax itself is standard MediaWiki; see [<tvar name="2">https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Templates</tvar> Help:Templates].
+renders as "'''Note:''' Rebuild the site after every edit." Templates take positional (<code><nowiki>{{{1}}}</nowiki></code>) and named parameters and run [<tvar name="1">https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Parser_functions</tvar> parser functions] exactly as in MediaWiki. The syntax itself is standard MediaWiki; see [<tvar name="2">https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Templates</tvar> Help:Templates].
 </translate>
 
 {{prevnext}}

--- a/docs/Pages.wikitext
+++ b/docs/Pages.wikitext
@@ -69,18 +69,24 @@ To keep a maintenance or tracking category out of the footer instead, add the <c
 Put a <code>Template:Name.wikitext</code> file in your source and use it on any page as <code><nowiki>{{Name}}</nowiki></code>. For example, this file:
 </translate>
 
+<translate nowrap>
+<!--T:22-->
 <syntaxhighlight lang="wikitext" copy>
-'''Note:''' {{{1}}}
+'''Note:''' <tvar name="1">{{{1}}}</tvar>
 </syntaxhighlight>
+</translate>
 
 <translate>
 <!--T:20-->
 saved as <code>Template:Note.wikitext</code> and used on a page as:
 </translate>
 
+<translate nowrap>
+<!--T:23-->
 <syntaxhighlight lang="wikitext" copy>
-{{Note|Rebuild the site after every edit.}}
+<tvar name="1">{{Note|</tvar>Rebuild the site after every edit.<tvar name="2">}}</tvar>
 </syntaxhighlight>
+</translate>
 
 <translate>
 <!--T:21-->

--- a/docs/Pages/ko.wikitext
+++ b/docs/Pages/ko.wikitext
@@ -60,8 +60,18 @@
 <!--T:19 @aeb975e4-->
 소스에 <code>Template:Name.wikitext</code> 파일을 두고 아무 문서에서나 <code><nowiki>{{Name}}</nowiki></code>으로 사용하세요. 예를 들어 다음 파일을:
 
+<!--T:22 @f13ce61f-->
+<syntaxhighlight lang="wikitext" copy>
+'''참고:''' $1
+</syntaxhighlight>
+
 <!--T:20 @8c4ff658-->
 <code>Template:Note.wikitext</code>로 저장하고 문서에서 다음과 같이 사용하면:
 
+<!--T:23 @24d2f744-->
+<syntaxhighlight lang="wikitext" copy>
+$1편집할 때마다 사이트를 다시 빌드하세요.$2
+</syntaxhighlight>
+
 <!--T:21 @88bcbed2-->
-"'''Note:''' Rebuild the site after every edit."로 렌더링됩니다. 틀은 위치 매개변수(<code><nowiki>{{{1}}}</nowiki></code>)와 이름 매개변수를 받고 MediaWiki에서와 똑같이 [$1 파서 함수]를 실행합니다. 문법 자체는 표준 MediaWiki입니다. [$2 Help:Templates] 참고.
+"'''참고:''' 편집할 때마다 사이트를 다시 빌드하세요."로 렌더링됩니다. 틀은 위치 매개변수(<code><nowiki>{{{1}}}</nowiki></code>)와 이름 매개변수를 받고 MediaWiki에서와 똑같이 [$1 파서 함수]를 실행합니다. 문법 자체는 표준 MediaWiki입니다. [$2 Help:Templates] 참고.

--- a/docs/Pages/ko.wikitext
+++ b/docs/Pages/ko.wikitext
@@ -63,5 +63,5 @@
 <!--T:20 @8c4ff658-->
 <code>Template:Note.wikitext</code>로 저장하고 문서에서 다음과 같이 사용하면:
 
-<!--T:21 @b3137057-->
-"'''Note:''' Back up your wiki first."로 렌더링됩니다. 틀은 위치 매개변수(<code><nowiki>{{{1}}}</nowiki></code>)와 이름 매개변수를 받고 MediaWiki에서와 똑같이 [$1 파서 함수]를 실행합니다. 문법 자체는 표준 MediaWiki입니다. [$2 Help:Templates] 참고.
+<!--T:21 @88bcbed2-->
+"'''Note:''' Rebuild the site after every edit."로 렌더링됩니다. 틀은 위치 매개변수(<code><nowiki>{{{1}}}</nowiki></code>)와 이름 매개변수를 받고 MediaWiki에서와 똑같이 [$1 파서 함수]를 실행합니다. 문법 자체는 표준 MediaWiki입니다. [$2 Help:Templates] 참고.


### PR DESCRIPTION
The `{{Note}}` example on [Getting Started](https://chaotic-ground.github.io/wikven/Getting_Started.html#Adding_a_template) and Pages read "Back up your wiki first." — advice for a wiki with a database behind it. A wikven site is a directory of wikitext files that a build turns into HTML, so there is nothing to back up that the source tree does not already hold, and the sentence points a reader at a backup step wikven has no command for.

It now reads "Rebuild the site after every edit.": true of a static build, and the same thing both pages tell the reader to do in the line right after the note.

The example blocks also sat outside the translate tags, so a Korean reader met an English note in the middle of a Korean page. They are now wrapped the way Configuration already wraps its commented YAML — `translate nowrap` around the block, `tvar` around the wikitext and shell that must stay as typed — leaving the note's own words translatable, and the Korean translation carries them.

## Changes

- `docs/Getting Started.wikitext` — the note text in the template step, and its `echo` block made translatable (new unit T:20).
- `docs/Pages.wikitext` — the same example in the Templates section: both code blocks made translatable (T:22, T:23), and the sentence quoting what the note renders as.
- `docs/Getting Started/ko.wikitext`, `docs/Pages/ko.wikitext` — Korean for the new units ("참고:" and the note sentence), and the quoted rendering in T:21 follows; restamped so no unit is left stale.

Checked every `docs/` translation with `StalenessComputer::analyze`: no unit went stale, and substituting the tvars back into the Korean units reproduces valid shell and wikitext.