### PR TITLE
fix(build): put wikven in front of the User-Agent core builds for Commons

### DIFF
--- a/includes/RetryingForeignRepo.php
+++ b/includes/RetryingForeignRepo.php
@@ -53,14 +53,8 @@ class RetryingForeignRepo extends ForeignAPIRepo {
 	 *
 	 * Answering with a body or with false is what Attempts::until reads as worked or did not, so
 	 * the loop is the one the fetching side of the build uses, and the waits are the same waits.
-	 *
-	 * It is also where every request this repository makes passes, which makes it the place to
-	 * say who is asking: core would otherwise sign each lookup "MediaWiki/" and its version,
-	 * naming the library rather than the tool, and Commons is the server wikven asks most. A
-	 * caller that brought its own string keeps it.
 	 */
 	public function httpGet($url, $timeout = 'default', $options = [], &$mtime = false) {
-		$options['userAgent'] ??= UserAgent::string();
 		return Attempts::until(
 			function () use ($url, $timeout, $options, &$mtime) {
 				return parent::httpGet($url, $timeout, $options, $mtime);
@@ -68,5 +62,21 @@ class RetryingForeignRepo extends ForeignAPIRepo {
 			Attempts::FETCH,
 			[Attempts::class, 'sleep']
 		);
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * Named here rather than passed to each request, because httpGet() above hands core the
+	 * options and core writes this key over whatever came in: the string a lookup goes out
+	 * under is this method's answer and nothing else. Left alone it is "MediaWiki/1.46.0
+	 * (server) ForeignAPIRepo/2.1", which names the library and the class doing the asking but
+	 * not the tool that wanted it -- and a bake asks Commons more than it asks anyone: a page
+	 * with ten images is ten lookups. wikven goes in front, where the policy wants the thing
+	 * making the requests, and core's own string keeps everything it said, including the extra
+	 * a repository configured with 'userAgent' asked for.
+	 */
+	public function getUserAgent() {
+		return UserAgent::tool() . ' ' . parent::getUserAgent();
 	}
 }

--- a/includes/UserAgent.php
+++ b/includes/UserAgent.php
@@ -33,21 +33,31 @@ class UserAgent {
 	 */
 	private const URL = 'https://github.com/chaotic-ground/wikven';
 
-	/** Built once: it names a release and a running MediaWiki, and neither changes mid-build. */
-	private static ?string $string = null;
+	/** Built once: it names a release, which does not change mid-build. */
+	private static ?string $tool = null;
 
-	/** The string every request wikven makes goes out under. */
+	/**
+	 * The string a request goes out under where wikven is the whole of what is sending it.
+	 *
+	 * The library is named after the tool, which is the order the policy asks for and the order
+	 * a reader wants: what made this request, then what it was built with.
+	 */
 	public static function string(): string {
-		if (self::$string === null) {
-			self::$string =
-				'Wikven/'
-				. self::version()
-				. ' (+'
-				. self::URL
-				. ')'
-				. ( defined('MW_VERSION') ? ' MediaWiki/' . MW_VERSION : '' );
+		return defined('MW_VERSION') ? self::tool() . ' MediaWiki/' . MW_VERSION : self::tool();
+	}
+
+	/**
+	 * wikven alone, for a client that names the library it is built on itself.
+	 *
+	 * ForeignAPIRepo is the one: it signs its requests "MediaWiki/1.46.0 (server)
+	 * ForeignAPIRepo/2.1" and there is no sense in that carrying a second MediaWiki version
+	 * behind it.
+	 */
+	public static function tool(): string {
+		if (self::$tool === null) {
+			self::$tool = 'Wikven/' . self::version() . ' (+' . self::URL . ')';
 		}
-		return self::$string;
+		return self::$tool;
 	}
 
 	/**

--- a/tests/phpunit/integration/RetryingForeignRepoTest.php
+++ b/tests/phpunit/integration/RetryingForeignRepoTest.php
@@ -108,6 +108,51 @@ class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
 		$this->newRepo()->getThumbUrlFromCache('Xclamation SVG.svg', 32, -1);
 	}
 
+	/**
+	 * Every lookup this repository makes says which tool made it and where to go about it.
+	 *
+	 * Core would sign them "MediaWiki/" and its version, which names the library rather than
+	 * the thing that asked, and Commons is the server a bake asks most: one page with ten
+	 * images is ten lookups. UserAgent holds the string; this is the wiring that carries it.
+	 */
+	public function testALookupSaysWhichToolIsAskingAndWhereToGoAboutIt() {
+		$agents = [];
+		$this->installMockHttp(function ($url, $options) use (&$agents) {
+			$agents[] = (string)( $options['userAgent'] ?? '' );
+			return $this->makeFakeHttpRequest(
+				$this->imageInfo('https://upload.example.org/commons/thumb/32px-Bakery_oven.jpg'),
+				200
+			);
+		});
+
+		$this->newRepo()->getThumbUrlFromCache('Bakery oven.jpg', 32, -1);
+
+		$this->assertNotSame([], $agents, 'the lookup should have made a request');
+		foreach ($agents as $agent) {
+			$this->assertStringStartsWith('Wikven/', $agent);
+			$this->assertStringContainsString('(+https://github.com/chaotic-ground/wikven)', $agent);
+		}
+	}
+
+	/** A caller that brought its own string keeps it: this names wikven, it does not insist. */
+	public function testACallerThatNamesItselfIsLeftAlone() {
+		$agents = [];
+		$this->installMockHttp(function ($url, $options) use (&$agents) {
+			$agents[] = (string)( $options['userAgent'] ?? '' );
+			return $this->makeFakeHttpRequest('answered', 200);
+		});
+
+		$mtime = false;
+		$this->newRepo()->httpGet(
+			'https://commons.example.org/w/api.php',
+			'default',
+			['userAgent' => 'Something Else/1.0'],
+			$mtime
+		);
+
+		$this->assertSame(['Something Else/1.0'], $agents);
+	}
+
 	public function testTheMessageSaysWhichRepositoryAndSizeAndWhatToDo() {
 		$this->answerWith([['body' => $this->imageInfo(null)]], $made);
 

--- a/tests/phpunit/integration/RetryingForeignRepoTest.php
+++ b/tests/phpunit/integration/RetryingForeignRepoTest.php
@@ -17,22 +17,30 @@ use Wikimedia\ObjectCache\WANObjectCache;
 class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
 	use MockHttpTrait;
 
-	/** A repository with its own empty cache, so one test's lookups cannot answer another's. */
-	private function newRepo(): RetryingForeignRepo {
-		return new RetryingForeignRepo([
-			'name' => 'testcommons',
-			'apibase' => 'https://commons.example.org/w/api.php',
-			'url' => 'https://upload.example.org/commons',
-			'thumbUrl' => 'https://upload.example.org/commons/thumb',
-			'hashLevels' => 2,
-			'apiThumbCacheExpiry' => 0,
-			'wanCache' => WANObjectCache::newEmpty(),
-			'backend' => new FSFileBackend([
-				'name' => 'testcommons-backend',
-				'domainId' => 'testcommons',
-				'basePath' => $this->getNewTempDirectory()
-			])
-		]);
+	/**
+	 * A repository with its own empty cache, so one test's lookups cannot answer another's.
+	 *
+	 * @param array $extra Repository settings on top of the defaults, as a site's own
+	 *   $wgForeignFileRepos entry would carry.
+	 */
+	private function newRepo(array $extra = []): RetryingForeignRepo {
+		return new RetryingForeignRepo(
+			$extra
+			+ [
+				'name' => 'testcommons',
+				'apibase' => 'https://commons.example.org/w/api.php',
+				'url' => 'https://upload.example.org/commons',
+				'thumbUrl' => 'https://upload.example.org/commons/thumb',
+				'hashLevels' => 2,
+				'apiThumbCacheExpiry' => 0,
+				'wanCache' => WANObjectCache::newEmpty(),
+				'backend' => new FSFileBackend([
+					'name' => 'testcommons-backend',
+					'domainId' => 'testcommons',
+					'basePath' => $this->getNewTempDirectory()
+				])
+			]
+		);
 	}
 
 	/**
@@ -131,26 +139,22 @@ class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
 		foreach ($agents as $agent) {
 			$this->assertStringStartsWith('Wikven/', $agent);
 			$this->assertStringContainsString('(+https://github.com/chaotic-ground/wikven)', $agent);
+			$this->assertStringContainsString('ForeignAPIRepo/', $agent);
 		}
 	}
 
-	/** A caller that brought its own string keeps it: this names wikven, it does not insist. */
-	public function testACallerThatNamesItselfIsLeftAlone() {
-		$agents = [];
-		$this->installMockHttp(function ($url, $options) use (&$agents) {
-			$agents[] = (string)( $options['userAgent'] ?? '' );
-			return $this->makeFakeHttpRequest('answered', 200);
-		});
+	/**
+	 * And keeps everything core said, including what a site asked for: the tool goes in front
+	 * of that string rather than in place of it, so the library, the class and a site's own
+	 * contact are all still there.
+	 */
+	public function testTheStringCoreBuildsIsKeptBehindIt() {
+		$agent = $this->newRepo(['userAgent' => 'Example Wiki (admin@example.org)'])->getUserAgent();
 
-		$mtime = false;
-		$this->newRepo()->httpGet(
-			'https://commons.example.org/w/api.php',
-			'default',
-			['userAgent' => 'Something Else/1.0'],
-			$mtime
-		);
-
-		$this->assertSame(['Something Else/1.0'], $agents);
+		$this->assertStringStartsWith('Wikven/', $agent);
+		$this->assertStringContainsString('MediaWiki/', $agent);
+		$this->assertStringContainsString('ForeignAPIRepo/', $agent);
+		$this->assertStringContainsString('Example Wiki (admin@example.org)', $agent);
 	}
 
 	public function testTheMessageSaysWhichRepositoryAndSizeAndWhatToDo() {

--- a/tests/phpunit/unit/UserAgentTest.php
+++ b/tests/phpunit/unit/UserAgentTest.php
@@ -31,6 +31,16 @@ class UserAgentTest extends MediaWikiUnitTestCase {
 	}
 
 	/**
+	 * A client that names MediaWiki itself gets the tool alone: ForeignAPIRepo already signs
+	 * its lookups with the version it is running, and saying it twice is noise.
+	 */
+	public function testTheToolAloneNamesNoLibrary() {
+		$this->assertStringStartsWith('Wikven/' . $this->version() . ' ', UserAgent::tool());
+		$this->assertStringNotContainsString('MediaWiki', UserAgent::tool());
+		$this->assertStringStartsWith(UserAgent::tool(), UserAgent::string());
+	}
+
+	/**
 	 * git signs its own requests, and some proxies only carry git traffic that still looks like
 	 * git's, so wikven is added after that string rather than in place of it.
 	 */


### PR DESCRIPTION
#542 gave the User-Agent string a unit test, which proves the string and nothing about whether anything sends it. So this started as the wiring test — and the wiring test found the wiring wrong.

## What was broken

`RetryingForeignRepo::httpGet()` set `userAgent` in the options it hands core. Core's `ForeignAPIRepo::httpGet()` then writes that key over whatever came in, from its own `getUserAgent()`:

```php
$options['userAgent'] = $this->getUserAgent();   // ForeignAPIRepo::httpGet(), line 557
```

So the Commons lookups still went out as `MediaWiki/1.46.0 (http://localhost) ForeignAPIRepo/2.1` — exactly what #542 said it had stopped them saying. The test caught it on the first run:

```
Failed asserting that 'MediaWiki/1.46.0 (http://localhost) ForeignAPIRepo/2.1' starts with "Wikven/".
```

The other three paths in #542 were fine and are untouched: the image downloads, the tarball downloads and the git fetches each set the string on a request nothing else rewrites.

## The fix

`getUserAgent()` is the only thing that decides that string, so that is what wikven names itself in. Core's answer is kept behind ours, so the library, the class and the extra a repository configured with `'userAgent'` asked for are all still there:

```
Wikven/0.1.0 (+https://github.com/chaotic-ground/wikven) MediaWiki/1.46.0 (http://localhost) ForeignAPIRepo/2.1
```

What goes in front is `UserAgent::tool()` — wikven with no MediaWiki version after it, because the string it is being added to already carries one. `UserAgent::string()` is that plus the library, for the requests where wikven is the whole of what is sending.

## Tests

- a thumbnail lookup goes out named — asserted on the request the mock actually sees, not on the option going in;
- core's own string is kept behind it, a site's `'userAgent'` included;
- `tool()` names no library, and `string()` starts with it.

`phpcs`, `mago lint`, `mago format --check` clean.