### PR TITLE
feat(docs): give the landing page symbols, an output it can show, and some warmth

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -295,3 +295,269 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 		animation: none;
 	}
 }
+
+/* The card symbols, the two states of the diagram's output pane, and the hero's warmth. All three
+ * are here for the reason the marks above are: TemplateStyles drops a mask-image, a @keyframes and
+ * a gradient alike, and drops them without saying so.
+ *
+ * The symbols are OOUI's own, which is the point of them. A reader who has used a MediaWiki wiki
+ * has met the jigsaw piece on a template and the 文A on a language menu, so the glyph is doing
+ * work no drawing of ours would do. They are masks rather than [[File:]] images for the same
+ * reason the file-type marks are: a mask throws the source's colour away and takes the accent
+ * token, so one copy serves both themes.
+ *
+ * Two of the four have a direction. OOUI ships puzzle and palette as an ltr/rtl pair because both
+ * shapes lean, and this page writes nothing but logical properties, so honouring that here costs
+ * two rules and keeps the set consistent with everything around it. */
+.wikven-home-sym {
+	display: block;
+	inline-size: 2rem;
+	block-size: 2rem;
+	margin-block-end: 1rem;
+	background-color: var(--color-progressive, #10707f);
+}
+
+.wikven-home-sym--template {
+	-webkit-mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%203a1%201%200%200%200%202%200V1h7v6a3%203%200%201%201%200%206v6H1V1h7zM3%2017h12v-6h2a1%201%200%201%200%200-2h-2V3h-3a3%203%200%201%201-6%200H3z'/></svg>")
+		no-repeat center / contain;
+	mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%203a1%201%200%200%200%202%200V1h7v6a3%203%200%201%201%200%206v6H1V1h7zM3%2017h12v-6h2a1%201%200%201%200%200-2h-2V3h-3a3%203%200%201%201-6%200H3z'/></svg>")
+		no-repeat center / contain;
+}
+
+.wikven-home-sym--parts {
+	-webkit-mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M1.456%207.172a9%209%200%200%201%2017.259%205.079l-.968.75L11.75%2013a.75.75%200%200%200-.75.75v4.21l-1.06%201c-.648-.04-1.938-.142-2.768-.416A9%209%200%200%201%201.456%207.172M12.2%203.354a7%207%200%200%200-4.4%2013.291c.3.1.745.17%201.2.224v-3.12A2.75%202.75%200%200%201%2011.75%2011h5.178A7%207%200%200%200%2012.2%203.355Z'/><circle%20cx='6.5'%20cy='10.5'%20r='1.5'/><circle%20cx='9.5'%20cy='6.5'%20r='1.5'/><circle%20cx='13.5'%20cy='8.5'%20r='1.5'/></svg>")
+		no-repeat center / contain;
+	mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M1.456%207.172a9%209%200%200%201%2017.259%205.079l-.968.75L11.75%2013a.75.75%200%200%200-.75.75v4.21l-1.06%201c-.648-.04-1.938-.142-2.768-.416A9%209%200%200%201%201.456%207.172M12.2%203.354a7%207%200%200%200-4.4%2013.291c.3.1.745.17%201.2.224v-3.12A2.75%202.75%200%200%201%2011.75%2011h5.178A7%207%200%200%200%2012.2%203.355Z'/><circle%20cx='6.5'%20cy='10.5'%20r='1.5'/><circle%20cx='9.5'%20cy='6.5'%20r='1.5'/><circle%20cx='13.5'%20cy='8.5'%20r='1.5'/></svg>")
+		no-repeat center / contain;
+}
+
+.wikven-home-sym--search {
+	-webkit-mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%201a7%207%200%200%201%205.605%2011.191l5.102%205.102-1.414%201.414-5.102-5.102A7%207%200%201%201%208%201m0%202a5%205%200%201%200%200%2010A5%205%200%200%200%208%203'/></svg>")
+		no-repeat center / contain;
+	mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%201a7%207%200%200%201%205.605%2011.191l5.102%205.102-1.414%201.414-5.102-5.102A7%207%200%201%201%208%201m0%202a5%205%200%201%200%200%2010A5%205%200%200%200%208%203'/></svg>")
+		no-repeat center / contain;
+}
+
+.wikven-home-sym--languages {
+	-webkit-mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='m17.835%2019-1.248-3h-4.174l-1.248%203.001H9l4.577-11.005h1.846L20%2019zm-4.59-5h2.51L14.5%2010.982zM7.618%203H12v2H9.991a8.5%208.5%200%200%201-1.423%204.02q-.24.358-.528.707.634.367%201.379.711l.908.42-.839%201.816-.907-.42a18%2018%200%200%201-2.026-1.09c-1.255.979-2.912%201.8-5.076%202.31l-.973.228-.458-1.946.973-.23c1.631-.383%202.885-.954%203.85-1.608C3.29%208.527%202.317%206.884%202.065%205H0V3h5.382l-.724-1.447%201.79-.895L7.617%203ZM4.094%205c.243%201.282.974%202.489%202.29%203.586A6.54%206.54%200%200%200%207.98%205z'/></svg>")
+		no-repeat center / contain;
+	mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='m17.835%2019-1.248-3h-4.174l-1.248%203.001H9l4.577-11.005h1.846L20%2019zm-4.59-5h2.51L14.5%2010.982zM7.618%203H12v2H9.991a8.5%208.5%200%200%201-1.423%204.02q-.24.358-.528.707.634.367%201.379.711l.908.42-.839%201.816-.907-.42a18%2018%200%200%201-2.026-1.09c-1.255.979-2.912%201.8-5.076%202.31l-.973.228-.458-1.946.973-.23c1.631-.383%202.885-.954%203.85-1.608C3.29%208.527%202.317%206.884%202.065%205H0V3h5.382l-.724-1.447%201.79-.895L7.617%203ZM4.094%205c.243%201.282.974%202.489%202.29%203.586A6.54%206.54%200%200%200%207.98%205z'/></svg>")
+		no-repeat center / contain;
+}
+
+/* The leaning pair, mirrored for a right-to-left reader. */
+
+html[dir="rtl"] .wikven-home-sym--template {
+	-webkit-mask-image: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M13%203a1%201%200%201%201-2%200V1H4v6a3%203%200%200%200%200%206v6h16V1h-7zm5%2014H6v-6H4a1%201%200%201%201%200-2h2V3h3a3%203%200%201%200%206%200h3z'/></svg>");
+	mask-image: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M13%203a1%201%200%201%201-2%200V1H4v6a3%203%200%200%200%200%206v6h16V1h-7zm5%2014H6v-6H4a1%201%200%201%201%200-2h2V3h3a3%203%200%201%200%206%200h3z'/></svg>");
+}
+
+html[dir="rtl"] .wikven-home-sym--parts {
+	-webkit-mask-image: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M18.544%207.172A9.001%209.001%200%200%200%201.285%2012.25l.968.75H8.25a.75.75%200%200%201%20.75.75v4.21l1.06%201c.648-.04%201.938-.142%202.768-.416a9%209%200%200%200%205.716-11.372M7.8%203.354a7%207%200%200%201%204.4%2013.291c-.3.1-.745.17-1.2.224v-3.12A2.75%202.75%200%200%200%208.25%2011H3.072A7%207%200%200%201%207.8%203.355Z'/><circle%20cx='6.5'%20cy='8.5'%20r='1.5'/><circle%20cx='10.5'%20cy='6.5'%20r='1.5'/><circle%20cx='13.5'%20cy='10.5'%20r='1.5'/></svg>");
+	mask-image: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M18.544%207.172A9.001%209.001%200%200%200%201.285%2012.25l.968.75H8.25a.75.75%200%200%201%20.75.75v4.21l1.06%201c.648-.04%201.938-.142%202.768-.416a9%209%200%200%200%205.716-11.372M7.8%203.354a7%207%200%200%201%204.4%2013.291c-.3.1-.745.17-1.2.224v-3.12A2.75%202.75%200%200%200%208.25%2011H3.072A7%207%200%200%201%207.8%203.355Z'/><circle%20cx='6.5'%20cy='8.5'%20r='1.5'/><circle%20cx='10.5'%20cy='6.5'%20r='1.5'/><circle%20cx='13.5'%20cy='10.5'%20r='1.5'/></svg>");
+}
+
+/* The output pane says two things that used to need two panes: the export is a directory of
+ * files, and what a reader opens is a page. They are stacked rather than set side by side --
+ * the diagram is already the widest object on the page, and a third pane is what tips it into
+ * scrolling on the skins with a narrow column. The tree stays in flow and so keeps sizing the
+ * box; the page is laid over it and inherits that size, which also means the box grows with a
+ * language whose file list runs longer.
+ *
+ * A reader who has asked for less motion is not shown one of the two: the pair unstacks and both
+ * stand, which is the same information without the crossing. */
+.wikven-home-out {
+	position: relative;
+}
+
+.wikven-home-out-page {
+	position: absolute;
+	inset: 0;
+}
+
+@keyframes wikven-out-tree {
+	0%,
+	40% {
+		opacity: 1;
+	}
+
+	48%,
+	90% {
+		opacity: 0;
+	}
+
+	98%,
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes wikven-out-page {
+	0%,
+	40% {
+		opacity: 0;
+	}
+
+	48%,
+	90% {
+		opacity: 1;
+	}
+
+	98%,
+	100% {
+		opacity: 0;
+	}
+}
+
+.wikven-home-out-tree {
+	animation: wikven-out-tree 11s ease-in-out infinite;
+}
+
+.wikven-home-out-page {
+	animation: wikven-out-page 11s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.wikven-home-out {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.wikven-home-out-page {
+		position: static;
+	}
+
+	.wikven-home-out-tree,
+	.wikven-home-out-page {
+		animation: none;
+	}
+}
+
+/* The page itself: a frame, a sidebar and a column of lines. The lines are one repeating gradient
+ * rather than a div each, so the miniature is four elements in the source instead of fifteen and
+ * the rhythm is a length to change rather than a list to edit. Nothing here is text, and nothing
+ * is announced: the pane's label already says what it is. */
+.wikven-home-page {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	block-size: 100%;
+	padding: 0.75rem;
+	border: 1px solid var(--border-color-base, #a2a9b1);
+	border-radius: 0.5rem;
+}
+
+.wikven-home-page-chrome {
+	flex: 0 0 auto;
+	block-size: 0.4rem;
+	inline-size: 2rem;
+	border-radius: 999px;
+	background-color: var(--border-color-base, #a2a9b1);
+}
+
+/* A floor as well as a grow. Laid over the tree the columns stretch to its height, but unstacked
+ * -- which is what a reader who asked for less motion gets -- there is no height to stretch to and
+ * the lines have none of their own, so the page came out as a frame with a title bar and nothing
+ * under it. */
+.wikven-home-page-cols {
+	display: flex;
+	flex: 1 1 auto;
+	min-block-size: 7rem;
+	gap: 0.75rem;
+	border-block-start: 1px solid var(--border-color-muted, #dadde3);
+	padding-block-start: 0.75rem;
+}
+
+.wikven-home-page-side,
+.wikven-home-page-main {
+	background-image: repeating-linear-gradient(
+		to bottom,
+		var(--border-color-muted, #dadde3) 0 0.3rem,
+		transparent 0.3rem 0.85rem
+	);
+	background-repeat: no-repeat;
+}
+
+.wikven-home-page-side {
+	flex: 0 0 4rem;
+	background-size: 80% 100%;
+}
+
+/* The title line is the accent, as it is on every page this site writes; the body below it starts
+ * far enough down to leave the title its own line. */
+.wikven-home-page-main {
+	flex: 1 1 auto;
+	background-position: 0 1.4rem;
+	background-size: 100% calc(100% - 1.4rem);
+	position: relative;
+}
+
+.wikven-home-page-main::before {
+	content: "";
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline-start: 0;
+	inline-size: 65%;
+	block-size: 0.5rem;
+	border-radius: 999px;
+	background-color: var(--color-progressive, #10707f);
+}
+
+/* The hero is lit from behind rather than given a picture: the page is about a thing that bakes,
+ * and warmth is the one part of that idea a landing page can carry without repeating the mark the
+ * skin already shows in its header.
+ *
+ * isolation makes the hero its own stacking context, so the two fields sit behind the tagline and
+ * nowhere else; without it a z-index of -1 escapes to the page ground and the skin paints over
+ * them. They are allowed to bleed past the hero box -- that is what keeps them reading as light
+ * rather than as a panel with a coloured background. */
+.wikven-home-hero {
+	position: relative;
+	isolation: isolate;
+}
+
+.wikven-home-hero::before,
+.wikven-home-hero::after {
+	content: "";
+	position: absolute;
+	z-index: -1;
+	pointer-events: none;
+}
+
+/* closest-side, not a percentage stop. A percentage is taken against the farthest corner, so on a
+ * box wider than it is tall the fade is still part-opaque when it reaches the near edge and the
+ * light ends in a straight line across the band -- which is what the first draft of this did. Sized
+ * to the closest side the falloff always finishes inside the box, whatever shape the column gives
+ * it, and it is the column that decides: the width is a reader preference in one of the skins. */
+.wikven-home-hero::before {
+	inset: -7rem 45% -7rem -9rem;
+	background: radial-gradient(circle closest-side at 35% 50%, rgba(255, 140, 26, 0.32), rgba(255, 140, 26, 0));
+}
+
+.wikven-home-hero::after {
+	inset: -6rem -9rem -6rem 40%;
+	background: radial-gradient(circle closest-side at 62% 45%, rgba(16, 112, 127, 0.2), rgba(16, 112, 127, 0));
+}
+
+/* Night wants both fields weaker. At the daytime strength they stop reading as light on a dark
+ * ground and start reading as two stains, which is the failure this kind of thing is known for. */
+@media screen {
+	html.skin-theme-clientpref-night .wikven-home-hero::before {
+		background: radial-gradient(circle closest-side at 35% 50%, rgba(255, 140, 26, 0.18), rgba(255, 140, 26, 0));
+	}
+
+	html.skin-theme-clientpref-night .wikven-home-hero::after {
+		background: radial-gradient(circle closest-side at 62% 45%, rgba(87, 188, 203, 0.14), rgba(87, 188, 203, 0));
+	}
+}
+
+@media screen and (prefers-color-scheme: dark) {
+	html.skin-theme-clientpref-os .wikven-home-hero::before {
+		background: radial-gradient(circle closest-side at 35% 50%, rgba(255, 140, 26, 0.18), rgba(255, 140, 26, 0));
+	}
+
+	html.skin-theme-clientpref-os .wikven-home-hero::after {
+		background: radial-gradient(circle closest-side at 62% 45%, rgba(87, 188, 203, 0.14), rgba(87, 188, 203, 0));
+	}
+}

--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -318,30 +318,38 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 }
 
 .wikven-home-sym--template {
-	-webkit-mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%203a1%201%200%200%200%202%200V1h7v6a3%203%200%201%201%200%206v6H1V1h7zM3%2017h12v-6h2a1%201%200%201%200%200-2h-2V3h-3a3%203%200%201%201-6%200H3z'/></svg>")
+	-webkit-mask:
+		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%203a1%201%200%200%200%202%200V1h7v6a3%203%200%201%201%200%206v6H1V1h7zM3%2017h12v-6h2a1%201%200%201%200%200-2h-2V3h-3a3%203%200%201%201-6%200H3z'/></svg>")
 		no-repeat center / contain;
-	mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%203a1%201%200%200%200%202%200V1h7v6a3%203%200%201%201%200%206v6H1V1h7zM3%2017h12v-6h2a1%201%200%201%200%200-2h-2V3h-3a3%203%200%201%201-6%200H3z'/></svg>")
+	mask:
+		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%203a1%201%200%200%200%202%200V1h7v6a3%203%200%201%201%200%206v6H1V1h7zM3%2017h12v-6h2a1%201%200%201%200%200-2h-2V3h-3a3%203%200%201%201-6%200H3z'/></svg>")
 		no-repeat center / contain;
 }
 
 .wikven-home-sym--parts {
-	-webkit-mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M1.456%207.172a9%209%200%200%201%2017.259%205.079l-.968.75L11.75%2013a.75.75%200%200%200-.75.75v4.21l-1.06%201c-.648-.04-1.938-.142-2.768-.416A9%209%200%200%201%201.456%207.172M12.2%203.354a7%207%200%200%200-4.4%2013.291c.3.1.745.17%201.2.224v-3.12A2.75%202.75%200%200%201%2011.75%2011h5.178A7%207%200%200%200%2012.2%203.355Z'/><circle%20cx='6.5'%20cy='10.5'%20r='1.5'/><circle%20cx='9.5'%20cy='6.5'%20r='1.5'/><circle%20cx='13.5'%20cy='8.5'%20r='1.5'/></svg>")
+	-webkit-mask:
+		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M1.456%207.172a9%209%200%200%201%2017.259%205.079l-.968.75L11.75%2013a.75.75%200%200%200-.75.75v4.21l-1.06%201c-.648-.04-1.938-.142-2.768-.416A9%209%200%200%201%201.456%207.172M12.2%203.354a7%207%200%200%200-4.4%2013.291c.3.1.745.17%201.2.224v-3.12A2.75%202.75%200%200%201%2011.75%2011h5.178A7%207%200%200%200%2012.2%203.355Z'/><circle%20cx='6.5'%20cy='10.5'%20r='1.5'/><circle%20cx='9.5'%20cy='6.5'%20r='1.5'/><circle%20cx='13.5'%20cy='8.5'%20r='1.5'/></svg>")
 		no-repeat center / contain;
-	mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M1.456%207.172a9%209%200%200%201%2017.259%205.079l-.968.75L11.75%2013a.75.75%200%200%200-.75.75v4.21l-1.06%201c-.648-.04-1.938-.142-2.768-.416A9%209%200%200%201%201.456%207.172M12.2%203.354a7%207%200%200%200-4.4%2013.291c.3.1.745.17%201.2.224v-3.12A2.75%202.75%200%200%201%2011.75%2011h5.178A7%207%200%200%200%2012.2%203.355Z'/><circle%20cx='6.5'%20cy='10.5'%20r='1.5'/><circle%20cx='9.5'%20cy='6.5'%20r='1.5'/><circle%20cx='13.5'%20cy='8.5'%20r='1.5'/></svg>")
+	mask:
+		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M1.456%207.172a9%209%200%200%201%2017.259%205.079l-.968.75L11.75%2013a.75.75%200%200%200-.75.75v4.21l-1.06%201c-.648-.04-1.938-.142-2.768-.416A9%209%200%200%201%201.456%207.172M12.2%203.354a7%207%200%200%200-4.4%2013.291c.3.1.745.17%201.2.224v-3.12A2.75%202.75%200%200%201%2011.75%2011h5.178A7%207%200%200%200%2012.2%203.355Z'/><circle%20cx='6.5'%20cy='10.5'%20r='1.5'/><circle%20cx='9.5'%20cy='6.5'%20r='1.5'/><circle%20cx='13.5'%20cy='8.5'%20r='1.5'/></svg>")
 		no-repeat center / contain;
 }
 
 .wikven-home-sym--search {
-	-webkit-mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%201a7%207%200%200%201%205.605%2011.191l5.102%205.102-1.414%201.414-5.102-5.102A7%207%200%201%201%208%201m0%202a5%205%200%201%200%200%2010A5%205%200%200%200%208%203'/></svg>")
+	-webkit-mask:
+		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%201a7%207%200%200%201%205.605%2011.191l5.102%205.102-1.414%201.414-5.102-5.102A7%207%200%201%201%208%201m0%202a5%205%200%201%200%200%2010A5%205%200%200%200%208%203'/></svg>")
 		no-repeat center / contain;
-	mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%201a7%207%200%200%201%205.605%2011.191l5.102%205.102-1.414%201.414-5.102-5.102A7%207%200%201%201%208%201m0%202a5%205%200%201%200%200%2010A5%205%200%200%200%208%203'/></svg>")
+	mask:
+		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='M8%201a7%207%200%200%201%205.605%2011.191l5.102%205.102-1.414%201.414-5.102-5.102A7%207%200%201%201%208%201m0%202a5%205%200%201%200%200%2010A5%205%200%200%200%208%203'/></svg>")
 		no-repeat center / contain;
 }
 
 .wikven-home-sym--languages {
-	-webkit-mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='m17.835%2019-1.248-3h-4.174l-1.248%203.001H9l4.577-11.005h1.846L20%2019zm-4.59-5h2.51L14.5%2010.982zM7.618%203H12v2H9.991a8.5%208.5%200%200%201-1.423%204.02q-.24.358-.528.707.634.367%201.379.711l.908.42-.839%201.816-.907-.42a18%2018%200%200%201-2.026-1.09c-1.255.979-2.912%201.8-5.076%202.31l-.973.228-.458-1.946.973-.23c1.631-.383%202.885-.954%203.85-1.608C3.29%208.527%202.317%206.884%202.065%205H0V3h5.382l-.724-1.447%201.79-.895L7.617%203ZM4.094%205c.243%201.282.974%202.489%202.29%203.586A6.54%206.54%200%200%200%207.98%205z'/></svg>")
+	-webkit-mask:
+		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='m17.835%2019-1.248-3h-4.174l-1.248%203.001H9l4.577-11.005h1.846L20%2019zm-4.59-5h2.51L14.5%2010.982zM7.618%203H12v2H9.991a8.5%208.5%200%200%201-1.423%204.02q-.24.358-.528.707.634.367%201.379.711l.908.42-.839%201.816-.907-.42a18%2018%200%200%201-2.026-1.09c-1.255.979-2.912%201.8-5.076%202.31l-.973.228-.458-1.946.973-.23c1.631-.383%202.885-.954%203.85-1.608C3.29%208.527%202.317%206.884%202.065%205H0V3h5.382l-.724-1.447%201.79-.895L7.617%203ZM4.094%205c.243%201.282.974%202.489%202.29%203.586A6.54%206.54%200%200%200%207.98%205z'/></svg>")
 		no-repeat center / contain;
-	mask: url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='m17.835%2019-1.248-3h-4.174l-1.248%203.001H9l4.577-11.005h1.846L20%2019zm-4.59-5h2.51L14.5%2010.982zM7.618%203H12v2H9.991a8.5%208.5%200%200%201-1.423%204.02q-.24.358-.528.707.634.367%201.379.711l.908.42-.839%201.816-.907-.42a18%2018%200%200%201-2.026-1.09c-1.255.979-2.912%201.8-5.076%202.31l-.973.228-.458-1.946.973-.23c1.631-.383%202.885-.954%203.85-1.608C3.29%208.527%202.317%206.884%202.065%205H0V3h5.382l-.724-1.447%201.79-.895L7.617%203ZM4.094%205c.243%201.282.974%202.489%202.29%203.586A6.54%206.54%200%200%200%207.98%205z'/></svg>")
+	mask:
+		url("data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2020%2020'><path%20d='m17.835%2019-1.248-3h-4.174l-1.248%203.001H9l4.577-11.005h1.846L20%2019zm-4.59-5h2.51L14.5%2010.982zM7.618%203H12v2H9.991a8.5%208.5%200%200%201-1.423%204.02q-.24.358-.528.707.634.367%201.379.711l.908.42-.839%201.816-.907-.42a18%2018%200%200%201-2.026-1.09c-1.255.979-2.912%201.8-5.076%202.31l-.973.228-.458-1.946.973-.23c1.631-.383%202.885-.954%203.85-1.608C3.29%208.527%202.317%206.884%202.065%205H0V3h5.382l-.724-1.447%201.79-.895L7.617%203ZM4.094%205c.243%201.282.974%202.489%202.29%203.586A6.54%206.54%200%200%200%207.98%205z'/></svg>")
 		no-repeat center / contain;
 }
 
@@ -532,32 +540,56 @@ html[dir="rtl"] .wikven-home-sym--parts {
  * it, and it is the column that decides: the width is a reader preference in one of the skins. */
 .wikven-home-hero::before {
 	inset: -7rem 45% -7rem -9rem;
-	background: radial-gradient(circle closest-side at 35% 50%, rgba(255, 140, 26, 0.32), rgba(255, 140, 26, 0));
+	background: radial-gradient(
+		circle closest-side at 35% 50%,
+		rgba(255, 140, 26, 0.32),
+		rgba(255, 140, 26, 0)
+	);
 }
 
 .wikven-home-hero::after {
 	inset: -6rem -9rem -6rem 40%;
-	background: radial-gradient(circle closest-side at 62% 45%, rgba(16, 112, 127, 0.2), rgba(16, 112, 127, 0));
+	background: radial-gradient(
+		circle closest-side at 62% 45%,
+		rgba(16, 112, 127, 0.2),
+		rgba(16, 112, 127, 0)
+	);
 }
 
 /* Night wants both fields weaker. At the daytime strength they stop reading as light on a dark
  * ground and start reading as two stains, which is the failure this kind of thing is known for. */
 @media screen {
 	html.skin-theme-clientpref-night .wikven-home-hero::before {
-		background: radial-gradient(circle closest-side at 35% 50%, rgba(255, 140, 26, 0.18), rgba(255, 140, 26, 0));
+		background: radial-gradient(
+			circle closest-side at 35% 50%,
+			rgba(255, 140, 26, 0.18),
+			rgba(255, 140, 26, 0)
+		);
 	}
 
 	html.skin-theme-clientpref-night .wikven-home-hero::after {
-		background: radial-gradient(circle closest-side at 62% 45%, rgba(87, 188, 203, 0.14), rgba(87, 188, 203, 0));
+		background: radial-gradient(
+			circle closest-side at 62% 45%,
+			rgba(87, 188, 203, 0.14),
+			rgba(87, 188, 203, 0)
+		);
 	}
 }
 
 @media screen and (prefers-color-scheme: dark) {
 	html.skin-theme-clientpref-os .wikven-home-hero::before {
-		background: radial-gradient(circle closest-side at 35% 50%, rgba(255, 140, 26, 0.18), rgba(255, 140, 26, 0));
+		background: radial-gradient(
+			circle closest-side at 35% 50%,
+			rgba(255, 140, 26, 0.18),
+			rgba(255, 140, 26, 0)
+		);
 	}
 
 	html.skin-theme-clientpref-os .wikven-home-hero::after {
-		background: radial-gradient(circle closest-side at 62% 45%, rgba(87, 188, 203, 0.14), rgba(87, 188, 203, 0));
+		background: radial-gradient(
+			circle closest-side at 62% 45%,
+			rgba(87, 188, 203, 0.14),
+			rgba(87, 188, 203, 0)
+		);
 	}
 }

--- a/docs/Template:home/styles.css
+++ b/docs/Template:home/styles.css
@@ -6,11 +6,13 @@
  * skin that defines none. Defining one is not an option -- TemplateStyles drops a
  * custom-property declaration, and drops it silently.
  *
- * Two things this file deliberately does not do, both of them in MediaWiki:Common.css instead,
- * scoped to this page: the file-type marks in the diagram, which are SVG masks, and the caret
- * that blinks in the command. A mask-image is not colour-typed, so a var() in one cannot be
- * checked and the declaration would go; @keyframes is not a rule this file can rely on either.
- * Common.css is not sanitised and already carries a data-URI SVG for the external-link arrow.
+ * Five things this file deliberately does not do, all of them in MediaWiki:Common.css instead:
+ * the file-type marks in the diagram and the symbol on each card, which are SVG masks; the caret
+ * that blinks in the command and the crossing between the output pane's two states, which are
+ * animations; and the warmth behind the hero, which is a pair of gradients. A mask-image is not
+ * colour-typed, so a var() in one cannot be checked and the declaration would go; @keyframes is
+ * not a rule this file can rely on either, and a gradient goes the way of the mask. Common.css is
+ * not sanitised and already carries a data-URI SVG for the external-link arrow.
  *
  * Every shape drawn here comes out of border-*-color or background-color, both colour-typed and
  * so able to read a token. A var() inside linear-gradient() cannot be type-checked and the whole
@@ -31,7 +33,11 @@
 
 /* No rule under the hero. The skin draws one under the title and another under the tab row, so a
  * third within a couple of hundred pixels made the page's own rule indistinguishable from the
- * furniture above it. The closing band keeps its rule and is the only one the page draws. */
+ * furniture above it. The closing band keeps its rule and is the only one the page draws.
+ *
+ * The band is not as empty as this rule makes it look: Common.css hangs two fields of light off
+ * ::before and ::after here, and makes this element a stacking context so they stay behind the
+ * tagline. Changing the margins moves them. */
 .wikven-home-hero {
 	margin-block: 4rem 6rem;
 }

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -60,6 +60,8 @@ Your source
 Your site
 </translate>
 </div>
+<div class="wikven-home-out">
+<div class="wikven-home-out-tree">
 <div class="wikven-home-tree">
 <div class="wikven-home-tree-root">dist/</div>
 <div class="wikven-home-tree-branch"><!--
@@ -74,6 +76,15 @@ the search index
 </span></div><!--
 --></div>
 </div>
+</div>
+<div class="wikven-home-out-page"><div class="wikven-home-page"><!--
+--><div class="wikven-home-page-chrome"></div><!--
+--><div class="wikven-home-page-cols"><!--
+--><div class="wikven-home-page-side"></div><!--
+--><div class="wikven-home-page-main"></div><!--
+--></div>
+</div></div>
+</div>
 </div><!--
 --></div>
 </div>
@@ -86,6 +97,7 @@ the search index
 </translate>
 <div class="wikven-home-cards"><!--
 --><div class="wikven-home-card">
+<div class="wikven-home-sym wikven-home-sym--template"></div>
 <div class="wikven-home-card-title">
 <translate>
 <!--T:6-->
@@ -100,6 +112,7 @@ Templates, parser functions and Lua modules, all resolved at build time.
 </div>
 </div><!--
 --><div class="wikven-home-card">
+<div class="wikven-home-sym wikven-home-sym--parts"></div>
 <div class="wikven-home-card-title">
 <translate>
 <!--T:8-->
@@ -114,6 +127,7 @@ Bundled or fetched from Git, with several skins for the reader to choose between
 </div>
 </div><!--
 --><div class="wikven-home-card">
+<div class="wikven-home-sym wikven-home-sym--search"></div>
 <div class="wikven-home-card-title">
 <translate>
 <!--T:10-->
@@ -128,6 +142,7 @@ The index is built with the site and runs in the reader's browser.
 </div>
 </div><!--
 --><div class="wikven-home-card">
+<div class="wikven-home-sym wikven-home-sym--languages"></div>
 <div class="wikven-home-card-title">
 <translate>
 <!--T:12-->


### PR DESCRIPTION
The landing page drew every shape it had out of borders and background colours and had no image at all. Three additions, chosen for what they say rather than for filling space. The oven mark is deliberately not one of them — the skin already shows it in the header, and putting it in the hero as well is the same thing twice.

All three live in `MediaWiki:Common.css`, because TemplateStyles drops a `mask-image`, a `@keyframes` and a gradient alike, and drops them silently. The stylesheet's own header comment named the two things that were already there for that reason; it now names five.

## A symbol on each card

From OOUI's own set, which is the point of them — a reader who has used a MediaWiki wiki has met the jigsaw piece on a template and the 文A on a language menu, so the glyph does work no drawing of ours would do.

| card | icon | pack |
| --- | --- | --- |
| Templates, not copy-paste | `puzzle` | editing-advanced |
| Extensions and skins | `palette` | editing-advanced |
| Search with nothing to query | `search` | interactions |
| Every language you write in | `language` | editing-advanced |

They are masks rather than `[[File:]]` images, for the reason the file-type marks are: a mask throws the source's colour away and takes `--color-progressive`, so one copy serves both themes. `puzzle` and `palette` ship as an ltr/rtl pair upstream because both shapes lean — this page writes nothing but logical properties, so the mirrored pair is honoured here too. OOUI is MIT.

## The output pane says both of the things it is

A directory of files, and a page a reader opens. Stacked rather than set side by side: the diagram is already the widest object on the page, and a third pane is what tips it into scrolling on a narrow column. The tree stays in flow and keeps sizing the box, so it also grows with a language whose file list runs longer; the page is laid over it and inherits that size.

The page itself is four elements — the body lines are one `repeating-linear-gradient` rather than a div each, so the rhythm is a length to change instead of a list to edit, and the source keeps four empty divs instead of fifteen. Nothing there is text and nothing is announced; the pane's label already says what it is.

**A reader who has asked for less motion gets the pair unstacked, both standing.** Nothing is hidden behind an animation that never plays.

## The hero is lit from behind

Two fields, no asset. Sized `closest-side` rather than by a percentage stop — a percentage is measured against the farthest corner, so on a box wider than it is tall the fade was still part-opaque when it reached the near edge and the light ended in a straight line across the band. That was the first draft, and the screenshots below are how it was caught. Night gets both fields weaker; at daytime strength they stop reading as light and start reading as two stains.

## Testing

- Rendered the real markup against the real stylesheets in Chromium, light and night, plus `prefers-reduced-motion` — which is where the hard edge and a collapsed miniature (no intrinsic height once unstacked) both turned up and were fixed.
- Both stylesheets parse clean; `translate check` over `docs/` reports only the pre-existing `docs/Licenses/km.wikitext` T:2 staleness.
- No new units, so no translation goes stale: everything added is markup and CSS.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_