### PR TITLE
fix(docs): keep the hero's light inside the hero

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -533,24 +533,35 @@ html[dir="rtl"] .wikven-home-sym--parts {
 	pointer-events: none;
 }
 
-/* closest-side, not a percentage stop. A percentage is taken against the farthest corner, so on a
- * box wider than it is tall the fade is still part-opaque when it reaches the near edge and the
- * light ends in a straight line across the band -- which is what the first draft of this did. Sized
- * to the closest side the falloff always finishes inside the box, whatever shape the column gives
- * it, and it is the column that decides: the width is a reader preference in one of the skins. */
+/* Two rules of geometry here, each of them a bug this had before it had them.
+ *
+ * closest-side, not a percentage stop. A percentage is taken against the farthest corner, so on a
+ * box wider than it is tall the fade is still part-opaque when it reaches the near edge, and the
+ * light ends in a straight line across the band. Sized to the closest side the falloff always
+ * finishes inside the box, whatever shape the column gives it -- and it is the column that
+ * decides, since the width is a reader preference in one of the skins.
+ *
+ * And neither field reaches past the hero on the inline axis. Bleeding a few rem to either side
+ * is invisible in a skin that centres its content in a wide margin, and is horizontal scroll in
+ * one that does not: Minerva runs its column to the edge, so the page grew 128px past a 360px
+ * viewport and the reader got a sideways scroll and a white gutter. Each field is centred in a box
+ * that stops at the hero's edge, which is also what gives it the largest radius closest-side
+ * allows. */
 .wikven-home-hero::before {
-	inset: -7rem 45% -7rem -9rem;
+	inset-block: -5rem;
+	inset-inline: 0 30%;
 	background: radial-gradient(
-		circle closest-side at 35% 50%,
+		circle closest-side at 50% 50%,
 		rgba(255, 140, 26, 0.32),
 		rgba(255, 140, 26, 0)
 	);
 }
 
 .wikven-home-hero::after {
-	inset: -6rem -9rem -6rem 40%;
+	inset-block: -4rem;
+	inset-inline: 40% 0;
 	background: radial-gradient(
-		circle closest-side at 62% 45%,
+		circle closest-side at 50% 45%,
 		rgba(16, 112, 127, 0.2),
 		rgba(16, 112, 127, 0)
 	);
@@ -561,7 +572,7 @@ html[dir="rtl"] .wikven-home-sym--parts {
 @media screen {
 	html.skin-theme-clientpref-night .wikven-home-hero::before {
 		background: radial-gradient(
-			circle closest-side at 35% 50%,
+			circle closest-side at 50% 50%,
 			rgba(255, 140, 26, 0.18),
 			rgba(255, 140, 26, 0)
 		);
@@ -569,7 +580,7 @@ html[dir="rtl"] .wikven-home-sym--parts {
 
 	html.skin-theme-clientpref-night .wikven-home-hero::after {
 		background: radial-gradient(
-			circle closest-side at 62% 45%,
+			circle closest-side at 50% 45%,
 			rgba(87, 188, 203, 0.14),
 			rgba(87, 188, 203, 0)
 		);
@@ -579,7 +590,7 @@ html[dir="rtl"] .wikven-home-sym--parts {
 @media screen and (prefers-color-scheme: dark) {
 	html.skin-theme-clientpref-os .wikven-home-hero::before {
 		background: radial-gradient(
-			circle closest-side at 35% 50%,
+			circle closest-side at 50% 50%,
 			rgba(255, 140, 26, 0.18),
 			rgba(255, 140, 26, 0)
 		);
@@ -587,7 +598,7 @@ html[dir="rtl"] .wikven-home-sym--parts {
 
 	html.skin-theme-clientpref-os .wikven-home-hero::after {
 		background: radial-gradient(
-			circle closest-side at 62% 45%,
+			circle closest-side at 50% 45%,
 			rgba(87, 188, 203, 0.14),
 			rgba(87, 188, 203, 0)
 		);


### PR DESCRIPTION
Reported from a phone: the landing page scrolls sideways in Minerva and has a white gutter down the right. Mine, from #524.

## What it was

Both hero fields bled `9rem` past the hero on the inline axis. In Vector that lands inside the wide margin the skin centres its content in, so nothing showed and I never saw it. Minerva runs its column to the edge of the viewport, so the bleed went straight past it:

```
viewport 360 → document 488   (hero right edge 344 + 144px of ::after = 488)
```

The gutter is the same bug seen from the other side: once the document is wider than the viewport, the body no longer fills it.

## What it is now

Each field sits in a box that stops at the hero's own edge, and is centred in that box rather than pushed to one side — which is also what gives it the largest radius `closest-side` will allow, so the light is no smaller for being contained. `inset-inline: 0 30%` and `40% 0`, centres at 50%.

The two geometry rules this thing needs are now one comment instead of two, since the second was written to answer the first bug and the first now answers both.

## Measured

| skin | viewport | document, glow on | glow disabled |
| --- | --- | --- | --- |
| Minerva | 320 | 321 | 321 |
| Minerva | 360 | 361 | 361 |
| Minerva | 414 | 415 | 415 |
| Vector | 360 / 768 / 1280 / 1600 | same as viewport | same |

The remaining 1px in Minerva is identical with the fields disabled, so it is not this — it predates the change.

Rendered against the deployed site's own HTML and stylesheets, not a harness. **No auto-merge on this one** — it is a visual change and the preview should outlive the CI run this time.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_