### PR TITLE
fix: give a linked code label its link's colour back

### DIFF
--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -170,3 +170,18 @@ a.new {
 .wikven-skin-item.active {
   font-weight: @font-weight-bold;
 }
+
+// A link whose label is code -- a linked `<code>` name, which the reference pages are full of --
+// was not reading as a link. Vector and Citizen both ship core's rule for the element
+// (`pre, code, .mw-code { color: var( --color-emphasized ) }`), and an element selector outranks
+// the colour a link passes down to its contents, so the code kept body-text colour inside the
+// anchor. Neither skin underlines a content link, which leaves the colour as the whole of the cue:
+// the reader saw a grey box where a link was.
+//
+// `inherit` rather than a link colour of its own, so the code follows the anchor into every state
+// the skin paints -- visited, hover, focus, and the red of a link to a page that does not exist --
+// instead of pinning one of them. The box and its border stay as they are: they say "code", which
+// is a different thing from "link" and worth keeping beside it.
+a code {
+  color: inherit;
+}

--- a/tests/e2e/code-link.spec.js
+++ b/tests/e2e/code-link.spec.js
@@ -1,0 +1,102 @@
+// A link whose label is code -- the reference pages link half their settings that way, as
+// [[#WikvenRepositories|<code>WikvenRepositories</code>]] -- has to look like a link. Vector and
+// Citizen both ship core's rule for the element (`pre, code, .mw-code { color: var(
+// --color-emphasized ) }`), and an element selector outranks the colour an anchor passes down, so
+// the label kept body-text colour; neither skin underlines a content link, so nothing else was
+// left to say it was one. ext.Wikven.styles hands the colour back with `a code { color: inherit }`,
+// which only a rendered page can show: the markup is identical either way.
+
+const { test, expect } = require("@playwright/test");
+
+// A reference page with both kinds of code on it: names that link and names that do not.
+const PAGE = "Configuration.html";
+
+// Every code label on the page, paired with the colour of the anchor it sits in, and the colours
+// the code standing on its own is painted in. Read from the rendered page rather than from the
+// stylesheet, so what is asserted is what a reader sees once every skin's rules have applied.
+const codeColours = (page) =>
+	page.evaluate(() => {
+		const content = document.querySelector(".mw-parser-output");
+		const linked = [];
+		const plain = new Set();
+		for (const code of content.querySelectorAll("code")) {
+			const anchor = code.closest("a");
+			if (anchor) {
+				linked.push({
+					text: code.textContent,
+					code: getComputedStyle(code).color,
+					anchor: getComputedStyle(anchor).color,
+				});
+			} else {
+				plain.add(getComputedStyle(code).color);
+			}
+		}
+		return { linked, plain: [...plain] };
+	});
+
+// Where each skin's copy of the page is, discovered from the switcher rather than restated from
+// docs/.wikven.yml. Every skin's copy carries the whole list, so the one on the main skin's page
+// names them all.
+let paths;
+
+test.beforeAll(async ({ browser }) => {
+	const page = await browser.newPage();
+	await page.goto("index.html");
+	const skins = await page.evaluate(() =>
+		Array.from(document.querySelectorAll('[id^="t-wikven-skin-"]')).map(
+			(element) => ({
+				skin: element.id.replace("t-wikven-skin-", ""),
+				current: element.classList.contains("active"),
+			}),
+		),
+	);
+	// The skin a page is rendered in writes into the export root; the others into a directory
+	// named after themselves.
+	paths = skins.map(({ skin, current }) => ({
+		skin,
+		path: current ? PAGE : `${skin}/${PAGE}`,
+	}));
+	await page.close();
+});
+
+test("a linked code label is painted in its link's colour, in every skin", async ({
+	page,
+}) => {
+	expect(paths.length, "the page listed no skins").toBeGreaterThan(0);
+
+	for (const { skin, path } of paths) {
+		await page.goto(path);
+		const { linked } = await codeColours(page);
+		expect(
+			linked.length,
+			`${skin} has no linked code on ${path}`,
+		).toBeGreaterThan(0);
+		for (const label of linked) {
+			expect(
+				label.code,
+				`${skin}: <code>${label.text}</code> is not painted in its link's colour`,
+			).toBe(label.anchor);
+		}
+	}
+});
+
+// The assertion above passes trivially on a skin that paints links and code alike, and on such a
+// skin the reader has no cue at all. Keep the two apart.
+test("and that colour is not the colour of the code beside it", async ({
+	page,
+}) => {
+	for (const { skin, path } of paths) {
+		await page.goto(path);
+		const { linked, plain } = await codeColours(page);
+		expect(
+			plain.length,
+			`${skin} has no unlinked code on ${path}`,
+		).toBeGreaterThan(0);
+		for (const label of linked) {
+			expect(
+				plain,
+				`${skin}: <code>${label.text}</code> reads as ordinary code`,
+			).not.toContain(label.anchor);
+		}
+	}
+});


### PR DESCRIPTION
On [Configuration](https://chaotic-ground.github.io/wikven/Configuration.html) — and every reference page that links a setting by name — a link whose label is `<code>` does not read as a link in Vector or Citizen.

## Why

Both skins ship core's rule for the element. From the export's own `skins.vector.styles.css`:

```css
pre,code,.mw-code{background-color:var(--background-color-neutral-subtle,#f8f9fa);color:var(--color-emphasized,#101418);border:1px solid var(--border-color-muted,#dadde3)}
```

and Citizen's is the same rule in its own tokens. `code` is an element selector, so it outranks the colour an anchor merely passes down to its contents: `<a href="#WikvenRepositories"><code>WikvenRepositories</code></a>` renders the label in body-text colour inside a teal link. Neither skin underlines a content link, so colour is the whole of the cue, and the reader is left with a grey box where a link is. MinervaNeue sets no colour on `code` (only a font, a border and padding), so it never had the problem.

## The fix

`resources/ext.Wikven.styles.less` gains:

```less
a code {
  color: inherit;
}
```

`inherit` rather than a link colour of its own, so the label follows the anchor into every state the skin paints — visited, hover, focus, and the red of a link to a page that does not exist — instead of pinning one of them. `a code` is two element selectors, so it outranks the skin's one wherever the sheets land. The background and border stay: they say "code", which is worth keeping beside "link".

## Test

`tests/e2e/code-link.spec.js` opens the page in every skin the export builds (discovered from the switcher, not restated from `docs/.wikven.yml`) and asserts:

- every `code` inside a link is painted in that link's colour; and
- that colour is not one the unlinked code on the same page wears — otherwise the first assertion would pass on a skin that paints links and code alike, where the reader still has no cue.

The markup is identical with and without the fix, so only a rendered page can tell; `biome ci` passes on the spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_