### PR TITLE
fix: fail the build when the webfonts a site asked for cannot be copied

### DIFF
--- a/includes/Webfonts/FontCopier.php
+++ b/includes/Webfonts/FontCopier.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Webfonts;
+
+/**
+ * Copy the woff2 files a baked stylesheet names out of UniversalLanguageSelector's font repository.
+ *
+ * The stylesheet and the files it points at are one thing: an @font-face whose url() answers 404
+ * leaves the reader with exactly the tofu the bundled font was there to spare them, and nothing on
+ * the page says why. So this reports every file that did not arrive rather than counting the ones
+ * that did -- a bake that ships nine fonts of the ten its stylesheet names got the site something
+ * other than what it asked for, and the caller is the one that has to be able to tell.
+ */
+class FontCopier {
+	/**
+	 * Copy each base-relative woff2 path into the output tree.
+	 *
+	 * @param string $srcBase ULS's font directory, the one its repository paths are relative to.
+	 * @param string $destBase Output directory the woff2 tree is copied under.
+	 * @param string[] $files Base-relative woff2 paths (e.g. "AbyssinicaSIL/AbyssinicaSIL-R.woff2").
+	 * @return string[] The paths that did not arrive -- missing from the repository, or the
+	 *   directory or the copy failed -- in the order they were asked for. Empty when all of them did.
+	 */
+	public static function copy(string $srcBase, string $destBase, array $files): array {
+		$missing = [];
+		foreach ($files as $relative) {
+			$src = "$srcBase/$relative";
+			if (!is_file($src)) {
+				$missing[] = $relative;
+				continue;
+			}
+			$dest = "$destBase/$relative";
+			$dir = dirname($dest);
+			if (!is_dir($dir) && !wfMkdirParents($dir)) {
+				$missing[] = $relative;
+				continue;
+			}
+			if (!copy($src, $dest)) {
+				$missing[] = $relative;
+			}
+		}
+		return $missing;
+	}
+}

--- a/maintenance/bakeWebfonts.php
+++ b/maintenance/bakeWebfonts.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Wikven;
 
 use Maintenance;
+use MediaWiki\Extension\Wikven\Webfonts\FontCopier;
 use MediaWiki\Extension\Wikven\Webfonts\FontRepository;
 use MediaWiki\Registration\ExtensionRegistry;
 
@@ -74,17 +75,20 @@ class BakeWebfonts extends Maintenance {
 			return;
 		}
 
-		$copied = $this->copyFonts($ulsDir, "$htmlDir/" . self::FONTS_SUBDIR, $built['files']);
-		if ($copied === 0) {
-			$this->error('Wikven: none of the required webfont files could be copied.');
-			return;
+		$missing = FontCopier::copy("$ulsDir/data/fontrepo/fonts", "$htmlDir/" . self::FONTS_SUBDIR, $built['files']);
+		// The stylesheet names every one of these files, so shipping it without them gives the
+		// reader the tofu the site opted into bundled fonts to spare them. The site asked for these
+		// fonts; a build that cannot deliver them has not done what it was asked, and says so.
+		if ($missing !== []) {
+			$counts = count($missing) . ' of ' . count($built['files']);
+			$this->fatalError("Wikven: $counts webfont file(s) could not be copied: " . implode(', ', $missing));
 		}
 
 		if (!is_dir($cssDir) && !wfMkdirParents($cssDir)) {
 			$this->fatalError("Wikven: could not create style directory $cssDir");
 		}
 		file_put_contents("$cssDir/webfonts.css", $built['css'], LOCK_EX);
-		$this->output("Wrote webfonts.css ($copied font file(s))\n");
+		$this->output('Wrote webfonts.css (' . count($built['files']) . " font file(s))\n");
 	}
 
 	/**
@@ -142,36 +146,6 @@ class BakeWebfonts extends Maintenance {
 			}
 		}
 		return $languages;
-	}
-
-	/**
-	 * Copy each base-relative woff2 path from ULS's font repo into the output.
-	 *
-	 * @param string $ulsDir
-	 * @param string $destBase Output directory the woff2 tree is copied under.
-	 * @param string[] $files Base-relative woff2 paths (e.g. "AbyssinicaSIL/AbyssinicaSIL-R.woff2").
-	 * @return int The number of files copied.
-	 */
-	private function copyFonts(string $ulsDir, string $destBase, array $files): int {
-		$srcBase = "$ulsDir/data/fontrepo/fonts";
-		$copied = 0;
-		foreach ($files as $relative) {
-			$src = "$srcBase/$relative";
-			if (!is_file($src)) {
-				$this->output("  missing font: $relative\n");
-				continue;
-			}
-			$dest = "$destBase/$relative";
-			$dir = dirname($dest);
-			if (!is_dir($dir) && !wfMkdirParents($dir)) {
-				$this->error("Wikven: could not create font directory $dir");
-				continue;
-			}
-			if (copy($src, $dest)) {
-				$copied++;
-			}
-		}
-		return $copied;
 	}
 }
 

--- a/tests/phpunit/integration/Webfonts/FontCopierTest.php
+++ b/tests/phpunit/integration/Webfonts/FontCopierTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration\Webfonts;
+
+use MediaWiki\Extension\Wikven\Webfonts\FontCopier;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * FontCopier makes the output directories with wfMkdirParents, so this is an integration test.
+ *
+ * @covers \MediaWiki\Extension\Wikven\Webfonts\FontCopier
+ */
+class FontCopierTest extends MediaWikiIntegrationTestCase {
+	/** The two woff2 paths a repository entry with a bold variant asks for. */
+	private const FILES = ['Alef/Alef-Bold.woff2', 'Alef/Alef-Regular.woff2'];
+
+	private string $directory;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->directory = sys_get_temp_dir() . '/wikven-font-copier-' . getmypid() . '-' . uniqid();
+		mkdir("$this->directory/uls/Alef", 0777, true);
+	}
+
+	protected function tearDown(): void {
+		$this->remove($this->directory);
+		parent::tearDown();
+	}
+
+	private function source(): string {
+		return "$this->directory/uls";
+	}
+
+	private function destination(): string {
+		return "$this->directory/dist/fonts/uls";
+	}
+
+	/** Put a font in the repository, with bytes of its own so a copy can be told from an empty file. */
+	private function repositoryHolds(string $relative): void {
+		file_put_contents("{$this->source()}/$relative", "woff2 of $relative");
+	}
+
+	private function remove(string $path): void {
+		if (is_dir($path)) {
+			foreach (array_diff(scandir($path) ?: [], ['.', '..']) as $entry) {
+				$this->remove("$path/$entry");
+			}
+			rmdir($path);
+			return;
+		}
+		if (is_file($path)) {
+			unlink($path);
+		}
+	}
+
+	/** Nothing missing: every file arrives, under a tree the copy makes for itself. */
+	public function testAFontRepositoryWithEveryFileDeliversThemAll() {
+		$this->repositoryHolds('Alef/Alef-Bold.woff2');
+		$this->repositoryHolds('Alef/Alef-Regular.woff2');
+
+		$missing = FontCopier::copy($this->source(), $this->destination(), self::FILES);
+
+		$this->assertSame([], $missing);
+		foreach (self::FILES as $relative) {
+			$this->assertFileExists("{$this->destination()}/$relative");
+			$this->assertSame("woff2 of $relative", file_get_contents("{$this->destination()}/$relative"));
+		}
+	}
+
+	/**
+	 * The regression this class exists for: a bake that delivers some of the fonts its stylesheet
+	 * names is not a bake that delivered them. Counting the copies made hid this, since one copy
+	 * out of two counted as success and the build went on to write @font-face rules pointing at a
+	 * file no reader can fetch.
+	 */
+	public function testAFontTheRepositoryDoesNotHaveIsReportedEvenWhenOthersCopy() {
+		$this->repositoryHolds('Alef/Alef-Regular.woff2');
+
+		$missing = FontCopier::copy($this->source(), $this->destination(), self::FILES);
+
+		$this->assertSame(['Alef/Alef-Bold.woff2'], $missing);
+		// The one that was there still arrived; the report is about what did not.
+		$this->assertFileExists("{$this->destination()}/Alef/Alef-Regular.woff2");
+	}
+
+	/** A repository with none of them names all of them, rather than saying only that it failed. */
+	public function testARepositoryWithNoneOfTheFilesReportsEveryOne() {
+		$missing = FontCopier::copy($this->source(), $this->destination(), self::FILES);
+
+		$this->assertSame(self::FILES, $missing);
+	}
+
+	/** A stylesheet naming no files asks for nothing, and nothing is what is missing. */
+	public function testAskingForNoFilesIsNotAFailure() {
+		$this->assertSame([], FontCopier::copy($this->source(), $this->destination(), []));
+	}
+}


### PR DESCRIPTION
## What was wrong

`maintenance/bakeWebfonts.php:78-81` let an opt-in feature fail completely while the build still reported success:

```php
$copied = $this->copyFonts($ulsDir, "$htmlDir/" . self::FONTS_SUBDIR, $built['files']);
if ($copied === 0) {
    $this->error('Wikven: none of the required webfont files could be copied.');
    return;
}
```

`Maintenance::error()` sets no exit code, and `return` yields `null`, which is not `false` — so `build.php`'s `step()` (`maintenance/build.php:862`, "A child returning false signals failure ... abort the build") waved it through. The line just below, `maintenance/bakeWebfonts.php:84`, gets this right with `fatalError()` for a directory it cannot create.

Partial failure was quieter still: `copyFonts()` printed `  missing font: X` to stdout, the return value of `copy()` (`maintenance/bakeWebfonts.php:170`) was not checked at all, and any `$copied > 0` counted as success.

## The failure scenario

A site sets `WikvenBundleWebfonts: true` — an opt-in someone had to type — and some or all of the woff2 files are absent from the ULS tree. `webfonts.css` is written anyway, its `@font-face` rules point at files that answer 404, readers get exactly the tofu the bundled fonts were there to spare them, and the build exits 0 with one line of chatter. A bake that copies three fonts of ten reported success in the same way.

## What changed

- New `includes/Webfonts/FontCopier.php`: the copy step now reports the base-relative paths that did not arrive — missing from the repository, undeliverable directory, or a failed `copy()` — instead of counting the ones that did.
- `maintenance/bakeWebfonts.php` calls it and, when anything is missing, ends the bake with `fatalError()` naming the counts and the paths, before `webfonts.css` is written. The build stops there, as it does for the style directory below it.

The extraction is only as large as the test needs; `copyFonts()` moved into the new class and nothing else in the script changed.

Deliberately untouched: the earlier returns in `execute()`. A site that did not ask for bundled webfonts, one without UniversalLanguageSelector, one whose ULS repository cannot be read, and one whose languages no bundled font applies to all still skip quietly — that last path is what the docs site's own bake relies on, and `.github/workflows/smoke.yml` (which bakes a Khmer page precisely so the feature has a subject) keeps asserting every `url()` in `webfonts.css` resolves, so the docs bake only reaches the new failure if it really is missing a font it names.

## How the test covers it

`tests/phpunit/integration/Webfonts/FontCopierTest.php` builds a small ULS-shaped font tree under a temp directory and drives `FontCopier::copy()` (an integration test because the copy makes its output directories with `wfMkdirParents`):

- `testAFontRepositoryWithEveryFileDeliversThemAll` — nothing reported missing, and both files arrive with their own bytes under a tree the copy makes for itself.
- `testAFontTheRepositoryDoesNotHaveIsReportedEvenWhenOthersCopy` — the regression: with one of two fonts on disk, the absent one comes back in the report while the other still arrives. Under the old count-the-copies logic this was success, and the build went on to write `@font-face` rules for a file no reader can fetch.
- `testARepositoryWithNoneOfTheFilesReportsEveryOne` — every path named, not merely "it failed".
- `testAskingForNoFilesIsNotAFailure` — asking for nothing is not a failure, so the empty-stylesheet path stays non-fatal.

`vendor/bin/phpcs -sp`, `vendor/bin/minus-x check .`, `mago format --check` and `mago lint` are clean on the changed files. PHPUnit needs a MediaWiki install and was not run here.

## Noticed but not fixed

`file_put_contents("$cssDir/webfonts.css", ...)` at `maintenance/bakeWebfonts.php:92` does not check its return value either, so a stylesheet that fails to write leaves the same silent success this change was about — the fonts are copied, the CSS that applies them is not, and the build exits 0. Left alone to keep this diff to the one defect.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_