### PR TITLE
docs: name the sidebar label's translation by language, not by Korean

### DIFF
--- a/docs/Editing sidebar.wikitext
+++ b/docs/Editing sidebar.wikitext
@@ -4,7 +4,7 @@
 The navigation sidebar is configured the same way as on MediaWiki, through the <code>MediaWiki:Sidebar</code> system message. Create a <code>MediaWiki:Sidebar.wikitext</code> file in your source directory, alongside your other pages.
 
 <!--T:2-->
-Each top-level <code>*</code> line is a heading, and each <code>**</code> line below it is a link written as <code>page|label</code>. Headings and labels are looked up as system messages first and only fall back to the literal text when no such message exists, so <code>mainpage</code> and <code>mainpage-description</code> resolve to the main page and its label. Write your own as message names too, because a message is what makes a label translatable: the English wording goes in <code>MediaWiki:Sidebar-docs.wikitext</code> and the Korean in <code>MediaWiki:Sidebar-docs/ko.wikitext</code>, next to your other pages. A sidebar then reads like this:
+Each top-level <code>*</code> line is a heading, and each <code>**</code> line below it is a link written as <code>page|label</code>. Headings and labels are looked up as system messages first and only fall back to the literal text when no such message exists, so <code>mainpage</code> and <code>mainpage-description</code> resolve to the main page and its label. Write your own as message names too, because a message is what makes a label translatable: the wording in your source language goes in <code>MediaWiki:Sidebar-docs.wikitext</code> and each translation in <code>MediaWiki:Sidebar-docs/&lt;language&gt;.wikitext</code>, next to your other pages, the way every other translated page is named. A sidebar then reads like this:
 </translate>
 
 <syntaxhighlight lang="wikitext" copy>

--- a/docs/Editing sidebar/ko.wikitext
+++ b/docs/Editing sidebar/ko.wikitext
@@ -4,8 +4,8 @@
 <!--T:1 @9d465705-->
 탐색 사이드바는 MediaWiki에서와 같은 방식으로, <code>MediaWiki:Sidebar</code> 시스템 메시지를 통해 설정합니다. 소스 디렉터리에 다른 문서들과 나란히 <code>MediaWiki:Sidebar.wikitext</code> 파일을 만드세요.
 
-<!--T:2 @7647f65b-->
-최상위 <code>*</code> 줄은 각각 제목이고, 그 아래 <code>**</code> 줄은 각각 <code>page|label</code> 형식으로 쓴 링크입니다. 제목과 라벨은 먼저 시스템 메시지로 조회되고, 그런 메시지가 없을 때만 적힌 글자를 그대로 씁니다(그래서 <code>mainpage</code>와 <code>mainpage-description</code>은 대문서와 그 라벨로 해석됩니다). 라벨을 번역할 수 있게 해 주는 것이 바로 메시지이므로, 여러분의 것도 메시지 이름으로 쓰세요. 영어 문구(<code>Docs</code>)는 <code>MediaWiki:Sidebar-docs.wikitext</code>에, 한국어 문구(<code>설명서</code>)는 <code>MediaWiki:Sidebar-docs/ko.wikitext</code>에 다른 문서들과 나란히 둡니다. 그러면 사이드바는 다음과 같은 모양이 됩니다:
+<!--T:2 @16a29b70-->
+최상위 <code>*</code> 줄은 각각 제목이고, 그 아래 <code>**</code> 줄은 각각 <code>page|label</code> 형식으로 쓴 링크입니다. 제목과 라벨은 먼저 시스템 메시지로 조회되고, 그런 메시지가 없을 때만 적힌 글자를 그대로 씁니다(그래서 <code>mainpage</code>와 <code>mainpage-description</code>은 대문서와 그 라벨로 해석됩니다). 라벨을 번역할 수 있게 해 주는 것이 바로 메시지이므로, 여러분의 것도 메시지 이름으로 쓰세요. 소스 언어의 문구는 <code>MediaWiki:Sidebar-docs.wikitext</code>에, 각 언어의 번역은 <code>MediaWiki:Sidebar-docs/&lt;언어&gt;.wikitext</code>에 다른 문서들과 나란히 둡니다. 번역되는 다른 문서의 이름 규칙과 같습니다. 그러면 사이드바는 다음과 같은 모양이 됩니다:
 
 <!--T:7 @36c877e2-->
 링크 대상도 메시지로 조회되며, 대상이 <code>-</code>인 메시지로 해석되는 항목은 아무 흔적 없이 사이드바에서 빠집니다. MediaWiki는 업로드 양식의 라이선스 선택 목록인 <code>licenses</code>를 <code>-</code>로 정의해 두었으므로, <code>Licenses</code>라는 이름의 문서를 대상에 그대로 쓰면 그 항목이 사라집니다. 그런 대상 앞에는 <code>:Licenses</code>처럼 콜론을 붙여 문서 자체로 연결하세요.


### PR DESCRIPTION
[Editing sidebar](https://chaotic-ground.github.io/wikven/Editing_sidebar.html) taught the message-name rule through one language pair:

> a message is what makes a label translatable: the English wording goes in `MediaWiki:Sidebar-docs.wikitext` and the Korean in `MediaWiki:Sidebar-docs/ko.wikitext`

Korean is one of this documentation site's own translations, not a language wikven treats differently from any other, and naming it in the rule leaves a reader whose site has neither English nor Korean to translate the sentence before it tells them anything.

It now states the rule itself: the wording in your source language goes in the message page, and each translation in `MediaWiki:Sidebar-docs/<language>.wikitext` beside it — the same naming as every other translated page, which [Translating](https://chaotic-ground.github.io/wikven/Translating.html) already describes.

## Changes

- `docs/Editing sidebar.wikitext` — T:2.
- `docs/Editing sidebar/ko.wikitext` — the Korean for it, restamped. (It carried the same pair, with `Docs`/`설명서` as the example wordings; those go with it.)

Checked every `docs/` translation with `StalenessComputer::analyze`: nothing stale beyond `Licenses/km` T:2, which is already stale on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_