### PR TITLE
fix(check-translations): keep the comment to what the change touches

### DIFF
--- a/actions/check-translations/action.yml
+++ b/actions/check-translations/action.yml
@@ -29,7 +29,10 @@ inputs:
       contributor meeting the workflow for the first time. Needs
       "pull-requests: write" on the job, and does nothing outside a pull
       request. One comment per pull request, edited on each run, and replaced
-      with an all-clear once the findings are answered.
+      with an all-clear once the findings are answered. The comment is about
+      the files the pull request touches -- and the translations of any source
+      page it touches -- rather than about the whole tree, so a page that fell
+      behind long before this change is left to the annotations.
     default: "false"
   comment-languages:
     description: >-
@@ -104,6 +107,23 @@ runs:
           comment=(--comment-file /report/comment.md)
           if [ -n "$COMMENT_LANGUAGES" ]; then
             comment+=(--comment-languages "$COMMENT_LANGUAGES")
+          fi
+          # What the pull request touches, so the comment can be about that and not about the
+          # whole wiki. A page that has been waiting for a translation since long before this
+          # change is not this contributor's to answer, and a comment that says so on every
+          # change is one nobody reads. The annotations still cover everything.
+          #
+          # Asked of the forge rather than worked out from the checkout, which is a shallow one
+          # and has no base commit to compare against. A list that cannot be had is not worth
+          # failing over: the check then comments about everything, which is what it did before.
+          if [ -n "$PULL_REQUEST" ]; then
+            if gh api "repos/$REPOSITORY/pulls/$PULL_REQUEST/files" --paginate \
+                 --jq '.[].filename' > "$report/changed.txt"; then
+              comment+=(--comment-paths /report/changed.txt)
+            else
+              echo "::warning::wikven: could not read what this change touches;" \
+                   "the translations comment will cover every page."
+            fi
           fi
         fi
         # Source is read-only for a check; no dist mount, nothing of yours is written.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,6 +14,7 @@
 	"wikven-skins-description": "Read this site in another skin. Each one renders the same pages.",
 	"wikven-translations-title": "Translations in this change",
 	"wikven-translations-lead": "`translate check` read the source pages and their translations, and has this to say. Every line is also an annotation on the file it belongs to.",
+	"wikven-translations-lead-scoped": "`translate check` read the pages this change touches, and their translations, and has this to say. Nothing here is about the rest of the wiki: every finding, wherever it is, is also an annotation on the file it belongs to.",
 	"wikven-translations-parse-heading": "The source page cannot be read",
 	"wikven-translations-parse-advice": "Translate refuses the page, so nothing of it can be translated yet. The message is Translate's own; it usually points at a `<!--T:n-->` marker somewhere other than the start of its unit or the end of a line.",
 	"wikven-translations-reserved-heading": "A unit is numbered `T:title`",
@@ -34,5 +35,6 @@
 	"wikven-translations-can-fail": "A broken source page is the one thing here that can fail the check, and only where the workflow asked it to; a translation that is merely behind or missing never does.",
 	"wikven-translations-documentation": "See [Translating]($1) for the whole workflow.",
 	"wikven-translations-documentation-url": "https://chaotic-ground.github.io/wikven/Translating.html",
-	"wikven-translations-all-clear": "`translate check` found nothing to report: every source page reads cleanly, and every translation of one is stamped current."
+	"wikven-translations-all-clear": "`translate check` found nothing to report: every source page reads cleanly, and every translation of one is stamped current.",
+	"wikven-translations-all-clear-scoped": "`translate check` found nothing to report about this change: the pages it touches read cleanly, and their translations are stamped current."
 }

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -4,6 +4,7 @@
 	},
 	"wikven-translations-title": "이 변경의 번역",
 	"wikven-translations-lead": "`translate check`가 원본 문서와 그 번역을 읽고 다음을 알려드립니다. 아래 각 줄은 해당 파일에 주석으로도 달려 있습니다.",
+	"wikven-translations-lead-scoped": "`translate check`가 이 변경이 건드린 문서와 그 번역을 읽고 다음을 알려드립니다. 이 변경 밖의 문서에 대해서는 아무 말도 하지 않습니다. 어디에서 발견된 것이든 모든 항목은 해당 파일에 주석으로도 달려 있습니다.",
 	"wikven-translations-parse-heading": "원본 문서를 읽을 수 없습니다",
 	"wikven-translations-parse-advice": "Translate가 이 문서를 거부하므로 아직 이 문서의 어느 것도 번역할 수 없습니다. 메시지는 Translate 자신의 것이며, 보통 단위의 맨 앞도 줄의 끝도 아닌 곳에 있는 `<!--T:n-->` 표시를 가리킵니다.",
 	"wikven-translations-reserved-heading": "단위 번호가 `T:title`입니다",
@@ -24,5 +25,6 @@
 	"wikven-translations-can-fail": "여기서 검사를 실패시킬 수 있는 것은 깨진 원본 문서뿐이며, 그것도 워크플로가 그렇게 요청한 경우에만입니다. 단지 뒤처지거나 빠진 번역은 결코 실패시키지 않습니다.",
 	"wikven-translations-documentation": "전체 흐름은 [번역하기]($1)를 참고하세요.",
 	"wikven-translations-documentation-url": "https://chaotic-ground.github.io/wikven/Translating/ko.html",
-	"wikven-translations-all-clear": "`translate check`가 보고할 것을 찾지 못했습니다. 모든 원본 문서가 깨끗하게 읽히고, 그 번역은 모두 최신으로 스탬프되어 있습니다."
+	"wikven-translations-all-clear": "`translate check`가 보고할 것을 찾지 못했습니다. 모든 원본 문서가 깨끗하게 읽히고, 그 번역은 모두 최신으로 스탬프되어 있습니다.",
+	"wikven-translations-all-clear-scoped": "`translate check`가 이 변경에 대해 보고할 것을 찾지 못했습니다. 이 변경이 건드린 문서는 깨끗하게 읽히고, 그 번역은 최신으로 스탬프되어 있습니다."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -14,6 +14,7 @@
 	"wikven-skins-description": "Description under {{msg-mw|wikven-skins}} on the generated settings page.",
 	"wikven-translations-title": "Heading of the comment the check-translations action leaves where the change is reviewed. Rendered once per language, so it is also what tells a reader which rendering is theirs. \"Change\" is deliberately not any one forge's word for it: the same comment is posted on a GitHub pull request, a GitLab merge request or a Gerrit change, so translate it as whatever your language calls a set of edits offered for review.",
 	"wikven-translations-lead": "Opening line of the comment, saying where the same findings appear as annotations. The comment is Markdown, not wikitext.",
+	"wikven-translations-lead-scoped": "Opening line of the comment when it has been kept to the files the change touches, used in place of {{msg-wikven|wikven-translations-lead}}. \"This change\" is deliberately not any one forge's word for a pull or merge request. The comment is Markdown, not wikitext.",
 	"wikven-translations-parse-heading": "Heading of the group for source pages the Translate extension cannot parse.",
 	"wikven-translations-parse-advice": "Advice under {{msg-mw|wikven-translations-parse-heading}}. The findings under it are Translate's own error messages.",
 	"wikven-translations-reserved-heading": "Heading of the group for a source page that numbers a unit with the id reserved for the page title.",
@@ -34,5 +35,6 @@
 	"wikven-translations-can-fail": "Closing line used when a source page is broken, which is the one kind of finding that can fail the check.",
 	"wikven-translations-documentation": "Sentence sending the reader to the Translating page, appended to whichever closing line was used. $1 is {{msg-mw|wikven-translations-documentation-url}}. Markdown link syntax, not wikitext.",
 	"wikven-translations-documentation-url": "URL of the Translating page linked from the comment. Translate this to the address of that page in your language where the wikven documentation has one, and leave it as is otherwise.",
-	"wikven-translations-all-clear": "The whole comment for a run that found nothing, which replaces an earlier complaint once it has been answered."
+	"wikven-translations-all-clear": "The whole comment for a run that found nothing, which replaces an earlier complaint once it has been answered.",
+	"wikven-translations-all-clear-scoped": "Body of the comment when the check found nothing about the files the change touches, used in place of {{msg-wikven|wikven-translations-all-clear}}. It says nothing about pages the change did not touch, which may still be waiting for a translation."
 }

--- a/includes/PageTranslation/TranslationAdvice.php
+++ b/includes/PageTranslation/TranslationAdvice.php
@@ -51,6 +51,13 @@ class TranslationAdvice {
 	/** @var callable(string,string,list<string>):string Message key, language code and parameters. */
 	private $message;
 
+	/**
+	 * The paths the comment is about, or null for all of them.
+	 *
+	 * @var list<string>|null
+	 */
+	private ?array $paths = null;
+
 	/** @param callable(string,string,list<string>):string $message */
 	public function __construct(callable $message) {
 		$this->message = $message;
@@ -64,13 +71,34 @@ class TranslationAdvice {
 	}
 
 	/**
+	 * The same advice, but only about the paths a change touches.
+	 *
+	 * A check reads the whole source tree, which is what a maintainer wants and the opposite of
+	 * what a comment wants: a page that has been waiting for a translation since long before this
+	 * change is not this contributor's to answer, and saying so on every change is how a comment
+	 * stops being read at all. So the comment is kept to the files in front of the reader.
+	 *
+	 * A translation counts as touched when its own file was, and also when the source page it
+	 * translates was: editing an English page is exactly what makes its translations stale, and
+	 * the person who did it is the one who needs to hear so.
+	 *
+	 * @param list<string> $paths As the findings name their files: repo-relative, in the same
+	 *   shape --path-prefix produces.
+	 */
+	public function about(array $paths): self {
+		$scoped = clone $this;
+		$scoped->paths = array_values($paths);
+		return $scoped;
+	}
+
+	/**
 	 * The comment for a run that found something, or null for one that found nothing.
 	 *
-	 * @param list<array{kind:string,file:string,unit?:string,lang?:string,detail?:string}> $findings
+	 * @param list<array{kind:string,file:string,source?:string,unit?:string,lang?:string,detail?:string}> $findings
 	 * @param list<string> $languages Rendered once each, in this order.
 	 */
 	public function comment(array $findings, array $languages = ['en']): ?string {
-		$grouped = self::group($findings);
+		$grouped = self::group($this->inScope($findings));
 		if ($grouped === []) {
 			return null;
 		}
@@ -100,7 +128,11 @@ class TranslationAdvice {
 		. $this->inEachLanguage(
 			$languages,
 			function (string $language): string {
-				return $this->heading($language) . $this->msg('wikven-translations-all-clear', $language) . "\n";
+				return (
+					$this->heading($language)
+					. $this->msg($this->key('wikven-translations-all-clear'), $language)
+					. "\n"
+				);
 			}
 		);
 	}
@@ -131,7 +163,7 @@ class TranslationAdvice {
 	 * @param array<string,array<string,list<array{unit?:string,lang?:string,detail?:string}>>> $grouped
 	 */
 	private function body(array $grouped, string $language): string {
-		$body = $this->heading($language) . $this->msg('wikven-translations-lead', $language) . "\n";
+		$body = $this->heading($language) . $this->msg($this->key('wikven-translations-lead'), $language) . "\n";
 		foreach (self::KINDS as $kind) {
 			if (!isset($grouped[$kind])) {
 				continue;
@@ -199,6 +231,52 @@ class TranslationAdvice {
 	 */
 	private function msg(string $key, string $language, array $parameters = []): string {
 		return ( $this->message )($key, $language, $parameters);
+	}
+
+	/**
+	 * The message for a comment about everything, or the one that says it is about a change.
+	 *
+	 * Two messages rather than one hedged wording, because a comment that has been narrowed and
+	 * one that has not are saying different things, and a reader deciding whether the check is
+	 * quiet about the rest of the wiki should not have to guess which they are holding.
+	 */
+	private function key(string $key): string {
+		return $this->paths === null ? $key : "$key-scoped";
+	}
+
+	/**
+	 * The findings a scoped comment is about; all of them where nothing was scoped.
+	 *
+	 * @param list<array{kind:string,file:string,source?:string,unit?:string,lang?:string,detail?:string}> $findings
+	 * @return list<array{kind:string,file:string,source?:string,unit?:string,lang?:string,detail?:string}>
+	 */
+	private function inScope(array $findings): array {
+		if ($this->paths === null) {
+			return $findings;
+		}
+		$paths = $this->paths;
+		return array_values(array_filter($findings, static function (array $finding) use ($paths): bool {
+			if (in_array($finding['file'], $paths, true)) {
+				return true;
+			}
+			// A translation is also this change's when the source page it translates is.
+			if (isset($finding['source']) && in_array($finding['source'], $paths, true)) {
+				return true;
+			}
+			// And the other way round: a source page nobody can read is why a translation of it
+			// renders as English, so whoever touched that translation is owed the reason. The
+			// translations of docs/Page.wikitext are the files under docs/Page/.
+			$directory = preg_replace('/\.wikitext$/', '/', $finding['file']);
+			if ($directory === $finding['file']) {
+				return false;
+			}
+			foreach ($paths as $path) {
+				if (str_starts_with($path, $directory)) {
+					return true;
+				}
+			}
+			return false;
+		}));
 	}
 
 	/**

--- a/maintenance/checkTranslations.php
+++ b/maintenance/checkTranslations.php
@@ -32,6 +32,13 @@ class CheckTranslations extends Maintenance {
 			true
 		);
 		$this->addOption(
+			'comment-paths',
+			'File listing the paths the change touches, one per line; the comment is then only about'
+			. ' those files and the translations of them.',
+			false,
+			true
+		);
+		$this->addOption(
 			'comment-languages',
 			'Languages to write that comment in, besides English: "auto" for the languages the findings'
 			. ' are about, or a comma-separated list of codes.',
@@ -97,9 +104,14 @@ class CheckTranslations extends Maintenance {
 						continue;
 					}
 					$stale++;
+					// The source page is carried alongside because editing it is what puts a
+					// translation of it behind: a comment kept to one change counts such a finding
+					// as belonging to whoever moved the source, not only to whoever last touched
+					// the translation.
 					$this->findings[] = [
 						'kind' => $unit['status'],
 						'file' => $reportFile,
+						'source' => $prefix . substr($baseFile, strlen($source) + 1),
 						'unit' => (string)$unit['id'],
 						'lang' => $lang
 					];
@@ -145,11 +157,44 @@ class CheckTranslations extends Maintenance {
 			return;
 		}
 		$advice = TranslationAdvice::usingMessages();
+		$paths = $this->commentPaths();
+		if ($paths !== null) {
+			$advice = $advice->about($paths);
+		}
 		$languages = $this->commentLanguages();
 		$body = $advice->comment($this->findings, $languages) ?? $advice->allClear($languages);
 		if (file_put_contents($path, $body) === false) {
 			$this->fatalError("Wikven: could not write the comment body to '$path'.");
 		}
+	}
+
+	/**
+	 * The paths --comment-paths named, or null when it named none and the comment is about the
+	 * whole tree.
+	 *
+	 * The file is written by whatever knows what the change touches -- the action asks the forge
+	 * for the list -- so a run that cannot read it says so and comments about everything, which
+	 * is the behaviour this option narrows rather than a state worth failing a check over.
+	 *
+	 * @return list<string>|null
+	 */
+	private function commentPaths(): ?array {
+		$path = (string)$this->getOption('comment-paths', '');
+		if ($path === '') {
+			return null;
+		}
+		if (!is_readable($path)) {
+			$this->output("::warning::Cannot read '$path'; the translations comment covers every page\n");
+			return null;
+		}
+		$paths = [];
+		foreach (explode("\n", (string)file_get_contents($path)) as $line) {
+			$line = trim($line);
+			if ($line !== '') {
+				$paths[] = $line;
+			}
+		}
+		return $paths;
 	}
 
 	/**

--- a/tests/phpunit/unit/TranslationAdviceTest.php
+++ b/tests/phpunit/unit/TranslationAdviceTest.php
@@ -127,6 +127,87 @@ class TranslationAdviceTest extends MediaWikiUnitTestCase {
 		$this->assertStringContainsString('[ko] `translate check` found nothing', $clear);
 	}
 
+	/**
+	 * A check reads the whole tree; a comment on one change should not. A page that fell behind
+	 * long before this change belongs to the annotations, not to whoever is reading this diff.
+	 */
+	public function testAScopedCommentIsOnlyAboutWhatTheChangeTouches() {
+		$body = $this
+			->advice()
+			->about(['docs/Pages/ko.wikitext'])
+			->comment([
+				[
+					'kind' => 'stale',
+					'file' => 'docs/Pages/ko.wikitext',
+					'source' => 'docs/Pages.wikitext',
+					'unit' => '3',
+					'lang' => 'ko'
+				],
+				[
+					'kind' => 'stale',
+					'file' => 'docs/Licenses/km.wikitext',
+					'source' => 'docs/Licenses.wikitext',
+					'unit' => '2',
+					'lang' => 'km'
+				]
+			]);
+		$this->assertStringContainsString('docs/Pages/ko.wikitext', $body);
+		$this->assertStringNotContainsString('km.wikitext', $body);
+		// And says so, rather than letting the reader think the rest of the wiki is clean.
+		$this->assertStringContainsString('the pages this change touches', $body);
+	}
+
+	/**
+	 * Editing an English page is what puts its translations behind, so the person who edited it
+	 * is told about them even though they never opened the translation file.
+	 */
+	public function testTouchingASourcePageCarriesItsTranslations() {
+		$body = $this
+			->advice()
+			->about(['docs/Pages.wikitext'])
+			->comment([
+				[
+					'kind' => 'stale',
+					'file' => 'docs/Pages/ko.wikitext',
+					'source' => 'docs/Pages.wikitext',
+					'unit' => '3',
+					'lang' => 'ko'
+				]
+			]);
+		$this->assertStringContainsString('docs/Pages/ko.wikitext', $body);
+	}
+
+	/**
+	 * And the other way round: a source page nobody can read is why a translation of it renders
+	 * as English, so whoever sent that translation is owed the reason.
+	 */
+	public function testTouchingATranslationCarriesItsSourcePage() {
+		$body = $this
+			->advice()
+			->about(['docs/Pages/ko.wikitext'])
+			->comment([
+				['kind' => 'parse', 'file' => 'docs/Pages.wikitext', 'detail' => 'pt-shake-position']
+			]);
+		$this->assertStringContainsString('docs/Pages.wikitext', $body);
+	}
+
+	public function testAChangeThatTouchesNoneOfThemIsToldNothingIsWrongWithIt() {
+		$advice = $this->advice()->about(['docs/index.wikitext']);
+		$this->assertNull($advice->comment([
+			[
+				'kind' => 'stale',
+				'file' => 'docs/Licenses/km.wikitext',
+				'source' => 'docs/Licenses.wikitext',
+				'unit' => '2',
+				'lang' => 'km'
+			]
+		]));
+		// The all-clear is narrowed with it: the wiki may well have pages waiting for a
+		// translation, and this comment is in no position to say otherwise.
+		$this->assertStringContainsString('about this change', $advice->allClear());
+		$this->assertStringContainsString('every source page', $this->advice()->allClear());
+	}
+
 	/** An untranslated language falls back to English, and saying it all twice reads as a bug. */
 	public function testALanguageThatFallsBackIsNotRepeated() {
 		$advice = new TranslationAdvice(static function (string $key): string {

--- a/tests/phpunit/unit/TranslationAdviceTest.php
+++ b/tests/phpunit/unit/TranslationAdviceTest.php
@@ -132,8 +132,7 @@ class TranslationAdviceTest extends MediaWikiUnitTestCase {
 	 * long before this change belongs to the annotations, not to whoever is reading this diff.
 	 */
 	public function testAScopedCommentIsOnlyAboutWhatTheChangeTouches() {
-		$body = $this
-			->advice()
+		$body = $this->advice()
 			->about(['docs/Pages/ko.wikitext'])
 			->comment([
 				[
@@ -162,8 +161,7 @@ class TranslationAdviceTest extends MediaWikiUnitTestCase {
 	 * is told about them even though they never opened the translation file.
 	 */
 	public function testTouchingASourcePageCarriesItsTranslations() {
-		$body = $this
-			->advice()
+		$body = $this->advice()
 			->about(['docs/Pages.wikitext'])
 			->comment([
 				[
@@ -182,8 +180,7 @@ class TranslationAdviceTest extends MediaWikiUnitTestCase {
 	 * as English, so whoever sent that translation is owed the reason.
 	 */
 	public function testTouchingATranslationCarriesItsSourcePage() {
-		$body = $this
-			->advice()
+		$body = $this->advice()
 			->about(['docs/Pages/ko.wikitext'])
 			->comment([
 				['kind' => 'parse', 'file' => 'docs/Pages.wikitext', 'detail' => 'pt-shake-position']


### PR DESCRIPTION
The check reads the whole source tree, and the comment was saying all of it — so `docs/Licenses/km.wikitext`, which fell behind long before any of this, turned up on every pull request addressed to whoever happened to open one. That is how a comment stops being read.

## What changes

The comment is now about the files the change touches. Two rules, because a translation and its source page are one thing kept in two files:

- **a translation is the change's** when its own file was touched, *and* when the source page it translates was — editing an English page is exactly what puts its translations behind, and the person who did it is the one who has to hear so;
- **a source page is the change's** when a translation of it was touched — a page Translate cannot read is why that translation renders as English, and the person who sent it is owed the reason.

The list of touched files comes from the forge (`gh api .../pulls/N/files`) rather than from the checkout, which is shallow and has no base commit to compare against. A list that cannot be had is not worth failing over: the check then says everything, as it did before, with a warning in the log.

**Annotations are untouched** and still cover the whole tree — that is what a maintainer reading the run wants, and it is where a finding outside the change still lives.

## Wording

The lead line and the all-clear each gain a second message for the narrowed comment (`-scoped`), rather than one hedged wording covering both. A comment that has been kept to a change and one that has not are saying different things, and a reader deciding whether the check is quiet about the rest of the wiki should not have to guess which they are holding. Both are translated into Korean alongside the rest of the set.

## Verified

- Four new unit tests, run against the real `i18n/en.json` like the rest of the file: a finding outside the change is left out, a source-page edit carries its translations, a translation edit carries its source page, and a change that touches none of them gets no comment and a narrowed all-clear.
- Exercised standalone against the same message set: scoping to `docs/Pages/ko.wikitext` or to `docs/Pages.wikitext` both yield the one `T:3 (ko)` line and drop the `km` findings; scoping to an unrelated file yields `null`; unscoped still renders all four findings.
- `phpcs`, `mago lint`, `mago format --check`, `yamllint` clean.

This pull request is its own first test: it touches no page under `docs/`, so the translations comment should not appear on it at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_