### PR TITLE
fix(docs): stop the diagram clipping its own file names on a narrow screen

### DIFF
--- a/docs/Template:home/styles.css
+++ b/docs/Template:home/styles.css
@@ -311,10 +311,17 @@
 	/* flex-basis is measured along the main axis, and the main axis is now the block one, so the
 	 * 1 1 0 that makes the panes share the row would here make them nought pixels tall -- and
 	 * the container's height comes from its content, so there is no free space for the grow to
-	 * hand back. They collapsed to their own borders. Stacked, a pane is as tall as it is. */
+	 * hand back. They collapsed to their own borders. Stacked, a pane is as tall as it is.
+	 *
+	 * And as wide as it is. A pane clips to its border radius, which is what keeps the label strip
+	 * inside the corners -- and on a narrow screen that clip was landing on the file names instead:
+	 * "pagefind/ the search in" and nothing after it, cut at the border with no way to reach the
+	 * rest, because a clipped box has no overflow to scroll. Sized to its content the pane holds
+	 * its longest line, and the band goes back to scrolling sideways in the scroller that is
+	 * already around it for exactly this. */
 	.wikven-home-pane {
 		flex: 0 0 auto;
-		min-inline-size: 0;
+		min-inline-size: max-content;
 	}
 
 	.wikven-home-arrow {

--- a/docs/Template:home/styles.css
+++ b/docs/Template:home/styles.css
@@ -313,15 +313,24 @@
 	 * the container's height comes from its content, so there is no free space for the grow to
 	 * hand back. They collapsed to their own borders. Stacked, a pane is as tall as it is.
 	 *
-	 * And as wide as it is. A pane clips to its border radius, which is what keeps the label strip
-	 * inside the corners -- and on a narrow screen that clip was landing on the file names instead:
-	 * "pagefind/ the search in" and nothing after it, cut at the border with no way to reach the
-	 * rest, because a clipped box has no overflow to scroll. Sized to its content the pane holds
-	 * its longest line, and the band goes back to scrolling sideways in the scroller that is
-	 * already around it for exactly this. */
+	 * The width is left alone: making the pane as wide as its longest line does stop the clipping,
+	 * but it puts a sideways scroll on one figure in the middle of a page that has none anywhere
+	 * else, which is a stranger thing to meet than the problem it solves. What actually overran is
+	 * one line, and it is handled where it is. */
 	.wikven-home-pane {
 		flex: 0 0 auto;
-		min-inline-size: max-content;
+		min-inline-size: 0;
+	}
+
+	/* The gloss goes under the name it is about rather than after it. It is the one thing in
+	 * either tree long enough to need the room -- every other line is a file name, and the one
+	 * with a space in it wraps on the space by itself -- and the pane clips to its border radius,
+	 * which on a narrow screen was landing on this line and cutting it at "the search in" with no
+	 * overflow to scroll and so no scrollbar either. Indented to the name's own column, so it
+	 * still reads as a note on pagefind/ and not as another entry. */
+	.wikven-home-gloss {
+		display: block;
+		margin-inline-start: 2.5rem;
 	}
 
 	.wikven-home-arrow {


### PR DESCRIPTION
Reported from a phone. Not the same bug as #525, and **not from the imagery work**: undoing #524's markup in the live page leaves every measurement identical, so this one is older.

## What it is

A pane clips to its border radius — that is what keeps the label strip inside the corners. Stacked on a phone, the clip lands on the content instead:

```
│ └ 🗀 pagefind/   the search in│      ← ends at the border, nothing reachable after it
```

A clipped box has no scrollable overflow, so there is no scrollbar either: the rest of the line is simply gone.

## What it is now

The first attempt widened the pane to its longest line, which stopped the clipping and put a sideways scroll on one figure in the middle of a page that has none anywhere else. That is a stranger thing to meet than the problem it solved, so it is not what this does.

Measuring the lines says the pane never needed the width. **Exactly one line of either tree overruns** — `pagefind/` with the gloss `the search index` after it, 286px against 270 available at 320 wide:

| line | width | 270 available |
| --- | ---: | --- |
| `index.wikitext` | 159 | fits |
| `Getting Started.wikitext` | 255 | fits, and wraps on its own space if it must |
| `Template:note.wikitext` | 236 | fits |
| `index.html` | 120 | fits |
| `Getting_Started.html` | 216 | fits |
| `site.styles.css` | 168 | fits |
| `pagefind/ the search index` | 286 | **over** |

So the gloss goes under the name it is about rather than after it, indented to the name's own column so it still reads as a note on `pagefind/` and not as another entry.

## Measured

| skin | viewport | worst line vs its pane | band scrolls | page vs viewport |
| --- | ---: | ---: | --- | --- |
| Vector | 320 / 360 / 414 / 600 | −24px (fits) | no | equal |
| Minerva | 320 / 360 / 414 / 600 | −24px (fits) | no | equal (+1px, pre-existing) |

Against the deployed site's own HTML and stylesheets.
