### PR TITLE
test: answer a response header the way MWHttpRequest answers one

### DIFF
--- a/tests/phpunit/integration/RetryingForeignRepoTest.php
+++ b/tests/phpunit/integration/RetryingForeignRepoTest.php
@@ -3,6 +3,8 @@
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
 use MediaWiki\Extension\Wikven\RetryingForeignRepo;
+use MediaWiki\Http\MWHttpRequest;
+use MediaWiki\Status\Status;
 use MediaWikiIntegrationTestCase;
 use MockHttpTrait;
 use RuntimeException;
@@ -59,11 +61,47 @@ class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
 			if (!isset($response['body'])) {
 				return $this->makeFakeTimeoutRequest();
 			}
-			$headers = isset($response['lastModified'])
-				? ['Last-Modified' => $response['lastModified']]
-				: [];
-			return $this->makeFakeHttpRequest($response['body'], 200, $headers);
+			if (!isset($response['lastModified'])) {
+				return $this->makeFakeHttpRequest($response['body'], 200);
+			}
+			return $this->answering($response['body'], ['Last-Modified' => $response['lastModified']]);
 		});
+	}
+
+	/**
+	 * A successful response carrying headers, answered the way MWHttpRequest answers them.
+	 *
+	 * getResponseHeader() is documented case-insensitive and the real class implements it that
+	 * way, lowercasing the name it is asked for. MockHttpTrait's fake lowercases the name it was
+	 * *given* and compares that to the name asked for, so it answers a lowercase ask and nothing
+	 * else -- and core asks for "Last-Modified". Every header a test hands it therefore reads back
+	 * as absent, which is not a fake of MWHttpRequest but of a different class. This is one, for
+	 * the one method that differs; the rest of the response is still the trait's.
+	 *
+	 * @param string $body The response body.
+	 * @param array<string,string> $headers The response headers, in any case.
+	 */
+	private function answering(string $body, array $headers): MWHttpRequest {
+		$response = $this->createNoOpMock(
+			MWHttpRequest::class,
+			['execute', 'setHeader', 'getStatus', 'getContent', 'getResponseHeaders', 'getResponseHeader']
+		);
+		$response->method('execute')->willReturn(Status::newGood(200));
+		$response->method('getStatus')->willReturn(200);
+		$response->method('getContent')->willReturn($body);
+		$response->method('getResponseHeaders')->willReturn($headers);
+		$response->method('getResponseHeader')
+			->willReturnCallback(
+				static function (string $name) use ($headers): ?string {
+					foreach ($headers as $header => $value) {
+						if (strcasecmp($header, $name) === 0) {
+							return $value;
+						}
+					}
+					return null;
+				}
+			);
+		return $response;
 	}
 
 	/** An imageinfo response body, with a thumbnail URL unless $thumbUrl is null. */


### PR DESCRIPTION
`phpunit (master)` has gone red on every branch — `#547` first, and it will take everything opened after it. `phpunit (REL1_46)` is green, and `main` was green yesterday, so nothing here changed: MediaWiki core master did.

`MockHttpTrait::makeFakeHttpRequest()` now answers a header like this:

```php
static function ( $name ) use ( $headers ) {
    foreach ( $headers as $headerName => $value ) {
        if ( strtolower( $headerName ) === $name ) { return $value; }
    }
    return null;
}
```

It lowercases the header name the **test** supplied and compares that to the name the code under test **asked for**. The real `MWHttpRequest` does the opposite — `getResponseHeader()` is documented `@param string $header case-insensitive` and lowercases the name it is asked for. So the fake answers a lowercase ask and nothing else, and `ForeignAPIRepo::httpGet()` asks for `'Last-Modified'`. No spelling of a supplied header can equal that, because the left-hand side of the comparison is always lowercase. The header always reads back absent and the `$mtime` core writes from it is always `false`.

That is what `testARequestThatFailsIsRepeatedUntilItAnswers` asserts:

```
-'1785715200'
+''
```

The assertion is worth keeping rather than relaxing. `$mtime` is an out-parameter written by the innermost call, and it reaches the caller only because the closure wrapping core's `httpGet()` captures it by reference — precisely the sort of thing that breaks silently.

So the one response in this file that carries a header is built here, with a `getResponseHeader()` that behaves like the class it stands in for. Everything else — the timeout responses, the bodies with no headers — is still the trait's, and this can go back to being entirely core's once core's fake answers a header again.

**REL1_46 is unaffected either way**: its `MockHttpTrait` looks the header up by exact key (`$headers[$name] ?? null`), and its `ForeignAPIRepo::httpGet()` calls the same four methods this response answers (`setHeader`, `execute`, `getResponseHeader`, `getContent`) — verified against both branches' sources.

`mago format --check`, `mago lint` and `phpcs` pass on the changed file. I could not run PHPUnit locally — there is no MediaWiki core checkout in this environment — so CI on this PR is the first run of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_