### PR TITLE
docs: give the last seven sections a marker of their own too

### DIFF
--- a/docs/Commands.wikitext
+++ b/docs/Commands.wikitext
@@ -73,6 +73,7 @@ docker run --rm -p 8080:8080 \
 Only the binary takes <code>--listen</code>; the container always listens on 8080 inside, and you choose the outside port with Docker's own <code>-p</code>.
 
 <!--T:12-->
+<span id="translate"></span>
 == <code>translate</code> ==
 
 <!--T:13-->

--- a/docs/Commands/ko.wikitext
+++ b/docs/Commands/ko.wikitext
@@ -39,7 +39,8 @@ Docker 이미지는 작업 디렉터리가 <code>/workspace</code>이고, 그래
 <!--T:11 @8221d3a9-->
 <code>--listen</code>은 바이너리만 받습니다. 컨테이너는 안에서 항상 8080을 듣고, 바깥 포트는 Docker 자신의 <code>-p</code>로 정합니다.
 
-<!--T:12 @4cfaef70-->
+<!--T:12 @801eba12-->
+<span id="translate"></span>
 == <code>translate</code> ==
 
 <!--T:13 @29242b5c-->

--- a/docs/Configuration.wikitext
+++ b/docs/Configuration.wikitext
@@ -84,6 +84,7 @@ The targets the "Edit", "View history" and "View source" links point at, so a re
 The title of the page used as the site root, written as <code>index.html</code> and served at the top of the site. Naming your entry file <code>index.wikitext</code> therefore takes no configuration at all. The page must be one you imported; the build fails if it is missing.
 
 <!--T:16-->
+<span id="WikvenAboutPage"></span>
 === <code>WikvenAboutPage</code> ===
 
 <!--T:48-->
@@ -105,6 +106,7 @@ Whatever this is set to, the build generates two templates, since an export has 
 A link added to the site footer, pointing at your project (typically its repository). The footer shows the host name for known forges (GitHub, GitLab, Codeberg, ...). With no URL there is no such link.
 
 <!--T:37-->
+<span id="WikvenSettingsPage"></span>
 === <code>WikvenSettingsPage</code> ===
 
 <!--T:50-->
@@ -117,6 +119,7 @@ The title of a page the build writes for the reader's own display choices: the c
 Write a source page of that name and it takes precedence, exactly as for the About page. Set it empty to write no page at all, and the entries pointing at it go with it. See [[<tvar name="1">Special:MyLanguage/Skins#settings</tvar>|Skins]] for what the page offers a reader.
 
 <!--T:40-->
+<span id="WikvenBundleWebfonts"></span>
 === <code>WikvenBundleWebfonts</code> ===
 
 <!--T:51-->
@@ -162,6 +165,7 @@ config:
 
 <translate>
 <!--T:20-->
+<span id="WikvenRepositories"></span>
 === <code>WikvenRepositories</code> ===
 
 <!--T:53-->
@@ -214,6 +218,7 @@ Nothing moves an exact pin for you, though: this file belongs to no ecosystem a 
 This very site fetches [<tvar name="2">https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:TabberNeue</tvar> TabberNeue] this way (see its <code>.wikven.yaml</code>): the tabbed Docker/binary command examples on [[<tvar name="1">Special:MyLanguage/Getting Started</tvar>|Getting Started]] are rendered by the fetched extension. (TemplateStyles, used by this site's templates, is bundled in MediaWiki and so needs no source here.)
 
 <!--T:27-->
+<span id="ContentNamespaces"></span>
 === <code>ContentNamespaces</code> ===
 
 <!--T:54-->

--- a/docs/Configuration/ko.wikitext
+++ b/docs/Configuration/ko.wikitext
@@ -61,7 +61,8 @@ Wikven은 또한 브라우저가 <code>/favicon.ico</code>에서 404를 내지 �
 <!--T:15 @46cc8c49-->
 사이트 루트로 쓰이는 문서의 제목으로, <code>index.html</code>로 작성되어 사이트 최상단에서 제공됩니다. 진입 파일 이름을 <code>index.wikitext</code>로 지으면 별도 설정이 전혀 필요 없습니다. 이 문서는 여러분이 가져온 문서여야 하며, 없으면 빌드가 실패합니다.
 
-<!--T:16 @af5c0b04-->
+<!--T:16 @7e0aaa2a-->
+<span id="WikvenAboutPage"></span>
 === <code>WikvenAboutPage</code> ===
 
 <!--T:48 @d8b59d5d-->
@@ -82,7 +83,8 @@ Wikven은 또한 브라우저가 <code>/favicon.ico</code>에서 404를 내지 �
 <!--T:19 @336524d0-->
 여러분의 프로젝트(보통 그 리포지터리)를 가리키며 사이트 바닥글에 추가되는 링크입니다. 바닥글은 알려진 포지(GitHub, GitLab, Codeberg 등)의 경우 호스트 이름을 표시합니다. URL이 없으면 그런 링크도 없습니다.
 
-<!--T:37 @96b83a89-->
+<!--T:37 @8bc6c748-->
+<span id="WikvenSettingsPage"></span>
 === <code>WikvenSettingsPage</code> ===
 
 <!--T:50 @0caa505b-->
@@ -94,7 +96,8 @@ Wikven은 또한 브라우저가 <code>/favicon.ico</code>에서 404를 내지 �
 <!--T:39 @bb7171ab-->
 그 이름의 소스 문서를 쓰면 소개 문서와 똑같이 그쪽이 우선합니다. 빈 값으로 두면 문서를 아예 쓰지 않으며, 그곳을 가리키던 항목들도 함께 사라집니다. 이 문서가 독자에게 무엇을 제공하는지는 [[$1|스킨]]을 참고하십시오.
 
-<!--T:40 @fcd29ea8-->
+<!--T:40 @39b09490-->
+<span id="WikvenBundleWebfonts"></span>
 === <code>WikvenBundleWebfonts</code> ===
 
 <!--T:51 @4f128b66-->
@@ -131,7 +134,8 @@ Wikven은 또한 브라우저가 <code>/favicon.ico</code>에서 404를 내지 �
 <!--T:43 @6ad7acb3-->
 빌드가 MediaWiki에서 뽑아낸 CSS와 자바스크립트를 출력 디렉터리 아래 어디에 쓸지입니다. <code>.</code>은 출력 루트입니다. 생성된 자산을 문서들과 섞이지 않게 두려면 설정하십시오. 경로는 출력 디렉터리 기준이고 빌드가 링크도 거기에 맞춰 쓰므로, 따로 알려 줄 것은 없습니다.
 
-<!--T:20 @c60c5ada-->
+<!--T:20 @a9d8c62a-->
+<span id="WikvenRepositories"></span>
 === <code>WikvenRepositories</code> ===
 
 <!--T:53 @6ab2d6cb-->
@@ -172,7 +176,8 @@ $1
 <!--T:26 @b03dacba-->
 바로 이 사이트도 이 방식으로 [$2 TabberNeue]를 가져옵니다(그 <code>.wikven.yaml</code> 참고). [[$1|시작하기]]에 있는 탭 형식의 Docker/바이너리 명령 예시는 가져온 이 확장 기능이 렌더링한 것입니다. (이 사이트의 틀이 쓰는 TemplateStyles는 MediaWiki에 번들되어 있어 여기에 소스가 필요 없습니다.)
 
-<!--T:27 @40cc4afa-->
+<!--T:27 @8c96352f-->
+<span id="ContentNamespaces"></span>
 === <code>ContentNamespaces</code> ===
 
 <!--T:54 @a3511c46-->

--- a/docs/Installation.wikitext
+++ b/docs/Installation.wikitext
@@ -23,6 +23,7 @@ chmod +x wikven
 On arm64, use <code>wikven-linux-aarch64</code>. See [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|Standalone binary]] for installing it onto your <code>PATH</code>, nightly builds, and the optional host tools it uses.
 
 <!--T:5-->
+<span id="Docker"></span>
 == Docker ==
 
 <!--T:6-->

--- a/docs/Installation/ko.wikitext
+++ b/docs/Installation/ko.wikitext
@@ -14,7 +14,8 @@ x86_64와 arm64 Linux용으로 MediaWiki를 내장한 단일 자체 완결형 �
 <!--T:4 @b679cc4f-->
 arm64에서는 <code>wikven-linux-aarch64</code>를 사용하십시오. 이 파일을 <code>PATH</code>에 설치하는 방법, 나이틀리 빌드, 그리고 이 파일이 사용하는 선택적 호스트 도구에 관해서는 [[$1|단독 실행 바이너리]]를 참고하십시오.
 
-<!--T:5 @77dff36a-->
+<!--T:5 @7436e800-->
+<span id="Docker"></span>
 == Docker ==
 
 <!--T:6 @26e9972a-->


### PR DESCRIPTION
`#552` fixed the nine section links that were actually broken — their fragment named a heading's text, and a heading is translated. Seven were left alone because they happened to work: `=== <code>WikvenAboutPage</code> ===` and `== Docker ==` render the same heading in every language, so the anchor derived from them held.

**Happening to work is not the same as being anchored.** Those seven still resolved by way of the visible sentence. Rename the heading, drop the `<code>` wrapper, or translate "Docker" for a language that would, and the link goes quietly to the top of the page — no error, nothing to notice. What a link should hold onto is a marker that is not the text and does not change, which is what the other fifteen already have.

| | Heading it depended on |
|---|---|
| `Commands#translate` | `== <code>translate</code> ==` |
| `Configuration#ContentNamespaces` | `=== <code>ContentNamespaces</code> ===` |
| `Configuration#WikvenAboutPage` | `=== <code>WikvenAboutPage</code> ===` |
| `Configuration#WikvenBundleWebfonts` | `=== <code>WikvenBundleWebfonts</code> ===` |
| `Configuration#WikvenRepositories` | `=== <code>WikvenRepositories</code> ===` |
| `Configuration#WikvenSettingsPage` | `=== <code>WikvenSettingsPage</code> ===` |
| `Installation#Docker` | `== Docker ==` |

### No link changes

The ids keep the names the fragments already used, so **not one link in the repository is edited**. Each simply attaches to the `<span id>` instead of to the heading it used to be spelled after — the same target, now held by something that cannot drift.

### Verified

All **22** section links in the documentation now ride a marker, and every marker is present on the Korean page as well as the English one — checked by script both ways, zero missing.

Adding a span changes each heading unit's source text, so seven Korean stamps are recomputed. `docs/Licenses/km.wikitext` T:2 is left as it was, for the reason it was left in `#552`: it was already stale, and re-stamping it here would hide a real finding behind an unrelated change. `translate check` still reports it, and only it. `typos` passes over the repository.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_