### PR TITLE
docs: make the disappearing sidebar entry a note, and say why it happens

### DIFF
--- a/docs/Editing sidebar.wikitext
+++ b/docs/Editing sidebar.wikitext
@@ -19,7 +19,7 @@ Each top-level <code>*</code> line is a heading, and each <code>**</code> line b
 
 <translate>
 <!--T:7-->
-A link target is looked up as a message too, and an entry whose target resolves to a message reading <code>-</code> is dropped from the sidebar without a trace. MediaWiki defines <code>licenses</code>, the upload form's list of license options, as <code>-</code>, so a page named <code>Licenses</code> disappears when written as a plain target. Prefix such a target with a colon, as in <code>:Licenses</code>, to link the page itself.
+{{note|A target is looked up as a message before it is read as a page name, the same way a label is, and MediaWiki drops an entry whose message says <code>-</code> — that is how it turns one of its own default entries off. So a target that happens to share a name with such a message leaves the sidebar without a word about it. The one worth knowing is <code>licenses</code>, the upload form's list of licence options, which MediaWiki defines as <code>-</code>: an entry for a page called <code>Licenses</code> is dropped when the target is written plainly. Write it with a leading colon, as <code>:Licenses</code>, to name the page itself and skip the lookup. The <code>Special:MyLanguage/</code> prefix below does the same, which is why this site's own sidebar needs no colon.}}
 
 <!--T:8-->
 == Linking on a translated site ==

--- a/docs/Editing sidebar/ko.wikitext
+++ b/docs/Editing sidebar/ko.wikitext
@@ -7,8 +7,8 @@
 <!--T:2 @16a29b70-->
 최상위 <code>*</code> 줄은 각각 제목이고, 그 아래 <code>**</code> 줄은 각각 <code>page|label</code> 형식으로 쓴 링크입니다. 제목과 라벨은 먼저 시스템 메시지로 조회되고, 그런 메시지가 없을 때만 적힌 글자를 그대로 씁니다(그래서 <code>mainpage</code>와 <code>mainpage-description</code>은 대문서와 그 라벨로 해석됩니다). 라벨을 번역할 수 있게 해 주는 것이 바로 메시지이므로, 여러분의 것도 메시지 이름으로 쓰세요. 소스 언어의 문구는 <code>MediaWiki:Sidebar-docs.wikitext</code>에, 각 언어의 번역은 <code>MediaWiki:Sidebar-docs/&lt;언어&gt;.wikitext</code>에 다른 문서들과 나란히 둡니다. 번역되는 다른 문서의 이름 규칙과 같습니다. 그러면 사이드바는 다음과 같은 모양이 됩니다:
 
-<!--T:7 @36c877e2-->
-링크 대상도 메시지로 조회되며, 대상이 <code>-</code>인 메시지로 해석되는 항목은 아무 흔적 없이 사이드바에서 빠집니다. MediaWiki는 업로드 양식의 라이선스 선택 목록인 <code>licenses</code>를 <code>-</code>로 정의해 두었으므로, <code>Licenses</code>라는 이름의 문서를 대상에 그대로 쓰면 그 항목이 사라집니다. 그런 대상 앞에는 <code>:Licenses</code>처럼 콜론을 붙여 문서 자체로 연결하세요.
+<!--T:7 @0b18613a-->
+{{note|대상도 라벨과 마찬가지로 문서 이름으로 읽히기 전에 먼저 메시지로 조회되며, 그 메시지가 <code>-</code>이면 MediaWiki가 그 항목을 사이드바에서 뺍니다. 자기 기본 항목을 끄는 방식이 그것입니다. 그래서 그런 메시지와 이름이 겹치는 대상은 아무 말 없이 사이드바에서 사라집니다. 알아 둘 것은 업로드 양식의 라이선스 선택 목록인 <code>licenses</code>로, MediaWiki가 이를 <code>-</code>로 정의해 두었습니다. <code>Licenses</code>라는 문서를 대상에 그대로 쓰면 그 항목이 빠지는 이유입니다. 앞에 콜론을 붙여 <code>:Licenses</code>로 쓰면 문서 자체를 가리키며 메시지 조회를 건너뜁니다. 아래의 <code>Special:MyLanguage/</code> 접두사도 같은 일을 하며, 그래서 이 사이트의 사이드바에는 콜론이 없습니다.}}
 
 <!--T:8 @140bba9d-->
 == 번역된 사이트에서 링크하기 ==


### PR DESCRIPTION
[Editing sidebar](https://chaotic-ground.github.io/wikven/Editing_sidebar.html) carried this as a paragraph of its own, in the same voice as the syntax being taught around it:

> A link target is looked up as a message too, and an entry whose target resolves to a message reading `-` is dropped from the sidebar without a trace. MediaWiki defines `licenses`, the upload form's list of license options, as `-`, so a page named `Licenses` disappears when written as a plain target.

It reads as part of the rule, and it is not — it is a trap to know about. It also left out the piece that makes it make sense.

## What it was trying to say

`Skin::addToSidebar()` runs each `**` line's target through the message lookup before treating it as a page name, and skips the entry when that message is disabled — which in MediaWiki means a message whose text is `-`. That is the mechanism core uses to switch one of its own default entries off. `licenses` is a real core message (the upload form's licence list) and its default text is `-`, so an entry pointing at a page called `Licenses` is dropped, silently, and nothing on the page says why.

## What it says now

The same content as a `{{note}}`, with the two missing pieces:

- a message of `-` is how MediaWiki turns an entry off, which is why an ordinary-looking target can vanish;
- `Special:MyLanguage/` skips the lookup as well, which is why this site's own `MediaWiki:Sidebar` links `Special:MyLanguage/Licenses` with no colon — a fact its source comment already records.

## Changes

- `docs/Editing sidebar.wikitext` — T:7.
- `docs/Editing sidebar/ko.wikitext` — the Korean for it, restamped.

Checked every `docs/` translation with `StalenessComputer::analyze`: nothing stale beyond `Licenses/km` T:2, which is already stale on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_