### PR TITLE
fix(docs): cross the output pane's two states gradually instead of at a line

### DIFF
--- a/docs/MediaWiki:Common.css
+++ b/docs/MediaWiki:Common.css
@@ -372,6 +372,13 @@ html[dir="rtl"] .wikven-home-sym--parts {
  * box; the page is laid over it and inherits that size, which also means the box grows with a
  * language whose file list runs longer.
  *
+ * The crossing is long on purpose. A short one is read as a switch being thrown -- the pane was
+ * showing one thing and now it is showing the other -- and what is true of the export is that it
+ * is both at once: a directory of files that is also a site. So the two spend most of the cycle,
+ * and most of the pass under the reader's scroll, part way through each other rather than
+ * arriving. The page never leaves either; it settles at a quarter strength and stays behind the
+ * tree.
+ *
  * A reader who has asked for less motion is not shown one of the two: the pair unstacks and both
  * stand, which is the same information without the crossing. */
 .wikven-home-out {
@@ -392,16 +399,15 @@ html[dir="rtl"] .wikven-home-sym--parts {
 
 @keyframes wikven-out-tree {
 	0%,
-	40% {
+	16% {
 		opacity: 0;
 	}
 
-	48%,
-	90% {
+	50%,
+	80% {
 		opacity: 1;
 	}
 
-	98%,
 	100% {
 		opacity: 0;
 	}
@@ -409,16 +415,15 @@ html[dir="rtl"] .wikven-home-sym--parts {
 
 @keyframes wikven-out-page {
 	0%,
-	40% {
+	16% {
 		opacity: 1;
 	}
 
-	48%,
-	90% {
+	50%,
+	80% {
 		opacity: 0.28;
 	}
 
-	98%,
 	100% {
 		opacity: 1;
 	}
@@ -450,11 +455,16 @@ html[dir="rtl"] .wikven-home-sym--parts {
  *
  * That box is also the smallest honest one. Named on the whole section, as it was, the timeline
  * counted the heading and the lede as part of the subject, and the turn was spent while the
- * diagram was still arriving; contain over the diagram alone runs from the moment it is fully in
- * view to the moment it starts to leave, so the pane turns over with the diagram in the middle of
- * the screen rather than at the bottom edge of it. (Where the diagram is taller than the screen,
- * which is a phone stacking it, contain is the other way round -- top edge to bottom edge -- and
- * the turn lands while it fills the screen, which is the same answer.)
+ * diagram was still arriving.
+ *
+ * cover over the diagram alone, rather than contain: cover is the diagram's whole pass, from
+ * first edge in to last edge out, and it is halfway through exactly when the diagram is centred
+ * on the screen, which is where the crossing should be halfway too. contain -- fully in view to
+ * starting to leave -- puts the middle in the same place but has no length to spend on a phone,
+ * where the stacked diagram is nearly as tall as the screen: the range there was 37 pixels of
+ * scrolling, and a crossing spent over 37 pixels is a switch being thrown. Over cover the same
+ * phone has around 1400, and the keyframes hold flat for the first fifth while the diagram is
+ * arriving and then cross the rest of the way, which is what makes it read as a dissolve.
  *
  * fill-mode is what makes it hold: outside the range an unfilled animation drops back to the base
  * style, which here is both states at full opacity, one on top of the other. */
@@ -469,7 +479,11 @@ html[dir="rtl"] .wikven-home-sym--parts {
 		animation-iteration-count: 1;
 		animation-fill-mode: both;
 		animation-timeline: --wikven-out;
-		animation-range: contain;
+		animation-range: cover;
+		/* Linear, unlike the clock's pair: on a scroll timeline the easing is spent against
+		 * distance scrolled rather than against time, and anything but linear makes the middle of
+		 * the pass turn over faster than the hand moving it. */
+		animation-timing-function: linear;
 	}
 
 	.wikven-home-out-tree {
@@ -482,14 +496,16 @@ html[dir="rtl"] .wikven-home-sym--parts {
 }
 
 /* The scrolled pair ends where the timed pair only passes through: on the page, since a reader who
- * has scrolled past has been shown the answer and should keep it. */
+ * has scrolled past has been shown the answer and should keep it. It also spends nearly the whole
+ * range crossing -- flat for an eighth at each end and moving in between -- so that what the
+ * reader sees is tied to how far they have scrolled rather than to having passed a line. */
 @keyframes wikven-out-tree-scrolled {
 	0%,
-	35% {
+	20% {
 		opacity: 0;
 	}
 
-	55%,
+	85%,
 	100% {
 		opacity: 1;
 	}
@@ -497,11 +513,11 @@ html[dir="rtl"] .wikven-home-sym--parts {
 
 @keyframes wikven-out-page-scrolled {
 	0%,
-	35% {
+	20% {
 		opacity: 1;
 	}
 
-	55%,
+	85%,
 	100% {
 		opacity: 0.28;
 	}


### PR DESCRIPTION
The `Your site` pane read as a switch being thrown: it showed the tree, then it showed the page. Both pairs of keyframes spent almost the whole cycle holding and crossed in what was left — an eighth of the clock's loop, a fifth of the scroll range — so what a reader saw was a state change rather than a dissolve.

## What changes

Both pairs now hold at the ends and spend the middle crossing.

- **The clock's pair** takes three and a half seconds of eleven over it (`0–16%` hold, cross to `50%`, hold to `80%`, back by `100%`).
- **The scrolled pair** holds flat for the first fifth of the range and crosses the rest (`0–20%`, `85–100%`).

The scrolled pair also needed the range back to `cover`. `contain` has no length to spend where the stacked diagram is nearly as tall as the screen — on a 360×740 phone it was **37 pixels** of scrolling end to end, so however the keyframes were written the crossing was instant there. `cover` is the diagram's whole pass and is halfway through exactly when the diagram is centred on the screen, which is where the crossing should be halfway too.

It is also `linear`, unlike the clock's pair: on a scroll timeline easing is spent against distance rather than time, and anything but linear turns the middle of the pass over faster than the hand moving it.

## Verified

Scrubbed against a mirror of the deployed site, reading both layers' computed opacity at 25 scroll positions across the pass:

| | crossing distance | pane at half |
|---|---|---|
| 1280×900 | ~700px of scrolling | diagram's middle 41% down the screen |
| 360×740 | ~950px | 42% down |

Each 60px of scrolling moves it about a twentieth — no step larger than 0.07. On the clock, stepped every 0.5s: `0.01 → 0.08 → 0.23 → 0.44 → 0.67 → 0.85 → 0.96` across the rise.

A frame captured mid-crossing shows both layers legible over each other, which is the state the dissolve passes through. Reduced motion is untouched: the pair unstacks and neither animates.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_