### PR TITLE
fix(docs): light the hero from its corners, and drop the clip #531 needed

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -298,9 +298,7 @@ body:not(.skin-citizen) .mw-parser-output a.external {
 
 /* The card symbols, the two states of the diagram's output pane, and the hero's warmth. All three
  * are here for the reason the marks above are: TemplateStyles drops a mask-image, a @keyframes and
- * a gradient alike, and drops them without saying so. The warmth has a second reason now, which is
- * that it asks the page itself to clip what runs off the sides: TemplateStyles scopes every
- * selector it is given to the parser output, and the body is not in there.
+ * a gradient alike, and drops them without saying so.
  *
  * The symbols are OOUI's own, which is the point of them. A reader who has used a MediaWiki wiki
  * has met the jigsaw piece on a template and the 文A on a language menu, so the glyph is doing
@@ -602,32 +600,30 @@ html[dir="rtl"] .wikven-home-sym--parts {
  * and warmth is the one part of that idea a landing page can carry without repeating the mark the
  * skin already shows in its header.
  *
- * What decides whether this reads as light or as an object is whether the reader can see the whole
- * of it, and a field that begins and ends inside the frame is a thing in the picture however soft
- * its edges are. #525 pulled the fields inside the band to stop a sideways scroll and #529 spent
- * the block axis on pushing their tops and bottoms out of sight, but each one still ended on both
- * sides of the text, where anyone could see it end. Ground is what runs off the edge of the frame.
+ * The light comes from two corners rather than from the middle. A field centred in the band is a
+ * thing in the picture however soft its edges are, which is what #525, #528 and #529 kept
+ * producing and what #531 answered by making the fields wider than the screen so the screen cut
+ * them -- at the cost of a clip on the root element, a feature query, and a rule reaching into
+ * Vector's sidebar to keep its white ground off the light. Anchored at the edges instead, each
+ * field is most of the way outside the frame already: the warm one just inside the near side, the
+ * cool one on the far side, both close to twice the size of the band. What is left on the page is
+ * the fall away from each corner, warm behind the first line of the title and cooling towards the
+ * far bottom one, with no boundary in it anywhere. The fade is spent by 62% of the radius, so each
+ * one is thin long before it reaches the other and they never mix into a third colour.
  *
- * So the light is cut by the screen instead, which is the one edge a reader does not read as the
- * edge of something. Each field is far wider than the viewport -- the custom property is a radius,
- * so 120vw spans 240 -- the box holding them runs past both sides of the screen rather than
- * stopping at the width of the text, and the page is told to clip what falls off, so nothing
- * scrolls sideways: the failure #525 was fixed for. What is left to see is the fall from warm to
- * nothing down the page, which is what light from behind the top of the screen looks like, and
- * across the screen there is barely a fall at all: at that radius the sides are gone before the
- * eye can find where they were going.
- *
- * Both halves of that stand on :has() and on clip, so both are asked for together. Without either
- * the fields stay inside the band and fade out by its edges: the older picture, which is safe if
- * it is not right. Safari had :has() for two versions before it had overflow: clip, which is
- * exactly the browser that would otherwise scroll sideways.
+ * The mask is what the box costs. Cut off at the inline edges the light reads as light, because
+ * that is where the text column ends and the reader is being shown the edge of the page anyway;
+ * cut off at the top and bottom it reads as a band, because there is nothing there to be an edge
+ * of -- a straight line across white, a few rows below the tab strip and again in the gap above
+ * How it works. So the box reaches further than it needs to on the block axis and the mask fades
+ * the last eighth of it at each end, which puts both of those lines where the light has already
+ * gone. A mask-image is another thing TemplateStyles drops, which is why this is here.
  *
  * isolation makes the hero its own stacking context, so the light stays behind the page's own
  * content; without it a z-index of -1 escapes to the page ground and the skin paints over it. */
 .wikven-home-hero {
 	position: relative;
 	isolation: isolate;
-	--wikven-glow-x: 50%;
 }
 
 .wikven-home-hero::before {
@@ -635,72 +631,52 @@ html[dir="rtl"] .wikven-home-sym--parts {
 	position: absolute;
 	z-index: -1;
 	pointer-events: none;
-	inset-block: -9rem -20rem;
+	inset-block: -7rem -12rem;
 	inset-inline: 0;
 	background:
 		radial-gradient(
-			ellipse var(--wikven-glow-x) 20rem at 50% 30%,
-			rgba(255, 140, 26, 0.3) 0%,
-			rgba(255, 140, 26, 0.19) 34%,
-			rgba(255, 140, 26, 0.05) 66%,
-			rgba(255, 140, 26, 0) 100%
+			ellipse 90% 120% at 8% 30%,
+			rgba(255, 140, 26, 0.22),
+			rgba(255, 140, 26, 0) 62%
 		),
 		radial-gradient(
-			ellipse var(--wikven-glow-x) 18rem at 50% 76%,
-			rgba(16, 112, 127, 0.16) 0%,
-			rgba(16, 112, 127, 0.09) 34%,
-			rgba(16, 112, 127, 0.03) 66%,
-			rgba(16, 112, 127, 0) 100%
+			ellipse 100% 130% at 96% 62%,
+			rgba(16, 112, 127, 0.14),
+			rgba(16, 112, 127, 0) 62%
 		);
-}
-
-@supports selector(:has(a)) and (overflow: clip) {
-	/* Both elements, and clip rather than hidden: clip is the one value that leaves the other axis
-	 * scrolling as it was, and asking only one of the two leaves the page scrolling sideways --
-	 * whichever of them the viewport ends up taking its overflow from, the other one is still a
-	 * box the light overflows. Scoped to the page that lights its hero, since no other page has
-	 * anything to clip. */
-	html:has(.wikven-home-hero),
-	body:has(.wikven-home-hero) {
-		overflow-x: clip;
-	}
-
-	.wikven-home-hero {
-		--wikven-glow-x: 120vw;
-	}
-
-	.wikven-home-hero::before {
-		inset-inline: -100vw;
-	}
-
-	/* Vector pins its appearance menu in a column of its own, on a white ground and above the
-	 * hero in paint order, which cut a white notch out of the light on every wide screen. The
-	 * ground is there to cover the text the menu scrolls over; on this page there is none beside
-	 * it, so taking it away costs nothing and the light runs behind the menu instead. */
-	body:has(.wikven-home-hero) .vector-pinned-container {
-		background-color: transparent;
-	}
+	-webkit-mask: linear-gradient(
+		to bottom,
+		transparent 0%,
+		#000 12%,
+		#000 88%,
+		transparent 100%
+	);
+	mask: linear-gradient(
+		to bottom,
+		transparent 0%,
+		#000 12%,
+		#000 88%,
+		transparent 100%
+	);
 }
 
 /* Night wants both weaker. At the daytime strength they stop reading as light on a dark ground and
  * start reading as stains, which is the failure this kind of thing is known for. The cool half
- * moves to the pale teal the skins use after dark, for the same reason the accent does. */
+ * moves to the pale teal the skins use after dark, for the same reason the accent does. Only the
+ * colours change: the shape of the light, and the mask that keeps its ends off the page, are the
+ * same after dark. */
 @media screen {
 	html.skin-theme-clientpref-night .wikven-home-hero::before {
 		background:
 			radial-gradient(
-				ellipse var(--wikven-glow-x) 20rem at 50% 30%,
-				rgba(255, 140, 26, 0.15) 0%,
-				rgba(255, 140, 26, 0.09) 34%,
-				rgba(255, 140, 26, 0.03) 66%,
-				rgba(255, 140, 26, 0) 100%
+				ellipse 90% 120% at 8% 30%,
+				rgba(255, 140, 26, 0.13),
+				rgba(255, 140, 26, 0) 62%
 			),
 			radial-gradient(
-				ellipse var(--wikven-glow-x) 18rem at 50% 76%,
-				rgba(87, 188, 203, 0.1) 0%,
-				rgba(87, 188, 203, 0.06) 34%,
-				rgba(87, 188, 203, 0.02) 66%,
-				rgba(87, 188, 203, 0) 100%
+				ellipse 100% 130% at 96% 62%,
+				rgba(87, 188, 203, 0.1),
+				rgba(87, 188, 203, 0) 62%
 			);
 	}
 }
@@ -709,18 +685,14 @@ html[dir="rtl"] .wikven-home-sym--parts {
 	html.skin-theme-clientpref-os .wikven-home-hero::before {
 		background:
 			radial-gradient(
-				ellipse var(--wikven-glow-x) 20rem at 50% 30%,
-				rgba(255, 140, 26, 0.15) 0%,
-				rgba(255, 140, 26, 0.09) 34%,
-				rgba(255, 140, 26, 0.03) 66%,
-				rgba(255, 140, 26, 0) 100%
+				ellipse 90% 120% at 8% 30%,
+				rgba(255, 140, 26, 0.13),
+				rgba(255, 140, 26, 0) 62%
 			),
 			radial-gradient(
-				ellipse var(--wikven-glow-x) 18rem at 50% 76%,
-				rgba(87, 188, 203, 0.1) 0%,
-				rgba(87, 188, 203, 0.06) 34%,
-				rgba(87, 188, 203, 0.02) 66%,
-				rgba(87, 188, 203, 0) 100%
+				ellipse 100% 130% at 96% 62%,
+				rgba(87, 188, 203, 0.1),
+				rgba(87, 188, 203, 0) 62%
 			);
 	}
 }


### PR DESCRIPTION
The hero's light is the one that was liked: warm coming in at the near top corner, cooling towards the far bottom one, with the fall between them the only thing on the page.

## What changes

Two fields, each anchored at an edge of the band and close to twice its size, instead of one composition centred in it. Cut off at the **inline** edges the light reads as light — that is where the text column ends and the reader is already being shown where the page stops — so nothing overflows and nothing has to be clipped. Everything #531 needed for that goes with it:

- the `overflow-x: clip` on the root element and the body,
- the `@supports selector(:has(a)) and (overflow: clip)` query and the `--wikven-glow-x` fallback,
- the rule turning off the ground under Vector's pinned appearance menu.

What a corner cannot answer is the **block** axis: cut off at the top and bottom the light reads as a band, and both cuts land on white — a straight line a few rows under the tab strip, and another in the gap above `How it works`. So the box reaches further than it needs to below the band and a mask fades the last eighth at each end, putting both lines where the light has already gone. `mask-image` is another declaration TemplateStyles drops, so it belongs in this file with the rest.

Nothing else on the page changes: the scroll-driven turn of the diagram's output pane, retimed in #531, is untouched.

## Verified

Rendered against a mirror of the deployed site with this file in place of the baked one:

- **Seams.** With the page's own content hidden so only the field paints, the worst row-to-row step anywhere in it is 9/255 — the gradient's own rate. The same measurement on the unmasked version finds 46 at the top edge and a matching one at the bottom.
- **No overflow.** `scrollWidth === clientWidth` at 360, 768, 1280 and 1920 on Vector; MinervaNeue's own overflow menu is 1px wider than the viewport in the mirror, with and without this file, which #531's clip had been hiding.
- **Night**, both `clientpref-night` and `prefers-color-scheme: dark`: same shape, weaker colours, mask unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_