### PR TITLE
fix: keep the site's own styles linked from a style directory

### DIFF
--- a/includes/StyleFile.php
+++ b/includes/StyleFile.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * Where a stylesheet the build dumped ends up: the href a page links it by, and the file it is.
+ *
+ * $wgWikvenStyleDirectory puts the dumped CSS anywhere under the output root, so a step that links
+ * one of those files has to answer the same question the step that wrote it answered. Deriving the
+ * link and the path together is what keeps the two answers from parting: a link written for one
+ * directory while the file is looked for in another leaves the page with no stylesheet at all, and
+ * nothing anywhere to say so.
+ */
+class StyleFile {
+	/**
+	 * @param string $htmlDirectory The output directory, as $wgWikvenHtmlDirectory gives it.
+	 * @param string $styleDirectory The style directory under it, as $wgWikvenStyleDirectory gives it.
+	 * @param string $name The stylesheet's file name, e.g. "site.styles.css".
+	 * @return array{href: string, path: string} The href to link the stylesheet by, relative to the
+	 *   output root as everything wikven writes is, and the path it lives at on disk.
+	 */
+	public static function locate(string $htmlDirectory, string $styleDirectory, string $name): array {
+		$directory = trim($styleDirectory, '/');
+		// Both spellings of the output directory itself; neither is a path segment of its own.
+		$atRoot = $directory === '' || $directory === '.';
+		$htmlDirectory = rtrim($htmlDirectory, '/');
+		return [
+			'href' => $atRoot ? "./$name" : "./$directory/$name",
+			'path' => $atRoot ? "$htmlDirectory/$name" : "$htmlDirectory/$directory/$name"
+		];
+	}
+}

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -29,13 +29,15 @@ class RewriteScripts extends Maintenance {
 
 		$htmlDir = rtrim($wgWikvenHtmlDirectory, '/');
 		$prefix = './' . rtrim($wgWikvenScriptDirectory, '/');
-		$siteStylesHref = './' . rtrim($wgWikvenStyleDirectory, '/') . '/site.styles.css';
-		$hasSiteStyles = is_file("$htmlDir/site.styles.css") && filesize("$htmlDir/site.styles.css") > 0;
+		$siteStyles = StyleFile::locate($htmlDir, $wgWikvenStyleDirectory, 'site.styles.css');
+		$siteStylesHref = $siteStyles['href'];
+		$hasSiteStyles = is_file($siteStyles['path']) && filesize($siteStyles['path']) > 0;
 
 		// Bundled webfonts (opt-in; bakeWebfonts wrote it): link ahead of site styles so a site can
 		// still override the font-family, and let rename's reparenting fix the href on subpages.
-		$webfontsHref = './' . rtrim($wgWikvenStyleDirectory, '/') . '/webfonts.css';
-		$hasWebfonts = is_file("$htmlDir/webfonts.css") && filesize("$htmlDir/webfonts.css") > 0;
+		$webfonts = StyleFile::locate($htmlDir, $wgWikvenStyleDirectory, 'webfonts.css');
+		$webfontsHref = $webfonts['href'];
+		$hasWebfonts = is_file($webfonts['path']) && filesize($webfonts['path']) > 0;
 
 		$rl = MediaWikiServices::getInstance()->getResourceLoader();
 

--- a/tests/phpunit/unit/StyleFileTest.php
+++ b/tests/phpunit/unit/StyleFileTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\StyleFile;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\StyleFile
+ */
+class StyleFileTest extends MediaWikiUnitTestCase {
+	public function testTheDefaultStyleDirectoryNamesTheOutputRoot() {
+		$this->assertSame(
+			['href' => './site.styles.css', 'path' => '/w/dist/site.styles.css'],
+			StyleFile::locate('/w/dist', '.', 'site.styles.css')
+		);
+	}
+
+	/**
+	 * The failure this exists to catch: buildStyles writes site.styles.css under the style
+	 * directory, so a link written for that directory while the file is looked for at the output
+	 * root finds nothing, and the page ships without MediaWiki:Common.css or any styles-only gadget.
+	 */
+	public function testAStyleDirectoryMovesTheFileAsWellAsTheHref() {
+		$this->assertSame(
+			['href' => './assets/site.styles.css', 'path' => '/w/dist/assets/site.styles.css'],
+			StyleFile::locate('/w/dist', 'assets', 'site.styles.css')
+		);
+	}
+
+	public function testTheBundledWebfontsAreLocatedTheSameWay() {
+		$this->assertSame(
+			['href' => './assets/webfonts.css', 'path' => '/w/dist/assets/webfonts.css'],
+			StyleFile::locate('/w/dist', 'assets', 'webfonts.css')
+		);
+	}
+
+	public function testANestedStyleDirectoryKeepsAllOfItsLevels() {
+		$this->assertSame(
+			['href' => './static/css/site.styles.css', 'path' => '/w/dist/static/css/site.styles.css'],
+			StyleFile::locate('/w/dist', 'static/css', 'site.styles.css')
+		);
+	}
+
+	public function testAnEmptyStyleDirectoryNamesTheOutputRootToo() {
+		$this->assertSame(
+			['href' => './site.styles.css', 'path' => '/w/dist/site.styles.css'],
+			StyleFile::locate('/w/dist', '', 'site.styles.css')
+		);
+	}
+
+	/** A directory written with slashes around it is the same directory. */
+	public function testSurroundingSlashesAreNotPartOfTheStyleDirectory() {
+		$located = ['href' => './assets/site.styles.css', 'path' => '/w/dist/assets/site.styles.css'];
+		$this->assertSame($located, StyleFile::locate('/w/dist', 'assets/', 'site.styles.css'));
+		$this->assertSame($located, StyleFile::locate('/w/dist', '/assets/', 'site.styles.css'));
+	}
+
+	public function testATrailingSlashOnTheOutputDirectoryDoesNotDoubleUp() {
+		$this->assertSame(
+			'/w/dist/assets/site.styles.css',
+			StyleFile::locate('/w/dist/', 'assets', 'site.styles.css')['path']
+		);
+	}
+}


### PR DESCRIPTION
## What was wrong

`rewriteScripts` was of two minds about where the dumped CSS lives. It wrote the `<link>` href **with** the style directory in it and then asked whether the file existed **without** it:

```php
// maintenance/rewriteScripts.php:32-38 (before)
$siteStylesHref = './' . rtrim($wgWikvenStyleDirectory, '/') . '/site.styles.css';
$hasSiteStyles = is_file("$htmlDir/site.styles.css") && filesize("$htmlDir/site.styles.css") > 0;
$webfontsHref = './' . rtrim($wgWikvenStyleDirectory, '/') . '/webfonts.css';
$hasWebfonts = is_file("$htmlDir/webfonts.css") && filesize("$htmlDir/webfonts.css") > 0;
```

The writers put both files under the style directory: `maintenance/buildStyles.php:84` writes `"$cssDir/site.styles.css"` with `$cssDir = "$wgWikvenHtmlDirectory/$wgWikvenStyleDirectory"`, and `maintenance/bakeWebfonts.php:86` writes `"$cssDir/webfonts.css"`. So the step that writes the file and the step that links it disagreed about where it is.

`WikvenStyleDirectory` defaults to `.` (`extension.json:108`), which is why nothing showed: at the default `"$htmlDir/site.styles.css"` happens to be the right path, and nothing in the repository sets the directory to anything else.

## The failure

Take the configuration `docs/Configuration.wikitext:170` gives verbatim:

```yaml
config:
  WikvenStyleDirectory: assets
```

`buildStyles` writes `dist/assets/site.styles.css`; `rewriteScripts` probes `dist/site.styles.css`, gets `false`, and emits no `<link>`. That link is the only route `site.styles` has into a page — it is excluded from the JS bundle (`maintenance/buildScripts.php:24`) and filtered out of the head links a page renders for itself (`includes/Hooks/Main.php:302`). So `MediaWiki:Common.css` and every styles-only gadget vanish from every page of the export, silently. With `WikvenBundleWebfonts` on, `webfonts.css` goes the same way: the woff2 files are copied and nothing references them.

The prose above that example promises "the build writes the links to match, so nothing else needs telling". It does now.

## What changed

`includes/StyleFile.php` — `StyleFile::locate($htmlDirectory, $styleDirectory, $name)` answers both halves of the question at once, returning the `href` a page links the stylesheet by and the `path` it lives at. Deriving them together is what keeps them from parting again. `.` and `''` both mean the output root (the reading `bakeWebfonts` already takes), and surrounding slashes are not part of the directory.

`maintenance/rewriteScripts.php` — asks `StyleFile` for each of the two stylesheets instead of composing the href and the probe separately. Behaviour at the default directory is unchanged apart from the href losing a redundant `./` segment (`././site.styles.css` → `./site.styles.css`), which `RelativeUrl::reparent` rebases identically either way.

The `WikvenScriptDirectory` half of the file was already consistent and is untouched.

## How the test covers it

`tests/phpunit/unit/StyleFileTest.php` pins the pairing. `testAStyleDirectoryMovesTheFileAsWellAsTheHref` is the regression: with `assets` it requires the probed path to be `/w/dist/assets/site.styles.css`, the file `buildStyles` actually wrote — the old code's `/w/dist/site.styles.css` fails it. The rest cover the default `.`, an empty directory, a nested `static/css`, slashes around the directory, a trailing slash on the output directory, and `webfonts.css` taking the same route as `site.styles.css`.

`vendor/bin/phpcs -sp` and `vendor/bin/minus-x check .` are clean on the changed files. PHPUnit needs a MediaWiki install, so it was not run here.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_