### PR TITLE
fix: fail the build when a stylesheet never reaches the disk

### DIFF
--- a/includes/Stylesheet.php
+++ b/includes/Stylesheet.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/** The CSS files a build dumps into the export directory. */
+class Stylesheet {
+	/**
+	 * Write one stylesheet out, and say what went wrong when it did not reach the disk.
+	 *
+	 * The caller is meant to stop the build on a problem rather than move on to the next module:
+	 * a bake that filled the disk, or wrote into a read-only export directory, used to leave the
+	 * site unstyled and say so only through wfDebug(), which goes nowhere without a debug log a
+	 * wikven build never configures. An unstyled site is not something to hand over with exit 0.
+	 *
+	 * The write's own warning is left to be printed, since it carries the reason the file could
+	 * not be opened; this message adds the name the build knows the file by.
+	 *
+	 * @param string $filename Where the stylesheet goes.
+	 * @param string $text The CSS to write there.
+	 * @return string|null A message naming the file, or null once the file is on the disk.
+	 */
+	public static function write(string $filename, string $text): ?string {
+		if (file_put_contents($filename, $text, LOCK_EX) === false) {
+			return "Wikven: could not write $filename";
+		}
+		return null;
+	}
+}

--- a/maintenance/buildStyles.php
+++ b/maintenance/buildStyles.php
@@ -56,9 +56,9 @@ class BuildStyles extends Maintenance {
 
 			$text = ModuleRenderer::render($resourceLoader, $context);
 
-			if (file_put_contents($filename, $text, LOCK_EX) === false) {
-				wfDebug(__METHOD__ . '() failed saving ' . $filename);
-				continue;
+			$problem = Stylesheet::write($filename, $text);
+			if ($problem !== null) {
+				$this->fatalError($problem);
 			}
 		}
 
@@ -81,7 +81,10 @@ class BuildStyles extends Maintenance {
 		$context = new Context($resourceLoader, new FauxRequest($query));
 		$siteStyles = ModuleRenderer::render($resourceLoader, $context);
 		if (trim($siteStyles) !== '') {
-			file_put_contents("$cssDir/site.styles.css", $siteStyles, LOCK_EX);
+			$problem = Stylesheet::write("$cssDir/site.styles.css", $siteStyles);
+			if ($problem !== null) {
+				$this->fatalError($problem);
+			}
 		}
 
 		// Dumped CSS points icons at load.php images that 404 on static hosts; localize them.

--- a/tests/phpunit/unit/StylesheetTest.php
+++ b/tests/phpunit/unit/StylesheetTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\Stylesheet;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Stylesheet
+ */
+class StylesheetTest extends MediaWikiUnitTestCase {
+	/** One rule, so a written file has bytes worth reading back. */
+	private const CSS = ".mw-body { color: #000; }\n";
+
+	private string $directory;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->directory = sys_get_temp_dir() . '/wikven-stylesheet-' . getmypid() . '-' . uniqid();
+		mkdir($this->directory, 0777, true);
+	}
+
+	protected function tearDown(): void {
+		foreach (glob($this->directory . '/*') as $file) {
+			unlink($file);
+		}
+		if (is_dir($this->directory)) {
+			rmdir($this->directory);
+		}
+		parent::tearDown();
+	}
+
+	public function testAStylesheetThatReachedTheDiskIsNoProblem() {
+		$file = $this->directory . '/skins.vector.styles.css';
+
+		$this->assertNull(Stylesheet::write($file, self::CSS));
+		$this->assertSame(self::CSS, file_get_contents($file));
+	}
+
+	/**
+	 * The one that used to go unnoticed: a bake that could not write its CSS left the site
+	 * unstyled, said so only to a debug log wikven never configures, and exited 0 anyway.
+	 */
+	public function testAStylesheetThatCouldNotBeWrittenIsAProblemNamingTheFile() {
+		// No such directory, which refuses to open for writing the way a read-only export
+		// directory does.
+		$file = $this->directory . '/gone/skins.vector.styles.css';
+
+		$problem = $this->writeQuietly($file, self::CSS);
+
+		$this->assertNotNull($problem, 'a stylesheet that never landed has to be reported');
+		$this->assertStringContainsString($file, $problem);
+	}
+
+	/**
+	 * A failing write warns, and a build wants to see that warning; a test that asks for the
+	 * failure on purpose does not, and PHPUnit would otherwise make the expected one a failure.
+	 */
+	private function writeQuietly(string $filename, string $text): ?string {
+		set_error_handler(static function (): bool {
+			return true;
+		});
+		try {
+			return Stylesheet::write($filename, $text);
+		} finally {
+			restore_error_handler();
+		}
+	}
+}


### PR DESCRIPTION
## What was wrong

`maintenance/buildStyles.php:59-62` looked at the result of its stylesheet write and then threw the answer away:

```php
if (file_put_contents($filename, $text, LOCK_EX) === false) {
	wfDebug(__METHOD__ . '() failed saving ' . $filename);
	continue;
}
```

`wfDebug()` needs `$wgDebugLogFile`, which a wikven build never sets, so the message went nowhere at all. `continue` then moved on to the next module, `execute()` returned null rather than `false`, and `build.php`'s `step()` (`maintenance/build.php:862`, "A child returning false signals failure … abort the build") waved it through.

The second write on the same path, `file_put_contents("$cssDir/site.styles.css", ...)` at `maintenance/buildStyles.php:84`, was not checked at all.

## The failure scenario

The disk fills part-way through a bake, or `dist` is mounted read-only. Some or all of the site's CSS is never written. The user gets an unstyled site, nothing on stdout or stderr says so, and the build exits 0. What they should have seen is `Wikven: could not write dist/skins.vector.styles.css`, and a build that failed.

## What changed

- New `includes/Stylesheet.php`: `Stylesheet::write()` writes one stylesheet and returns either null or a message naming the file, following the `Scribunto::problem()` / `build.php:98` shape already used for a problem the build should stop on.
- `buildStyles.php` calls it for both writes and passes the message to `fatalError()`, which is how `bakeWebfonts.php:84` already reports a path it could not create. The build now exits non-zero, and `step()` never gets the chance to wave it through.
- The write's own PHP warning is deliberately left unsuppressed, since it carries the reason (`No space left on device`, `Permission denied`) that the build's own message cannot know.

## How the test covers it

`tests/phpunit/unit/StylesheetTest.php`:

- `testAStylesheetThatCouldNotBeWrittenIsAProblemNamingTheFile` writes into a directory that does not exist — the same refusal to open for writing that a read-only export directory gives — and asserts that a problem comes back and that it names the file. Under the old code this failure produced nothing an operator or the build could see; the assertion is exactly the signal that was missing.
- `testAStylesheetThatReachedTheDiskIsNoProblem` pins the other half: a successful write reports no problem and the bytes are on the disk, so the new check cannot fail a build that was fine.

The failing case is driven through a small helper that installs an error handler for the duration of the call, because the write warns on purpose there and PHPUnit would otherwise turn the expected warning into a failure.

## Noticed but not fixed

- `file_put_contents()` returns a byte count, so a write that is cut short mid-file (the disk filling while this very file is being written) still returns non-false and passes the `=== false` check. Catching that means comparing against `strlen($text)`, which is a wider change than the defect described here. The same applies to `FetchPin::stamp()` (`includes/FetchPin.php:98`) and `checkTranslations.php:166`.
- The same defect class runs through the rest of the build: `bakeWebfonts.php:86`, `buildScripts.php:91` and `:95`, `rewriteScripts.php:142`, `storeImages.php:159`, `stripBuildStamps.php:38`, `rename.php:68`, `fillMinervaMenu.php:93`, `resolveTranslationLinks.php:61`, `stampTranslations.php:75`, `scaffoldTranslations.php:82` and `markTranslations.php:61` all write without checking, so each can drop a file from the output and still exit 0. `Stylesheet::write()` is deliberately named for stylesheets rather than generalised, since a shared writer for all of those is a separate change with its own call sites to think about.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_