### PR TITLE
feat(docs): keep the rendered page behind the tree instead of trading places

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -383,37 +383,44 @@ html[dir="rtl"] .wikven-home-sym--parts {
 	inset: 0;
 }
 
+/* Positioned, and after the page in the source, so it paints over it: an absolutely positioned
+ * box outranks in-flow content whatever the order, so the tree has to be positioned too before
+ * being second in the document means being on top. */
+.wikven-home-out-tree {
+	position: relative;
+}
+
 @keyframes wikven-out-tree {
 	0%,
 	40% {
-		opacity: 1;
+		opacity: 0;
 	}
 
 	48%,
 	90% {
-		opacity: 0;
+		opacity: 1;
 	}
 
 	98%,
 	100% {
-		opacity: 1;
+		opacity: 0;
 	}
 }
 
 @keyframes wikven-out-page {
 	0%,
 	40% {
-		opacity: 0;
+		opacity: 1;
 	}
 
 	48%,
 	90% {
-		opacity: 1;
+		opacity: 0.28;
 	}
 
 	98%,
 	100% {
-		opacity: 0;
+		opacity: 1;
 	}
 }
 
@@ -470,24 +477,24 @@ html[dir="rtl"] .wikven-home-sym--parts {
 @keyframes wikven-out-tree-scrolled {
 	0%,
 	35% {
-		opacity: 1;
+		opacity: 0;
 	}
 
 	55%,
 	100% {
-		opacity: 0;
+		opacity: 1;
 	}
 }
 
 @keyframes wikven-out-page-scrolled {
 	0%,
 	35% {
-		opacity: 0;
+		opacity: 1;
 	}
 
 	55%,
 	100% {
-		opacity: 1;
+		opacity: 0.28;
 	}
 }
 

--- a/docs/Template:home/styles.css
+++ b/docs/Template:home/styles.css
@@ -207,8 +207,17 @@
 
 /* One line in the output tree is a product name rather than a file type, so it says what it is.
  * The other three are read off their extensions and need nothing. */
+/* The gloss goes under the name it is about rather than after it, at every width. It is the one
+ * thing in either tree long enough to need the room -- every other line is a file name, and the
+ * one with a space in it wraps on the space by itself -- and the pane clips to its border radius,
+ * which is what keeps the label strip inside the corners and was landing on this line instead,
+ * cutting it at "the search in" with no overflow to scroll and so no scrollbar either. It was
+ * fixed for the stacked layout first, on measurements taken only at phone widths; the row layout
+ * loses between 33 and 95 pixels of it and had been doing so all along. Indented to the name's own
+ * column, so it still reads as a note on pagefind/ and not as another entry. */
 .wikven-home-gloss {
-	margin-inline-start: 0.75rem;
+	display: block;
+	margin-inline-start: 2.5rem;
 	color: var(--color-subtle, #54595d);
 }
 
@@ -320,17 +329,6 @@
 	.wikven-home-pane {
 		flex: 0 0 auto;
 		min-inline-size: 0;
-	}
-
-	/* The gloss goes under the name it is about rather than after it. It is the one thing in
-	 * either tree long enough to need the room -- every other line is a file name, and the one
-	 * with a space in it wraps on the space by itself -- and the pane clips to its border radius,
-	 * which on a narrow screen was landing on this line and cutting it at "the search in" with no
-	 * overflow to scroll and so no scrollbar either. Indented to the name's own column, so it
-	 * still reads as a note on pagefind/ and not as another entry. */
-	.wikven-home-gloss {
-		display: block;
-		margin-inline-start: 2.5rem;
 	}
 
 	.wikven-home-arrow {

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -61,6 +61,13 @@ Your site
 </translate>
 </div>
 <div class="wikven-home-out">
+<div class="wikven-home-out-page"><div class="wikven-home-page"><!--
+--><div class="wikven-home-page-chrome"></div><!--
+--><div class="wikven-home-page-cols"><!--
+--><div class="wikven-home-page-side"></div><!--
+--><div class="wikven-home-page-main"></div><!--
+--></div>
+</div></div>
 <div class="wikven-home-out-tree">
 <div class="wikven-home-tree">
 <div class="wikven-home-tree-root">dist/</div>
@@ -77,13 +84,6 @@ the search index
 --></div>
 </div>
 </div>
-<div class="wikven-home-out-page"><div class="wikven-home-page"><!--
---><div class="wikven-home-page-chrome"></div><!--
---><div class="wikven-home-page-cols"><!--
---><div class="wikven-home-page-side"></div><!--
---><div class="wikven-home-page-main"></div><!--
---></div>
-</div></div>
 </div>
 </div><!--
 --></div>


### PR DESCRIPTION
The output pane showed one of its two answers at a time. It now **starts on the rendered page** and brings the file tree up over it — and the page stays: it drops back to a quarter opacity and goes on being the ground the names sit on.

Both things the pane has to say are true at once, which is what it was trying to get across by alternating: the export is a directory of files, and what a reader opens is a page.

```
scroll 0%   →  the rendered page, alone
scroll 100% →  dist/ index.html …           tree at full
               (the page still there, at 0.28, behind it)
```

## The one mechanical thing

The layers swap order in the source. An absolutely positioned box paints over in-flow content **whatever the document order says**, so the tree had to be positioned too before coming second could mean coming out on top.

## Also in here: #527 only fixed half the bug

The gloss fix from #527 was scoped to the stacked layout, because the measurements behind it were taken at phone widths alone. The row layout loses **33 to 95 pixels** of `the search index` at every width from 900 up, and had been doing so long before any of this work:

| viewport | gloss past its pane, before |
| ---: | ---: |
| 900 | +95px clipped |
| 1024 | +33px clipped |
| 1280 / 1440 / 1920 | +47px clipped |

The rule moves out of the media query, so the gloss sits under the name it belongs to at every width. After: nothing clipped at 360, 900, 1280 or 1920, and the page stays exactly as wide as the viewport.

Rendered against the deployed site's own HTML and stylesheets.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_