### PR TITLE
fix: wrap a word too long for the screen instead of scrolling the page

### DIFF
--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -170,3 +170,19 @@ a.new {
 .wikven-skin-item.active {
   font-weight: @font-weight-bold;
 }
+
+// A word too long for the screen wraps rather than taking the page with it.
+//
+// One identifier in a paragraph is all it takes: an unbreakable token runs past the right edge, and
+// because the page is one document the whole of it scrolls sideways after it -- every heading and
+// every line of prose shifted, on the phone where a docs site is read. docs/Development names three
+// settings in a row joined by slashes, which is 430 pixels of text with nowhere to break in it, and
+// that page scrolled 95 pixels wide at every width below 455.
+//
+// Minerva and Citizen both wrap content this way already; Vector 2022 does it for links alone, so
+// the export is where the three skins are made to agree. break-word rather than anywhere: a token
+// is only broken when it would not fit a line of its own, so nothing that fits is ever split, and a
+// <pre> is untouched -- it does not wrap at all, and scrolls inside its own box instead.
+.mw-parser-output {
+  overflow-wrap: break-word;
+}

--- a/tests/e2e/sideways-scroll.spec.js
+++ b/tests/e2e/sideways-scroll.spec.js
@@ -1,0 +1,50 @@
+// A page that scrolls sideways on a phone is a page whose every line has moved, and one long
+// identifier in a paragraph is all it takes to cause it. Minerva and Citizen wrap content that
+// cannot fit; Vector 2022 wraps links alone, so the export says so itself in ext.Wikven.styles.
+// Asserted in a browser because nothing in the markup shows it: the overflow is a line box that
+// laid out wider than the screen.
+
+const { test, expect } = require("@playwright/test");
+
+// Development names three settings in a row, joined by slashes -- the longest unbreakable run the
+// docs have, in the language that reads it most narrowly and in the one that wrote it -- and one
+// page per skin, since this is a skin's default that the export overrides.
+const PAGES = [
+	"Development.html",
+	"Development/ko.html",
+	"minerva/Development.html",
+	"citizen/Development.html",
+];
+
+test.use({ viewport: { width: 360, height: 740 } });
+
+for (const path of PAGES) {
+	test(`${path} does not scroll sideways on a phone`, async ({ page }) => {
+		await page.goto(path, { waitUntil: "load" });
+
+		const { over, widest } = await page.evaluate(() => {
+			const root = document.scrollingElement;
+			let widest = "";
+			let right = innerWidth + 1;
+			for (const element of document.querySelectorAll("*")) {
+				const box = element.getBoundingClientRect();
+				if (box.width > 0 && box.height > 0 && box.right > right) {
+					right = box.right;
+					widest = `<${element.tagName.toLowerCase()}> "${(
+						element.textContent || ""
+					)
+						.trim()
+						.slice(0, 40)}" ends at ${Math.round(box.right)}`;
+				}
+			}
+			return { over: root.scrollWidth - root.clientWidth, widest };
+		});
+
+		// A pixel of slack: Minerva's own overflow menu lays out one wider than the screen, which
+		// is the skin's and not the export's, and is not something a reader can scroll to.
+		expect(
+			over,
+			widest || `${over}px of page past the screen`,
+		).toBeLessThanOrEqual(1);
+	});
+}


### PR DESCRIPTION
`Development/ko.html` scrolls sideways on a phone. It is not the translation, and it is not upstream's to fix for us.

## What it is

`docs/Development` names three settings in a row joined by slashes — `WikvenFooterUrl`/`WikvenEditUrl`/`WikvenHistoryUrl` — which is one 430-pixel run with nowhere to break in it. It runs past the right edge, and because the page is one document, the whole page scrolls after it: every heading and every line of prose shifted.

Measured on the deployed pages at 360 and at 320 wide:

| page | before | after |
|---|---|---|
| `Development/ko.html` | 455 | 360 / 320 |
| `Development.html` | 459 | 360 / 320 |
| `minerva/Development/ko.html` | 361 | unchanged |
| `citizen/Development/ko.html` | 360 | unchanged |

English overflows slightly more than Korean, so this is the docs' own shape rather than anything about the translation.

## Whose it is

Minerva and Citizen both wrap content that cannot fit — that is why they measure clean above. **Vector 2022 wraps links alone**, so the same page scrolls in the skin the site opens in and not in the two beside it. Nothing is broken in MediaWiki; the three skins simply disagree, and the export is the one place that can make them agree for every site wikven builds. So the rule goes in `ext.Wikven.styles`, next to the other places wikven settles what a static export should do, rather than in this site's own CSS.

`break-word` rather than `anywhere`: a token is broken only when it would not fit a line of its own, so nothing that fits is ever split, and `<pre>` is untouched — it does not wrap at all and scrolls inside its own box.

## Test

`tests/e2e/sideways-scroll.spec.js` is the same measurement on the built site: one page per skin at 360 × 740, failing with the offending element named. A pixel of slack, because Minerva's own overflow menu lays out one wider than the screen — the skin's, not ours, and nothing a reader can scroll to.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_