### PR TITLE
fix: fetch a third-party extension again when its pin moves

### DIFF
--- a/includes/FetchPin.php
+++ b/includes/FetchPin.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * What a fetched extension or skin was fetched from, written next to it so the next build can tell.
+ *
+ * A bake fetches what WikvenRepositories names, and a fetch it has already made is one it should
+ * not make again: fetchExtensions skips any directory that is already there. That is right where
+ * the tree came from the same source, and wrong where it did not -- move a pin to a new tag, build
+ * again in a tree that survives (a bind mount, the standalone binary's own install, a container
+ * that is not thrown away), and the old checkout stays, silently, with nothing on the build's
+ * output to say the new pin was not what got built.
+ *
+ * So a fetched tree carries a line naming what fetched it, and the next build compares. Same line,
+ * nothing to do; different line, the tree goes and the fetch is made again. A tree with no line at
+ * all is left exactly as it was found: it is bundled in the image, or somebody put it there, and a
+ * build is in no position to decide it knows better.
+ *
+ * A reference is not a pin, though it is written like one: `reference: main` names whatever the
+ * branch points at today, and a tag can be moved. So a git fetch also records the commit it ended
+ * up on, and a build that finds the source unchanged asks the remote what that reference points at
+ * now -- one round trip, and only where the tree is already there -- and fetches again when the
+ * answer has moved. A remote that cannot be reached is not an error: the tree that is there is
+ * kept, and the build says why it could not check.
+ */
+class FetchPin {
+	/**
+	 * The file a fetched tree carries, inside the tree so it cannot outlive it.
+	 *
+	 * Named for what it is rather than hidden away in a state directory: someone reading the
+	 * extension folder to work out where its code came from should find the answer in it.
+	 */
+	public const FILE = '.wikven-fetch.json';
+
+	/** The keys that decide what is fetched. Anything else in a spec cannot change the bytes. */
+	private const KEYS = ['tarball', 'repository', 'reference', 'commit', 'sha256'];
+
+	/**
+	 * What a source spec fetches, as one line: the same source is the same line.
+	 *
+	 * Keys and values rather than JSON, because the line is written into the tree it fetched and
+	 * the first thing anyone does with a file like that is read it.
+	 *
+	 * The hex pins are lowercased because the validators lowercase them and a spec may not have;
+	 * nothing else is touched, since a URL's path is the remote's to be particular about.
+	 *
+	 * @param array $spec One WikvenRepositories entry.
+	 */
+	public static function of(array $spec): string {
+		$pin = [];
+		foreach (self::KEYS as $key) {
+			$value = trim((string)( $spec[$key] ?? '' ));
+			if ($value === '') {
+				continue;
+			}
+			$pin[$key] = in_array($key, ['commit', 'sha256'], true) ? strtolower($value) : $value;
+		}
+		// Not a source, but it is the difference between a clone and a clone with its dependencies
+		// installed, which is a different tree on disk.
+		$pin['composer'] = empty($spec['composer']) ? '0' : '1';
+		ksort($pin);
+		$line = [];
+		foreach ($pin as $key => $value) {
+			$line[] = "$key=$value";
+		}
+		return implode(' ', $line);
+	}
+
+	/**
+	 * What fetched $directory: the source, and the commit it landed on where there was one.
+	 *
+	 * Null where nothing wikven fetched put the tree there, which includes a file written by a
+	 * version of this that has since changed shape: an unreadable stamp is no answer, and the
+	 * tree it sits in is somebody else's to keep.
+	 *
+	 * @return array{source:string,commit:?string}|null
+	 */
+	public static function inside(string $directory): ?array {
+		$file = $directory . '/' . self::FILE;
+		if (!is_file($file) || !is_readable($file)) {
+			return null;
+		}
+		$stamp = json_decode(trim((string)file_get_contents($file)), true);
+		if (!is_array($stamp) || !isset($stamp['source']) || !is_string($stamp['source'])) {
+			return null;
+		}
+		$commit = isset($stamp['commit']) && is_string($stamp['commit']) ? $stamp['commit'] : '';
+		return ['source' => $stamp['source'], 'commit' => $commit === '' ? null : $commit];
+	}
+
+	/** Write what fetched $directory into it, for the next build to compare against. */
+	public static function stamp(string $directory, string $source, ?string $commit = null): bool {
+		$stamp = json_encode(
+			['source' => $source, 'commit' => $commit],
+			JSON_UNESCAPED_SLASHES
+		);
+		return file_put_contents($directory . '/' . self::FILE, $stamp . "\n") !== false;
+	}
+
+	/**
+	 * The commit a `git ls-remote` answer points $reference at, or null if it said nothing.
+	 *
+	 * An annotated tag is listed twice, as the tag object and again as the commit it wraps with
+	 * a ^{} suffix; the commit is the one to keep, since that is what a checkout ends up on.
+	 */
+	public static function pointedAt(string $lsRemote): ?string {
+		$found = null;
+		foreach (explode("\n", $lsRemote) as $line) {
+			$parts = preg_split('/\s+/', trim($line));
+			if ($parts === false || count($parts) < 2 || !preg_match('/^[0-9a-f]{40,64}$/i', $parts[0])) {
+				continue;
+			}
+			if (str_ends_with($parts[1], '^{}')) {
+				return strtolower($parts[0]);
+			}
+			$found ??= strtolower($parts[0]);
+		}
+		return $found;
+	}
+}

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -21,6 +21,7 @@ require_once "$IP/maintenance/Maintenance.php";
 // what this script is for, so it runs before that. Loaded directly for the same reason loadConfig()
 // loads SiteConfig directly below, and both classes are dependency-free so that is all it takes.
 require_once __DIR__ . '/../includes/Attempts.php';
+require_once __DIR__ . '/../includes/FetchPin.php';
 require_once __DIR__ . '/../includes/UserAgent.php';
 
 /** Fetch third-party extensions/skins declared in .wikven.yaml before MediaWiki loads them. */
@@ -79,9 +80,8 @@ class FetchExtensions extends Maintenance {
 			}
 
 			$dest = "$baseDir/$name";
-			if (is_dir($dest)) {
-				// Already bundled or cloned by an earlier run; never overwrite it.
-				$this->output("Wikven: $kind '$name' already present, skipping.\n");
+			$pin = FetchPin::of($spec);
+			if (is_dir($dest) && !$this->isStale($spec, $dest, $pin, $name, $kind)) {
 				continue;
 			}
 
@@ -94,6 +94,17 @@ class FetchExtensions extends Maintenance {
 				$this->fatalError(
 					"Wikven: $kind '$name' must declare one of: tarball, repository, package."
 				);
+			}
+
+			// Written last: a tree stamped before its fetch finished would be taken for a good one
+			// by the next build, which is the state this is here to catch. The commit goes in with
+			// it, because a reference is not a pin: the tag or branch it names can be moved, and
+			// this is what the next build compares the remote against.
+			$commit = isset($spec['repository'])
+				? self::gitOutput(['-C', $dest, 'rev-parse', 'HEAD'])
+				: null;
+			if (!FetchPin::stamp($dest, $pin, $commit)) {
+				$this->fatalError("Wikven: could not record what $kind '$name' was fetched from.");
 			}
 		}
 
@@ -134,6 +145,80 @@ class FetchExtensions extends Maintenance {
 			}
 		}
 		return $set;
+	}
+
+	/**
+	 * Whether an existing $dest has to go before the fetch, saying either way what it decided.
+	 *
+	 * Three answers, and the quiet one is the common one. A tree fetched from this same source
+	 * is the fetch already made. A tree with no pin in it was not fetched by wikven -- it is
+	 * bundled in the image, or somebody put it there -- and is left alone, which is what this
+	 * check has always done. A tree fetched from a different source is the one worth acting on:
+	 * a pin moved under a build that would otherwise keep the old code and say nothing.
+	 */
+	private function isStale(array $spec, string $dest, string $pin, string $name, string $kind): bool {
+		$stamp = FetchPin::inside($dest);
+		if ($stamp === null) {
+			$this->output("Wikven: $kind '$name' already present, skipping.\n");
+			return false;
+		}
+		if ($stamp['source'] !== $pin) {
+			$this->output(
+				"Wikven: $kind '$name' was fetched from {$stamp['source']}; the source is now $pin,"
+				. " fetching again.\n"
+			);
+			self::removeTree($dest);
+			return true;
+		}
+
+		$moved = $this->movedReference($spec, $stamp['commit'], $name, $kind);
+		if ($moved === null) {
+			$this->output("Wikven: $kind '$name' already fetched from this source, skipping.\n");
+			return false;
+		}
+		$this->output(
+			"Wikven: $kind '$name' has {$stamp['commit']} and {$spec['reference']} now points at"
+			. " $moved, fetching again.\n"
+		);
+		self::removeTree($dest);
+		return true;
+	}
+
+	/**
+	 * The commit the declared reference points at now, where that is not the one on disk.
+	 *
+	 * Only for a spec that names a reference: a commit is already the whole answer, a tarball
+	 * has no reference to move, and a tree that recorded no commit was not fetched by git. The
+	 * ask is one `git ls-remote`, made only where the tree is already there -- a build that has
+	 * to clone anyway never makes it -- and a remote that will not answer leaves what is on disk
+	 * alone rather than failing a build over a question nobody asked.
+	 *
+	 * @return string|null The commit to fetch, or null where there is nothing to do.
+	 */
+	private function movedReference(array $spec, ?string $commit, string $name, string $kind): ?string {
+		$reference = trim((string)( $spec['reference'] ?? '' ));
+		if ($reference === '' || $commit === null || empty($spec['repository'])) {
+			return null;
+		}
+		// Both the reference and its peeled form: git matches a pattern against whole ref
+		// components, so "v4.0.2" alone never lists "refs/tags/v4.0.2^{}" -- and for an
+		// annotated tag that line is the only one carrying the commit a checkout lands on. Ask
+		// for the tag alone and every build would read the tag object as a moved reference.
+		$answer = self::gitOutput([
+			'ls-remote',
+			'--',
+			(string)$spec['repository'],
+			$reference,
+			$reference . '^{}'
+		]);
+		if ($answer === null) {
+			$this->output(
+				"Wikven: could not ask where $kind '$name' points at $reference now;" . " keeping what is on disk.\n"
+			);
+			return null;
+		}
+		$now = FetchPin::pointedAt($answer);
+		return $now === null || $now === strtolower($commit) ? null : $now;
 	}
 
 	/**
@@ -343,8 +428,25 @@ class FetchExtensions extends Maintenance {
 
 	/** What git calls itself over HTTP, "git/2.43.0", or null if it would not say. */
 	private static function gitVersion(): ?string {
-		// Located rather than spawned by name, as SourceHistory does: proc_open() warns of its
-		// own when the command is not there, and a host without git is an answer this can give.
+		$output = self::gitOutput(['--version']);
+		if ($output === null) {
+			return null;
+		}
+		// "git version 2.43.0", which git itself sends as "git/2.43.0".
+		return preg_match('/\bversion\s+(\S+)/', $output, $matches) ? 'git/' . $matches[1] : null;
+	}
+
+	/**
+	 * What `git $arguments` printed, or null where it could not be run or did not succeed.
+	 *
+	 * Located rather than spawned by name, as SourceHistory does: proc_open() warns of its own
+	 * when the command is not there, and a host without git is an answer this can give. An array
+	 * argv never reaches a shell, so a repository URL needs no quoting; git's own complaints go
+	 * nowhere, since every caller here has something to say for itself when the answer is null.
+	 *
+	 * @param string[] $arguments
+	 */
+	private static function gitOutput(array $arguments): ?string {
 		$binary = ExecutableFinder::findInDefaultPaths(['git']) ?: null;
 		if ($binary === null) {
 			return null;
@@ -355,17 +457,13 @@ class FetchExtensions extends Maintenance {
 			2 => ['file', '/dev/null', 'w']
 		];
 		$pipes = [];
-		$process = proc_open([$binary, '--version'], $descriptors, $pipes);
+		$process = proc_open(array_merge([$binary], $arguments), $descriptors, $pipes);
 		if ($process === false) {
 			return null;
 		}
 		$output = (string)stream_get_contents($pipes[1]);
 		fclose($pipes[1]);
-		if (proc_close($process) !== 0) {
-			return null;
-		}
-		// "git version 2.43.0", which git itself sends as "git/2.43.0".
-		return preg_match('/\bversion\s+(\S+)/', $output, $matches) ? 'git/' . $matches[1] : null;
+		return proc_close($process) === 0 ? trim($output) : null;
 	}
 
 	/**

--- a/tests/phpunit/unit/FetchPinTest.php
+++ b/tests/phpunit/unit/FetchPinTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\FetchPin;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\FetchPin
+ */
+class FetchPinTest extends MediaWikiUnitTestCase {
+	private string $directory;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->directory = sys_get_temp_dir() . '/wikven-fetch-pin-' . getmypid() . '-' . uniqid();
+		mkdir($this->directory, 0777, true);
+	}
+
+	protected function tearDown(): void {
+		$file = $this->directory . '/' . FetchPin::FILE;
+		if (is_file($file)) {
+			unlink($file);
+		}
+		if (is_dir($this->directory)) {
+			rmdir($this->directory);
+		}
+		parent::tearDown();
+	}
+
+	/** The whole point: a pin that moved is a different line, and the build sees it. */
+	public function testAMovedPinIsADifferentSource() {
+		$repository = 'https://example.org/thing.git';
+		$this->assertSame(
+			FetchPin::of(['repository' => $repository, 'reference' => 'v1.0.0']),
+			FetchPin::of(['repository' => $repository, 'reference' => 'v1.0.0'])
+		);
+		$this->assertNotSame(
+			FetchPin::of(['repository' => $repository, 'reference' => 'v1.0.0']),
+			FetchPin::of(['repository' => $repository, 'reference' => 'v1.0.1'])
+		);
+		$this->assertNotSame(
+			FetchPin::of(['tarball' => 'https://example.org/thing-1.tar.gz']),
+			FetchPin::of(['tarball' => 'https://example.org/thing-2.tar.gz'])
+		);
+	}
+
+	/**
+	 * A spec is a mapping, so the order it was written in is not something the build should read
+	 * a moved source into; and what is not a source cannot move one either.
+	 */
+	public function testOnlyTheSourceCounts() {
+		$this->assertSame(
+			FetchPin::of(['repository' => 'https://example.org/a.git', 'commit' => 'abc123']),
+			FetchPin::of(['commit' => 'abc123', 'repository' => 'https://example.org/a.git'])
+		);
+		$this->assertSame(
+			FetchPin::of(['tarball' => 'https://example.org/a.tar.gz']),
+			FetchPin::of(['tarball' => 'https://example.org/a.tar.gz', 'note' => 'why we pin it'])
+		);
+	}
+
+	/** A clone and a clone with its dependencies installed are not the same tree on disk. */
+	public function testComposerIsPartOfWhatWasFetched() {
+		$this->assertNotSame(
+			FetchPin::of(['repository' => 'https://example.org/a.git']),
+			FetchPin::of(['repository' => 'https://example.org/a.git', 'composer' => true])
+		);
+	}
+
+	/** The validators lowercase a hex pin; a spec written by hand may not have. */
+	public function testAHexPinIsTheSamePinInEitherCase() {
+		$this->assertSame(
+			FetchPin::of(['repository' => 'https://example.org/a.git', 'commit' => 'ABC123']),
+			FetchPin::of(['repository' => 'https://example.org/a.git', 'commit' => 'abc123'])
+		);
+	}
+
+	/** A tree nothing wikven fetched put there says nothing, and is left alone on that account. */
+	public function testATreeWithNoStampInItAnswersNothing() {
+		$this->assertNull(FetchPin::inside($this->directory));
+		$this->assertNull(FetchPin::inside($this->directory . '/not-here'));
+	}
+
+	/** Nor does one written by a version of this that has since changed shape. */
+	public function testAStampThisCannotReadAnswersNothing() {
+		file_put_contents($this->directory . '/' . FetchPin::FILE, "an older line\n");
+
+		$this->assertNull(FetchPin::inside($this->directory));
+	}
+
+	public function testAStampedTreeAnswersWithWhatFetchedIt() {
+		$source = FetchPin::of(['repository' => 'https://example.org/a.git', 'reference' => 'v1.0.0']);
+		$commit = str_repeat('a1b2c3d4', 5);
+
+		$this->assertTrue(FetchPin::stamp($this->directory, $source, $commit));
+		$this->assertSame(
+			['source' => $source, 'commit' => $commit],
+			FetchPin::inside($this->directory)
+		);
+	}
+
+	/** A tarball has no commit to record, and the tree still says where it came from. */
+	public function testATreeFetchedWithoutGitRecordsNoCommit() {
+		$source = FetchPin::of(['tarball' => 'https://example.org/a.tar.gz']);
+
+		FetchPin::stamp($this->directory, $source);
+
+		$this->assertSame(['source' => $source, 'commit' => null], FetchPin::inside($this->directory));
+	}
+
+	/**
+	 * An annotated tag is listed twice: as the tag object, and as the commit it wraps. The
+	 * commit is the one a checkout lands on, so reading the first line instead would make every
+	 * build think the tag had moved.
+	 */
+	public function testAnAnnotatedTagAnswersWithTheCommitItWraps() {
+		$tag = str_repeat('f', 40);
+		$commit = str_repeat('4', 40);
+
+		$this->assertSame(
+			$commit,
+			FetchPin::pointedAt("$tag\trefs/tags/v2\n$commit\trefs/tags/v2^{}\n")
+		);
+	}
+
+	public function testABranchAnswersWithWhatItPointsAt() {
+		$commit = str_repeat('b', 40);
+
+		$this->assertSame($commit, FetchPin::pointedAt("$commit\trefs/heads/main\n"));
+	}
+
+	/** A remote that would not answer, or answered with something else, is not a moved pin. */
+	public function testAnAnswerWithNoCommitInItIsNoAnswer() {
+		$this->assertNull(FetchPin::pointedAt(''));
+		$this->assertNull(FetchPin::pointedAt('fatal: repository not found'));
+	}
+}


### PR DESCRIPTION
`fetchExtensions` skips a directory that is already there — right where the tree came from the same source, wrong where it did not. Move a pin to a new tag and build again in a tree that survives (a bind mount, the standalone binary's own install, a container nobody threw away) and the old checkout stays, with nothing in the output to say the new pin was not what got built.

## What a fetched tree now carries

```
{"source":"composer=0 reference=v4.0.2 repository=https://github.com/StarCitizenTools/mediawiki-extensions-TabberNeue.git","commit":"aa26d27…"}
```

Written into the tree it fetched (`.wikven-fetch.json`), in keys and values rather than nested JSON, because the first thing anyone does with a file like that is read it. The next build compares:

| what it finds | what it does |
|---|---|
| the same source | nothing — unless the reference moved, below |
| a different source | removes the tree and fetches again, naming both |
| no stamp at all | leaves it exactly as found — bundled in the image, or somebody put it there |

That last row is also why CI is untouched: there the tree is a fresh container every time.

## The commit, because a reference is not a pin

`reference: main` names whatever the branch points at today, and a tag can be moved. So the commit a git fetch landed on goes in beside the source, and a build that finds the source unchanged asks the remote where that reference points **now** — one `git ls-remote`, and only where the tree is already there, so a build that has to clone anyway never makes it.

That question has to be asked for the reference **and its peeled form**: git matches a pattern against whole ref components, so `v4.0.2` alone never lists `refs/tags/v4.0.2^{}`, and for an annotated tag that line is the only one carrying the commit a checkout lands on. Asking for the tag alone would read the tag object as a moved reference on **every** build — an endless re-fetch. Caught by building a real repository with an annotated tag and comparing:

```
recorded 4ceca1b…   remote 4ceca1b…   moved? false
(git tag -f -a v2)
                    remote f11d8e3…   moved? true
```

A remote that will not answer is not an error: the tree that is there is kept, and the build says which question it could not ask.

## Also

- The stamp is written **after** the fetch, never before — a tree stamped ahead of a fetch that then died would be taken for a good one by the next build, which is the state this exists to catch.
- `rev-parse HEAD` is only asked of a git fetch, so a tarball tree never reads a commit off whatever repository happens to be above it.
- `gitVersion()` (from #542) and the new lookups share one `gitOutput()` helper: located rather than spawned by name, array argv, no shell.

Nine unit tests on `FetchPin`: a moved pin is a different line, spec key order and unrelated keys are not, `composer` is, a hex pin is case-insensitive, a stamp this version cannot read answers nothing, and an annotated tag answers with the commit it wraps.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_