### PR TITLE
fix: stop a new unit inheriting a deleted one's translations

### DIFF
--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -82,8 +82,13 @@ class StalenessComputer {
 	 * Units are the blank-line-separated blocks Translate segments on; an already-marked unit keeps
 	 * its number and new ones continue from the highest on the page. The marker goes on its own line
 	 * before the unit, which both the unit scan and Translate's own re-parse honour. Idempotent.
+	 *
+	 * @param string $text
+	 * @param string[] $translations The page's existing translations, whose own markers say which
+	 *   numbers a deleted unit left behind are still spoken for. A caller with no source directory to
+	 *   look in, or a page with no translations yet, passes none.
 	 */
-	public static function mark(string $text): string {
+	public static function mark(string $text, array $translations = []): string {
 		$blocks = self::blockRanges($text);
 
 		// Only a marker inside a block is a unit, so only those numbers are taken; one shown elsewhere
@@ -93,6 +98,18 @@ class StalenessComputer {
 		foreach ($existing[0] as $i => $marker) {
 			if (self::containingRange($marker[1], $blocks) !== null) {
 				$numbers[] = (int)$existing[1][$i][0];
+			}
+		}
+		// Deleting the highest-numbered unit does not free its number while a translation still answers
+		// to it: the next unmarked block would inherit that unit's translations and read as merely
+		// stale, hiding both the orphan and the new unit nobody has translated. A number no
+		// translation ever carried is free, which is why this asks the translations and not a tally.
+		foreach ($translations as $translation) {
+			foreach (array_keys(self::translationUnits($translation)) as $id) {
+				// The reserved title unit is not a number and never stands in the way of one.
+				if (ctype_digit((string)$id)) {
+					$numbers[] = (int)$id;
+				}
 			}
 		}
 		$next = $numbers === [] ? 1 : max($numbers) + 1;

--- a/maintenance/markTranslations.php
+++ b/maintenance/markTranslations.php
@@ -24,14 +24,14 @@ class MarkTranslations extends Maintenance {
 
 	public function execute() {
 		$source = rtrim((string)$this->getOption('source', $GLOBALS['wgWikvenSourceDirectory'] ?? ''), '/');
+		$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
 
 		if ($this->hasOption('all')) {
 			if ($source === '' || !is_dir($source)) {
 				$this->fatalError("Wikven: source directory '$source' does not exist.");
 			}
-			$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
 			foreach (TranslationSource::baseFiles($source, $isKnownLanguage) as $baseFile) {
-				$this->markFile($baseFile);
+				$this->markFile($baseFile, $isKnownLanguage);
 			}
 			return;
 		}
@@ -47,19 +47,42 @@ class MarkTranslations extends Maintenance {
 		if (!is_file($file)) {
 			$this->fatalError("Wikven: '$file' does not exist.");
 		}
-		$this->markFile($file);
+		$this->markFile($file, $isKnownLanguage);
 	}
 
-	/** Mark one file in place, reporting whether it changed. */
-	private function markFile(string $file): void {
+	/**
+	 * Mark one file in place, reporting whether it changed.
+	 *
+	 * @param string $file
+	 * @param callable(string):bool $isKnownLanguage
+	 */
+	private function markFile(string $file, callable $isKnownLanguage): void {
 		$before = (string)file_get_contents($file);
-		$after = StalenessComputer::mark($before);
+		$after = StalenessComputer::mark($before, $this->translationsOf($file, $isKnownLanguage));
 		if ($after === $before) {
 			$this->output("unchanged: $file\n");
 			return;
 		}
 		file_put_contents($file, $after);
 		$this->output("marked:    $file\n");
+	}
+
+	/**
+	 * The text of every translation a page already has.
+	 *
+	 * Numbering reads them because a number one of them still carries stays taken even after the unit
+	 * it was written for is deleted; a file that is not a base page simply has none.
+	 *
+	 * @param string $baseFile
+	 * @param callable(string):bool $isKnownLanguage
+	 * @return string[]
+	 */
+	private function translationsOf(string $baseFile, callable $isKnownLanguage): array {
+		$translations = [];
+		foreach (TranslationSource::translationLanguages($baseFile, $isKnownLanguage) as $lang) {
+			$translations[] = (string)file_get_contents(TranslationSource::translationPath($baseFile, $lang));
+		}
+		return $translations;
 	}
 }
 

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -39,6 +39,19 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 		);
 	}
 
+	public function testMarkDoesNotHandOutANumberATranslationStillCarries() {
+		// The highest-numbered unit has been deleted and a new one written where it stood. Its number
+		// is not free while a translation still answers to it: giving it to the new unit would hand
+		// that unit the deleted one's translations, which then read as merely stale.
+		$this->assertSame(
+			"<translate>\n<!--T:1-->\nAlpha.\n\n<!--T:3-->\nGamma.\n</translate>",
+			StalenessComputer::mark(
+				"<translate>\n<!--T:1-->\nAlpha.\n\nGamma.\n</translate>",
+				["<!--T:1 @00000000-->\n알파\n\n<!--T:2 @00000000-->\n베타\n"]
+			)
+		);
+	}
+
 	public function testMarkNumbersContinueAcrossBlocks() {
 		$this->assertSame(
 			"<translate>\n<!--T:1-->\nA.\n</translate>\nx\n<translate>\n<!--T:2-->\nB.\n</translate>",


### PR DESCRIPTION
## What was wrong

`StalenessComputer::mark()` picked the next translation-unit number from the numbers present in the current source text alone (`includes/PageTranslation/StalenessComputer.php:98`). Deleting the highest-numbered unit therefore freed its number, and the next unmarked block was handed it — along with everything already translated under it.

## The failure

`src/Page.wikitext` has `T:1` ("Alpha.") and `T:2` ("Beta."); `src/Page/ko.wikitext` holds `<!--T:1 @h1-->` 알파 and `<!--T:2 @h2-->` 베타, both current.

Delete the "Beta." paragraph, write "Gamma." in its place, run `wikven translate mark --all`: Gamma is numbered `T:2`. `wikven translate scaffold ko --all` then adds nothing, because id 2 is already in the Korean file, so the translator is never shown a new empty unit. `wikven translate check` collapses two truthful findings — an orphaned `T:2` and an untranslated new unit — into one ambiguous "Stale translation unit T:2 (ko)". The published `dist/Page/ko.html` renders 베타 ("Beta") where the English reads "Gamma".

## What changed

`mark()` takes an optional second argument: the text of the page's existing translations. A number one of them still carries counts as taken alongside the numbers in the source text, so a deleted unit's number is not reissued while any translation still answers to it. A number no translation ever used stays free to reuse, so pages that never had translations number exactly as before. The reserved `title` unit is not a number and never stands in the way of one.

`maintenance/markTranslations.php` supplies those translations, finding them with `TranslationSource::translationLanguages()` and `translationPath()` rather than re-deriving the naming convention. The `$isKnownLanguage` callable moved to the top of `execute()` so the single-file path gets it too; a file that is not a base page simply has no translations, so both paths keep working, as does a call with no translations at all. The marker format is unchanged.

## How the test covers it

`testMarkDoesNotHandOutANumberATranslationStillCarries` in `tests/phpunit/unit/StalenessComputerTest.php` marks a source page whose `T:2` has been deleted and replaced by a new paragraph, passing a Korean translation that still carries `<!--T:1-->` and `<!--T:2-->`. It asserts the new paragraph is numbered `T:3`. Before the change it is numbered `T:2` and the test fails. The neighbouring `testMarkKeepsExistingNumbersAndContinuesFromTheHighest` pins the unchanged no-translations behaviour.

`vendor/bin/phpcs -sp` and `vendor/bin/minus-x check .` are clean on the changed files. PHPUnit needs a MediaWiki install, so the test was verified by hand against the class instead: the new numbering, the old single-argument behaviour, idempotency, and the `title` unit.

## Noticed but not fixed

- `restamp()` refreshes every marker's `@hash` with no evidence the translation itself was updated, so a translation can be stamped fresh while its text still says the old thing. Left alone as agreed — it is a separate decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_