### PR TITLE
docs: put the two preview commands in a tabber, as the other pages do

### DIFF
--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -92,25 +92,30 @@ Because <code>dist/</code> is just files, you can serve it from any static host 
 
 <!--T:9-->
 Open <code>dist/index.html</code> directly, or serve the directory so links and assets resolve exactly as they will in production. {{SITENAME}} has a built-in <code>serve</code> command for this.
-
-<!--T:10-->
-With the [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|standalone binary]], it serves <code>dist/</code> on <code>http://localhost:8080</code> (override with <code>--listen</code>):
 </translate>
 
+<tabber>
+|-|Binary=
+<translate>
+<!--T:10-->
+The [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|standalone binary]] serves <code>dist/</code> on <code>http://localhost:8080</code>, and takes <code>--listen</code> for another address:
+</translate>
 <syntaxhighlight lang="shell" copy>
 wikven serve
 </syntaxhighlight>
-
+|-|Docker=
 <translate>
 <!--T:11-->
-With the Docker image, run the <code>serve</code> command and publish the port (the build output must already be in the mounted <code>dist/</code>):
+The image runs the same command; publish the port, and have the build output in the mounted <code>dist/</code> already:
 </translate>
-
 <syntaxhighlight lang="shell" copy>
 docker run --rm -p 8080:8080 \
   -v "$(pwd)/dist:/workspace/dist" \
   ghcr.io/chaotic-ground/wikven serve
 </syntaxhighlight>
+</tabber>
+
+<translate>
 
 <translate>
 <!--T:12-->

--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -116,8 +116,6 @@ docker run --rm -p 8080:8080 \
 </tabber>
 
 <translate>
-
-<translate>
 <!--T:12-->
 Any static server works too, for example <code>cd dist && python3 -m http.server</code>.
 

--- a/docs/Deploying/ko.wikitext
+++ b/docs/Deploying/ko.wikitext
@@ -37,11 +37,11 @@
 <!--T:9 @3bb18363-->
 <code>dist/index.html</code>을 직접 열거나, 링크와 자산이 프로덕션에서와 똑같이 해석되도록 디렉터리를 제공하세요. {{SITENAME}}에는 이를 위한 <code>serve</code> 명령이 내장되어 있습니다.
 
-<!--T:10 @ee704a0e-->
-[[$1|단독 실행 바이너리]]를 쓰면 <code>dist/</code>를 <code>http://localhost:8080</code>에서 제공합니다 (<code>--listen</code>으로 변경):
+<!--T:10 @d3ee2d94-->
+단독 실행 [[$1|바이너리]]는 <code>dist/</code>를 <code>http://localhost:8080</code>에서 제공하며, 다른 주소로 바꾸려면 <code>--listen</code>을 씁니다:
 
-<!--T:11 @77a3cf99-->
-Docker 이미지를 쓸 때는 <code>serve</code> 명령을 실행하고 포트를 공개하세요 (빌드 출력이 마운트된 <code>dist/</code>에 이미 있어야 합니다):
+<!--T:11 @0cf187df-->
+이미지도 같은 명령을 실행합니다. 포트를 공개하고, 빌드 출력이 마운트된 <code>dist/</code>에 이미 있어야 합니다:
 
 <!--T:12 @fdf6c82a-->
 임의의 정적 서버도 됩니다. 예를 들어 <code>cd dist && python3 -m http.server</code>처럼요.


### PR DESCRIPTION
[Deploying § Preview locally](https://chaotic-ground.github.io/wikven/Deploying.html#Preview_locally) stacked the two `serve` commands one under the other, each introduced by a sentence that named the product for it — "With the standalone binary…", "With the Docker image…" — while [Getting Started](https://chaotic-ground.github.io/wikven/Getting_Started.html) and Commands put the same pair behind a `<tabber>` and let the tab label do that work.

It is a tabber now, with the same **Binary** / **Docker** tabs. Each tab keeps the sentence for what a label cannot say — the binary's `--listen`, and that the image wants the built `dist/` already mounted — and drops the half the label says.

## Changes

- `docs/Deploying.wikitext` — T:10 and T:11 move into the tabber, with their leading "with the …" clauses gone.
- `docs/Deploying/ko.wikitext` — the Korean for both, restamped.

`StalenessComputer::analyze` reports nothing stale beyond `Licenses/km` T:2, which is already stale on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_