### PR TITLE
feat(docs): turn the diagram's output pane over on scroll where the browser can

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -425,6 +425,74 @@ html[dir="rtl"] .wikven-home-sym--parts {
 	animation: wikven-out-page 11s ease-in-out infinite;
 }
 
+/* Where the browser can drive an animation from the scroll position, it does, and the clock is
+ * left out of it: the pane turns over as the reader brings the diagram up the viewport, once,
+ * ending on the page and staying there. Nothing moves while it is being read.
+ *
+ * A feature query rather than both at once, because both at once is not a thing an animation can
+ * be: it has one timeline, and setting animation-timeline replaces the clock rather than joining
+ * it.
+ *
+ * The timeline is named on the band and referenced from inside it, rather than each layer taking
+ * its own view(). view() measures the subject against its nearest scroll container, and the layers
+ * have one much nearer than the page: the diagram's own horizontal scroller. overflow-x: auto
+ * makes overflow-y compute to auto as well -- there is no way to scroll one axis and leave the
+ * other alone -- so the layers were being measured against a box they never move inside, and the
+ * pane sat frozen mid-turn. The band is outside that scroller, so it is measured against the page.
+ *
+ * fill-mode is what makes it hold: outside the range an unfilled animation drops back to the base
+ * style, which here is both states at full opacity, one on top of the other. */
+@supports (animation-timeline: --wikven-out) {
+	.wikven-home-section-demo {
+		view-timeline-name: --wikven-out;
+	}
+
+	.wikven-home-out-tree,
+	.wikven-home-out-page {
+		animation-duration: auto;
+		animation-iteration-count: 1;
+		animation-fill-mode: both;
+		animation-timeline: --wikven-out;
+		animation-range: cover;
+	}
+
+	.wikven-home-out-tree {
+		animation-name: wikven-out-tree-scrolled;
+	}
+
+	.wikven-home-out-page {
+		animation-name: wikven-out-page-scrolled;
+	}
+}
+
+/* The scrolled pair ends where the timed pair only passes through: on the page, since a reader who
+ * has scrolled past has been shown the answer and should keep it. */
+@keyframes wikven-out-tree-scrolled {
+	0%,
+	35% {
+		opacity: 1;
+	}
+
+	55%,
+	100% {
+		opacity: 0;
+	}
+}
+
+@keyframes wikven-out-page-scrolled {
+	0%,
+	35% {
+		opacity: 0;
+	}
+
+	55%,
+	100% {
+		opacity: 1;
+	}
+}
+
+/* Last, so it wins over both of the above: whichever timeline the browser has, a reader who asked
+ * for less motion gets neither, and the two states stand one under the other. */
 @media (prefers-reduced-motion: reduce) {
 	.wikven-home-out {
 		display: flex;


### PR DESCRIPTION
The pane crossed between the file tree and the rendered page on an 11-second clock: it moves while it is being read, and it has usually already turned over by the time anyone arrives. Where the browser can drive an animation from the scroll position it now does — the pane turns once as the reader brings the band up the viewport, ends on the page, and holds there.

## Behind a feature query, not both at once

Both at once is not something an animation can be: it has one timeline, and `animation-timeline` *replaces* the clock rather than joining it. So `@supports (animation-timeline: --wikven-out)` picks one, and the timed pair stays exactly as it shipped for a browser without scroll-driven animations. `prefers-reduced-motion` still comes last and beats both.

## The part that took the debugging

`view()` measures its subject against the **nearest scroll container**, and the layers have one much nearer than the page: the diagram's own horizontal scroller. `overflow-x: auto` makes `overflow-y` compute to `auto` too — there is no way to scroll one axis and leave the other alone — so the layers were measured against a box they never move inside. The timeline attached, reported `running`, and sat frozen at 45%: both states at half opacity, one on top of the other, at every scroll position.

So the timeline is named on `.wikven-home-section-demo`, which is outside that scroller, and referenced by name from the layers.

## Measured in Chromium

Scrolling the band up a 900px viewport:

| band top in viewport | tree | page |
| ---: | ---: | ---: |
| 871 | 1.00 | 0.00 |
| 585 | 0.94 | 0.06 |
| 405 | 0.03 | 0.97 |
| 225 | 0.00 | 1.00 |
| 0 | 0.00 | 1.00 |

- `prefers-reduced-motion: reduce` → 0 animations on either layer, both at opacity 1, the page layer `static`: the two stand one under the other, as before.
- Minerva at 360 wide: scrubs the same, and the document stays 361px — no return of #525's sideways scroll.

Scrolling back up reverses it, which is what a scrubbed timeline does. **No auto-merge** — worth a look in the preview first.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_