### PR TITLE
docs: correct what keeps a skin's directory apart from a page's

### DIFF
--- a/includes/SkinOutput.php
+++ b/includes/SkinOutput.php
@@ -18,9 +18,18 @@ use SplFileInfo;
  * resolves its links against the wrong root when read from here, and writing one races the pass
  * that owns it once the passes run together (#407, #409).
  *
- * A skin's directory is named after the skin, so it cannot be mistaken for a page's: the cache
- * writes a page under its title, and MediaWiki capitalizes a title's first letter, while the
- * canonical skin names these directories take are lowercase.
+ * Which directory belongs to which is decided by name, and a page can take a skin's name. Nothing
+ * capitalizes it out of the way: wikven's own defaults set CapitalLinks off, so a title keeps the
+ * case its file was written in, and a subpage of "citizen" makes the same dist/citizen/ the Citizen
+ * pass renders into. The exclusion below is by name too, so on such a site the main pass skips that
+ * page along with the skin's copies -- resolveTranslationLinks, the only caller, leaves its
+ * Special:MyLanguage links unresolved.
+ *
+ * That is not a case to fix here. Once the two are in one directory nothing tells them apart: a
+ * name is all either has, and reading the page would mean writing into the directory the Citizen
+ * pass is writing to, which is the race this exists to prevent. Choosing the skin's copies is the
+ * safe half of an unresolvable collision. What fixes it is not naming a page after a skin, which
+ * Special:MyLanguage/Pages#reserved-names asks of a site.
  */
 class SkinOutput {
 	/**


### PR DESCRIPTION
`SkinOutput` closed with a guarantee:

> A skin's directory is named after the skin, so it cannot be mistaken for a page's: the cache writes a page under its title, and **MediaWiki capitalizes a title's first letter**, while the canonical skin names these directories take are lowercase.

Wikven's own `default.yml` sets `CapitalLinks: false`. A title keeps the case its file was written in, so `citizen` is a page a site can have, and a subpage of it makes the same `dist/citizen/` the Citizen pass renders into — the collision `#550` documented as `Pages#reserved-names`.

A comment claiming a guarantee the build does not have is worse than no comment: the next person to read it takes the collision as impossible and stops thinking about it.

### What the comment says now

The collision is possible. `foreignDirectories()` excludes by name, so on such a site the main pass skips that page along with the skin's copies, and `resolveTranslationLinks` — the only caller of `SkinOutput::pages()` — leaves its `Special:MyLanguage` links unresolved.

### Why no code change

There is nothing better for it to do. Once a page and a skin's output share one directory, nothing tells them apart: a name is all either has. And reading the page would mean walking into the directory the Citizen pass is concurrently writing to, which is the race (#407, #409) this class exists to prevent. Choosing the skin's copies is the safe half of a collision that cannot be resolved here.

What resolves it is not naming a page after a skin, which the docs now ask of a site; the comment points at that section.

Comment only — no behaviour changes. `mago format --check`, `mago lint`, `phpcs` and `typos` pass on the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_