### PR TITLE
feat(build): name wikven in the User-Agent of every request it makes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,14 @@ RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 # curl counts a connection reset as a non-transient error and would otherwise not repeat it.
 ARG CURL_RETRY="--retry 5 --retry-delay 2 --retry-all-errors"
 
+# And to say who is asking. curl signs a request with its own version and nothing else, which
+# tells the operator on the other end which library made it and not which project: these three
+# downloads are the image build reaching GitHub and Gerrit, and the same rule applies to them as
+# to the fetching a bake does, which carries UserAgent::string(). No version here, because the
+# release this image is cut from is not known until wikven's own code is copied in, well after
+# these run.
+ARG CURL_AGENT="Wikven image build (+https://github.com/chaotic-ground/wikven)"
+
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 #
@@ -37,7 +45,7 @@ ARG TARGETARCH
 ARG SIFTERSEARCH_VERSION=v0.8.0
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \
- && curl -fsSL $CURL_RETRY -o /tmp/siftersearch.tar.gz \
+ && curl -fsSL $CURL_RETRY -A "$CURL_AGENT" -o /tmp/siftersearch.tar.gz \
       "https://github.com/chaotic-ground/SifterSearch/releases/download/${SIFTERSEARCH_VERSION}/SifterSearch-linux-${arch}.tar.gz" \
  && tar -xzf /tmp/siftersearch.tar.gz -C /var/www/html/extensions/ \
  && rm /tmp/siftersearch.tar.gz
@@ -68,9 +76,9 @@ ARG COMPOSER_INSTALLERS_VERSION=v2.3.0
 # matching what the ARGs pin, so a new upstream dependency cannot slip in unpinned.
 RUN composer config --global policy.advisories.block false \
  && ext=/var/www/html/extensions \
- && curl -fsSL $CURL_RETRY -o /tmp/uls.tar.gz \
+ && curl -fsSL $CURL_RETRY -A "$CURL_AGENT" -o /tmp/uls.tar.gz \
       "https://codeload.github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector/tar.gz/$ULS_VERSION" \
- && curl -fsSL $CURL_RETRY -o /tmp/translate.tar.gz \
+ && curl -fsSL $CURL_RETRY -A "$CURL_AGENT" -o /tmp/translate.tar.gz \
       "https://codeload.github.com/wikimedia/mediawiki-extensions-Translate/tar.gz/$TRANSLATE_VERSION" \
  && mkdir -p "$ext/UniversalLanguageSelector" "$ext/Translate" \
  && tar -xzf /tmp/uls.tar.gz --strip-components=1 -C "$ext/UniversalLanguageSelector" \

--- a/includes/RetryingForeignRepo.php
+++ b/includes/RetryingForeignRepo.php
@@ -53,8 +53,14 @@ class RetryingForeignRepo extends ForeignAPIRepo {
 	 *
 	 * Answering with a body or with false is what Attempts::until reads as worked or did not, so
 	 * the loop is the one the fetching side of the build uses, and the waits are the same waits.
+	 *
+	 * It is also where every request this repository makes passes, which makes it the place to
+	 * say who is asking: core would otherwise sign each lookup "MediaWiki/" and its version,
+	 * naming the library rather than the tool, and Commons is the server wikven asks most. A
+	 * caller that brought its own string keeps it.
 	 */
 	public function httpGet($url, $timeout = 'default', $options = [], &$mtime = false) {
+		$options['userAgent'] ??= UserAgent::string();
 		return Attempts::until(
 			function () use ($url, $timeout, $options, &$mtime) {
 				return parent::httpGet($url, $timeout, $options, $mtime);

--- a/includes/UserAgent.php
+++ b/includes/UserAgent.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * What wikven calls itself on the servers it fetches from.
+ *
+ * A bake reaches other people's machines: it asks Commons for the thumbnail of every image a page
+ * embeds and downloads each one, and it clones or downloads whatever third-party extensions and
+ * skins the site declares. All of that arrives on somebody else's logs, and what it says there is
+ * the only chance they have of telling this traffic apart from anything else -- of knowing which
+ * tool made it, which version, and where to go about it. Wikimedia asks for exactly that in its
+ * User-Agent policy, and it is the party wikven talks to most.
+ *
+ * Left alone, none of it says wikven. MediaWiki's HttpRequestFactory signs a request "MediaWiki/"
+ * and its own version, which names the library doing the sending and not the thing that asked for
+ * it: an operator reading that has no way to reach anyone, and every wikven build in the world
+ * looks like a wiki. So requests carry this instead, and the shape is the one the policy asks for
+ * -- the tool, its version, where it lives, and the library underneath:
+ *
+ *     Wikven/0.1.0 (+https://github.com/chaotic-ground/wikven) MediaWiki/1.46.0
+ *
+ * The version is read from extension.json rather than written here twice, so a release moves it
+ * without anyone remembering to. The class is dependency-free on purpose: fetchExtensions runs
+ * before wikven's autoloader exists and loads it by path, the same way it loads Attempts.
+ */
+class UserAgent {
+	/**
+	 * Where the tool lives.
+	 *
+	 * The address a server operator has for whoever is making the requests, which for a tool with
+	 * no operator of its own is where its issues are read.
+	 */
+	private const URL = 'https://github.com/chaotic-ground/wikven';
+
+	/** Built once: it names a release and a running MediaWiki, and neither changes mid-build. */
+	private static ?string $string = null;
+
+	/** The string every request wikven makes goes out under. */
+	public static function string(): string {
+		if (self::$string === null) {
+			self::$string =
+				'Wikven/'
+				. self::version()
+				. ' (+'
+				. self::URL
+				. ')'
+				. ( defined('MW_VERSION') ? ' MediaWiki/' . MW_VERSION : '' );
+		}
+		return self::$string;
+	}
+
+	/**
+	 * The same, after whatever the client would have said on its own.
+	 *
+	 * For a client that is not wikven's to speak for entirely. git is the one: its own string is
+	 * "git/2.43.0", and some proxies pass HTTP git traffic only when the User-Agent still looks
+	 * like a git client's, so replacing it outright would break a fetch on networks nobody here
+	 * can see. Adding to it says who is driving without taking that away.
+	 */
+	public static function after(string $client): string {
+		$client = trim($client);
+		return $client === '' ? self::string() : $client . ' ' . self::string();
+	}
+
+	/** The version this copy of wikven is, or "dev" for a checkout that has no release in it. */
+	private static function version(): string {
+		$file = __DIR__ . '/../extension.json';
+		$manifest = is_readable($file) ? json_decode((string)file_get_contents($file), true) : null;
+		$version = is_array($manifest) ? trim((string)( $manifest['version'] ?? '' )) : '';
+		return $version !== '' ? $version : 'dev';
+	}
+}

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -7,6 +7,7 @@ use Maintenance;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Settings\Source\Format\JsonFormat;
 use MediaWiki\Settings\Source\Format\YamlFormat;
+use MediaWiki\Utils\ExecutableFinder;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
@@ -18,11 +19,19 @@ require_once "$IP/maintenance/Maintenance.php";
 
 // Wikven's autoloader is not active this early: making the extensions MediaWiki will load present is
 // what this script is for, so it runs before that. Loaded directly for the same reason loadConfig()
-// loads SiteConfig directly below, and the class is dependency-free so that is all it takes.
+// loads SiteConfig directly below, and both classes are dependency-free so that is all it takes.
 require_once __DIR__ . '/../includes/Attempts.php';
+require_once __DIR__ . '/../includes/UserAgent.php';
 
 /** Fetch third-party extensions/skins declared in .wikven.yaml before MediaWiki loads them. */
 class FetchExtensions extends Maintenance {
+	/**
+	 * argv up to git's subcommand, worked out once: it asks git what version it is.
+	 *
+	 * @var string[]|null
+	 */
+	private ?array $gitCommand = null;
+
 	public function __construct() {
 		parent::__construct();
 		$this->addDescription(
@@ -214,12 +223,12 @@ class FetchExtensions extends Maintenance {
 			$this->run(['git', '-C', $dest, 'remote', 'add', 'origin', $repo], "configure $kind '$name'");
 			// No reset: a fetch that failed leaves a repository another fetch is happy to reuse.
 			$this->runOnNetwork(
-				['git', '-C', $dest, 'fetch', '--depth', '1', 'origin', $commit],
+				array_merge($this->gitCommand(), ['-C', $dest, 'fetch', '--depth', '1', 'origin', $commit]),
 				"fetch $kind '$name' @ $commit"
 			);
 			$this->run(['git', '-C', $dest, 'checkout', '--quiet', '--detach', 'FETCH_HEAD'], "checkout $kind '$name'");
 		} else {
-			$cmd = ['git', 'clone', '--depth', '1'];
+			$cmd = array_merge($this->gitCommand(), ['clone', '--depth', '1']);
 			if (!empty($spec['reference'])) {
 				// --branch takes a tag or a branch (not an arbitrary commit SHA).
 				$cmd[] = '--branch';
@@ -269,7 +278,11 @@ class FetchExtensions extends Maintenance {
 		$httpStatus = 0;
 		$ok = Attempts::until(
 			function () use ($http, $url, $dest, $caller, &$httpStatus) {
-				$req = $http->create($url, ['followRedirects' => true], $caller);
+				$req = $http->create(
+					$url,
+					['followRedirects' => true, 'userAgent' => UserAgent::string()],
+					$caller
+				);
 				// Opened per attempt, and truncating, so a retry replaces a partial body rather
 				// than appending a second one to it.
 				$fh = fopen($dest, 'wb');
@@ -300,6 +313,59 @@ class FetchExtensions extends Maintenance {
 			unlink($dest);
 			$this->fatalError("Wikven: failed to $what (HTTP $httpStatus).");
 		}
+	}
+
+	/**
+	 * How to call git, with the User-Agent it should send in front of the subcommand.
+	 *
+	 * A clone or a fetch over HTTPS is wikven reaching somebody else's server, and git signs it
+	 * with nothing but its own version: the operator on the other end sees a git, like every
+	 * other git, with no way to tell whose build it is or where to go about it. http.userAgent
+	 * replaces that string, so git's own goes back in front of wikven's rather than being taken
+	 * away -- there are proxies that carry git traffic only while the User-Agent still looks
+	 * like a git client's, and none of them are visible from here.
+	 *
+	 * A git that will not say what version it is keeps the string it had; naming a version this
+	 * never read would be worse than saying nothing. (composer, which some extensions need
+	 * afterwards, signs its own requests and offers no way to add to them.)
+	 *
+	 * @return string[] argv up to but not including the subcommand.
+	 */
+	private function gitCommand(): array {
+		if ($this->gitCommand === null) {
+			$version = self::gitVersion();
+			$this->gitCommand = $version === null
+				? ['git']
+				: ['git', '-c', 'http.userAgent=' . UserAgent::after($version)];
+		}
+		return $this->gitCommand;
+	}
+
+	/** What git calls itself over HTTP, "git/2.43.0", or null if it would not say. */
+	private static function gitVersion(): ?string {
+		// Located rather than spawned by name, as SourceHistory does: proc_open() warns of its
+		// own when the command is not there, and a host without git is an answer this can give.
+		$binary = ExecutableFinder::findInDefaultPaths(['git']) ?: null;
+		if ($binary === null) {
+			return null;
+		}
+		$descriptors = [
+			0 => ['file', '/dev/null', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['file', '/dev/null', 'w']
+		];
+		$pipes = [];
+		$process = proc_open([$binary, '--version'], $descriptors, $pipes);
+		if ($process === false) {
+			return null;
+		}
+		$output = (string)stream_get_contents($pipes[1]);
+		fclose($pipes[1]);
+		if (proc_close($process) !== 0) {
+			return null;
+		}
+		// "git version 2.43.0", which git itself sends as "git/2.43.0".
+		return preg_match('/\bversion\s+(\S+)/', $output, $matches) ? 'git/' . $matches[1] : null;
 	}
 
 	/**

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -92,10 +92,7 @@ class StoreImages extends Maintenance {
 			return "./$name";
 		}
 
-		$options = [
-			'timeout' => 30,
-			'userAgent' => 'wikven static-site builder (https://github.com/chaotic-ground/wikven)'
-		];
+		$options = ['timeout' => 30, 'userAgent' => UserAgent::string()];
 		$tmp = "$dest.tmp";
 		// Retry with backoff: Commons may 5xx while generating an uncached thumbnail. A 4xx (e.g. a
 		// dead File: link) won't change on retry, so stop as soon as one comes back.

--- a/tests/phpunit/unit/UserAgentTest.php
+++ b/tests/phpunit/unit/UserAgentTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\UserAgent;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\UserAgent
+ */
+class UserAgentTest extends MediaWikiUnitTestCase {
+	/** The version a release moves, read from the same file the class reads. */
+	private function version(): string {
+		$manifest = json_decode(file_get_contents(__DIR__ . '/../../../extension.json'), true);
+		return (string)$manifest['version'];
+	}
+
+	/**
+	 * What the string is for: an operator reading their logs can tell which tool made the request,
+	 * which version of it, and where to go about it.
+	 */
+	public function testItNamesTheToolItsVersionAndWhereToFindIt() {
+		$agent = UserAgent::string();
+		$this->assertStringStartsWith('Wikven/' . $this->version() . ' ', $agent);
+		$this->assertStringContainsString('(+https://github.com/chaotic-ground/wikven)', $agent);
+	}
+
+	/** The version is not written here twice: a release moves extension.json and this follows. */
+	public function testTheVersionIsTheOneTheManifestCarries() {
+		$this->assertStringStartsNotWith('Wikven/dev', UserAgent::string());
+	}
+
+	/**
+	 * git signs its own requests, and some proxies only carry git traffic that still looks like
+	 * git's, so wikven is added after that string rather than in place of it.
+	 */
+	public function testAClientKeepsItsOwnStringInFront() {
+		$this->assertSame('git/2.43.0 ' . UserAgent::string(), UserAgent::after('git/2.43.0'));
+		$this->assertSame(UserAgent::string(), UserAgent::after('  '));
+	}
+}


### PR DESCRIPTION
A bake reaches other people's machines: it asks Commons for the thumbnail of every image a page embeds and downloads each one, and it clones or downloads whatever third-party extensions and skins the site declares. None of that said wikven.

## What it said before

| Request | User-Agent |
|---|---|
| Commons API lookups (`RetryingForeignRepo`) | `MediaWiki/1.46.0` |
| Commons image downloads (`storeImages`) | `wikven static-site builder (https://github.com/…)` — hand-written, no version |
| Extension/skin tarballs (`fetchExtensions`) | `MediaWiki/1.46.0` |
| Extension/skin clones and fetches | `git/2.43.0` |

Three of the four name the library rather than the thing that asked, so an operator reading their logs cannot tell a wikven build from a wiki, or reach anyone about it. Wikimedia asks for better than that in its [User-Agent policy](https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy), and it is the server wikven talks to most.

## What it says now

One string, in `UserAgent`, built from `extension.json` so a release moves it and nobody has to remember:

```
Wikven/0.1.0 (+https://github.com/chaotic-ground/wikven) MediaWiki/1.46.0
```

- **Commons API lookups** — set in `RetryingForeignRepo::httpGet()`, which is where all of that repository's traffic already passes. A caller that brought its own string keeps it.
- **Image downloads** — in place of the hand-written string.
- **Tarballs** — passed to `HttpRequestFactory::create()`, which asked for nothing before.
- **Clones and fetches** — through git's `http.userAgent`, **after** git's own string rather than in place of it: there are proxies that carry git traffic only while the User-Agent still looks like a git client's, and none of them are visible from here. A git that will not say what version it is keeps what it had.

The class is dependency-free because `fetchExtensions` runs before wikven's autoloader exists and loads it by path, the way it already loads `Attempts`.

## Boundaries

- The **image build's** three `curl` downloads now say `Wikven image build (+…)` with no version — the release this image is cut from is not known until wikven's own code is copied in, well after they run.
- **composer**, which some extensions need after a clone, signs its own requests and offers no way to add to them.

## Verified

- The git half against a local HTTP server that logs what it is sent: with the option, `git/9.9.9 Wikven/0.1.0 (+https://github.com/chaotic-ground/wikven)`; without it, `git/2.43.0`. The version parse (`git version 2.43.0` → `git/2.43.0`) matches what git sends on its own, so the prefix is git's real string and not an invention.
- Three unit tests: the string names the tool, the version `extension.json` carries and where to find it; it is never `Wikven/dev` in a checkout that has a release in it; a client's own string stays in front, and an empty one is not padded.
- `phpcs`, `mago lint`, `mago format --check` clean.

Not included: a line in the docs naming the string, which would be useful to someone allowlisting the traffic but wants a new translation unit — happy to add it if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_