### PR TITLE
fix: translate a page whose file name is not spelled like its title

### DIFF
--- a/includes/PageTranslation/TranslationSource.php
+++ b/includes/PageTranslation/TranslationSource.php
@@ -159,6 +159,26 @@ class TranslationSource {
 	}
 
 	/**
+	 * The translation files a base page has, keyed by the language each is written in.
+	 *
+	 * A caller that has the base file gets its translations by the paths they were found at, rather
+	 * than by rebuilding them from the page title: a title has been through MediaWiki's
+	 * normalization and no longer spells the file it came from ("Getting_Started.wikitext" imports
+	 * as "Getting Started"), so a rebuilt path can miss a translation that is sitting right there.
+	 *
+	 * @param string $baseFile
+	 * @param callable(string):bool $isKnownLanguage
+	 * @return array<string,string> Absolute paths, keyed by language code, sorted by code.
+	 */
+	public static function translationFiles(string $baseFile, callable $isKnownLanguage): array {
+		$files = [];
+		foreach (self::translationLanguages($baseFile, $isKnownLanguage) as $lang) {
+			$files[$lang] = self::translationPath($baseFile, $lang);
+		}
+		return $files;
+	}
+
+	/**
 	 * Every language the source tree carries a translation in.
 	 *
 	 * The languages a site is built in are the ones its pages have translations for. Read from the

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -65,9 +65,9 @@ class BuildTranslations extends Maintenance {
 				continue;
 			}
 			$sourceText = (string)file_get_contents($baseFile);
-			$languages = TranslationSource::translationLanguages($baseFile, $isKnownLanguage);
+			$translations = TranslationSource::translationFiles($baseFile, $isKnownLanguage);
 			$pageTitle = TranslationSource::translatableTitle($baseFile, $source, $sourceText);
-			if ($this->prepare($title, $sourceText, $languages, $pageTitle, $user)) {
+			if ($this->prepare($title, $sourceText, $translations, $pageTitle, $user)) {
 				$prepared[] = $title;
 			}
 		}
@@ -104,7 +104,7 @@ class BuildTranslations extends Maintenance {
 	 *
 	 * @param Title $title
 	 * @param string $sourceText
-	 * @param string[] $languages
+	 * @param array<string,string> $translations Translation file paths, keyed by language code.
 	 * @param ?string $pageTitle Source text of the page's title unit, or null if its title is fixed.
 	 * @param User $user
 	 * @return bool Whether the page was marked (false if it could not be loaded, parsed or validated).
@@ -112,7 +112,7 @@ class BuildTranslations extends Maintenance {
 	private function prepare(
 		Title $title,
 		string $sourceText,
-		array $languages,
+		array $translations,
 		?string $pageTitle,
 		User $user
 	): bool {
@@ -155,7 +155,7 @@ class BuildTranslations extends Maintenance {
 		// before we fill in translations.
 		$this->drainJobs();
 
-		$this->loadTranslations($title, $sourceText, $languages, $pageTitle, $user);
+		$this->loadTranslations($title, $sourceText, $translations, $pageTitle, $user);
 		return true;
 	}
 
@@ -177,14 +177,14 @@ class BuildTranslations extends Maintenance {
 	 *
 	 * @param Title $title
 	 * @param string $sourceText
-	 * @param string[] $languages
+	 * @param array<string,string> $translations Translation file paths, keyed by language code.
 	 * @param ?string $pageTitle Source text of the page's title unit, or null if its title is fixed.
 	 * @param User $user
 	 */
 	private function loadTranslations(
 		Title $title,
 		string $sourceText,
-		array $languages,
+		array $translations,
 		?string $pageTitle,
 		User $user
 	): void {
@@ -192,12 +192,12 @@ class BuildTranslations extends Maintenance {
 		$sourceUnits = StalenessComputer::sourceUnits($sourceText, $pageTitle);
 		$prefixed = $title->getPrefixedText();
 
-		foreach ($languages as $lang) {
-			$translationFile = TranslationSource::translationPath(
-				rtrim($GLOBALS['wgWikvenSourceDirectory'], '/') . '/' . SourceFile::titleToFilename($prefixed),
-				$lang
-			);
+		foreach ($translations as $lang => $translationFile) {
 			if (!is_file($translationFile)) {
+				// The file is the one the language was discovered at, so it is only missing if the
+				// source tree changed under the build. Say so: the page would otherwise be exported
+				// in that language with nothing translated and nothing to explain why.
+				$this->output("Wikven: $prefixed has no readable $lang translation at $translationFile\n");
 				continue;
 			}
 			$translationText = (string)file_get_contents($translationFile);

--- a/tests/phpunit/integration/TranslationSourceTest.php
+++ b/tests/phpunit/integration/TranslationSourceTest.php
@@ -3,6 +3,8 @@
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
 use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
+use MediaWiki\Extension\Wikven\SourceFile;
+use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 
 /**
@@ -85,6 +87,30 @@ class TranslationSourceTest extends MediaWikiIntegrationTestCase {
 		rmdir($dir);
 
 		$this->assertSame(["$dir/Intro.wikitext", "$dir/Intro/Details.wikitext"], $found);
+	}
+
+	/**
+	 * A page reaches its translations by the paths they were found at, because a page title cannot
+	 * be turned back into one: "Getting_Started.wikitext" imports as "Getting Started", and a path
+	 * rebuilt from that title points at a directory the source tree does not have, so the build
+	 * would find no Korean to load and say nothing about it.
+	 */
+	public function testATranslationIsFoundAtThePathItsLanguageWasDiscoveredAt() {
+		$dir = $this->getNewTempDirectory();
+		mkdir("$dir/Getting_Started");
+		file_put_contents("$dir/Getting_Started.wikitext", "<languages/>\n<translate>\n<!--T:1-->\nHi.\n</translate>");
+		file_put_contents("$dir/Getting_Started/ko.wikitext", "<!--T:1-->\n안녕하세요.");
+
+		$isKnownLanguage = [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
+		$files = TranslationSource::translationFiles("$dir/Getting_Started.wikitext", $isKnownLanguage);
+
+		$this->assertSame(['ko' => "$dir/Getting_Started/ko.wikitext"], $files);
+		$this->assertFileExists($files['ko'], 'the translation is where the language was discovered');
+		$this->assertSame(
+			'Getting Started',
+			Title::newFromText(SourceFile::filenameToTitle('Getting_Started.wikitext'))?->getPrefixedText(),
+			'the file name does not survive title normalization'
+		);
 	}
 
 	/** @dataProvider provideTranslatableTitle */


### PR DESCRIPTION
## What was wrong

`buildTranslations` found a page's languages from the base file on disk, then went looking for the translation files somewhere else. `maintenance/buildTranslations.php:195-201` rebuilt the path out of the normalized page title:

```php
$translationFile = TranslationSource::translationPath(
    rtrim($GLOBALS['wgWikvenSourceDirectory'], '/') . '/' . SourceFile::titleToFilename($prefixed),
    $lang
);
if (!is_file($translationFile)) {
    continue;
}
```

Every other caller — `checkTranslations`, `stampTranslations`, `scaffoldTranslations`, `retranslateChrome` — reaches a translation through `TranslationSource::translationPath($baseFile, $lang)` with the real base file path. `loadTranslations()` alone reconstructed it, and `SourceFile::titleToFilename()` (`includes/SourceFile.php:27`) is just `$title . '.wikitext'`, with no inverse of MediaWiki's title normalization.

## The failure

The source tree holds `src/Getting_Started.wikitext` (translatable) and `src/Getting_Started/ko.wikitext`, filled and stamped. MediaWiki normalizes the underscore to a space, so `getPrefixedText()` is `Getting Started` and the build looked for `src/Getting Started/ko.wikitext`. The language was still discovered — `$languages` came from the real directory — so the loop ran, the `is_file()` check missed, and it `continue`d in silence. `dist/Getting_Started/ko.html` shipped with no Korean in it, while `wikven translate check --gate`, which reaches the same file by the real path, reported the page fully translated and kept CI green. `maintenance/importWikitext.php:49` already warns about exactly this non-round-trip; the build did not act on it.

## What changed

- `TranslationSource::translationFiles()` pairs each discovered language with the file it was discovered at, so there is nothing left to rebuild.
- `buildTranslations` computes that map where it used to compute `$languages`, and carries it through `prepare()` into `loadTranslations()`, which now iterates `$lang => $translationFile`.
- The `is_file()` check stays — a source tree can change under a running build — but no longer passes over a language in silence: it names the page, the language and the path it could not read.

## The test

`tests/phpunit/integration/TranslationSourceTest.php` gains `testATranslationIsFoundAtThePathItsLanguageWasDiscoveredAt`, which writes `Getting_Started.wikitext` and `Getting_Started/ko.wikitext` into a temp source tree and pins that `ko` maps to the file that is actually there. It also asserts that the same file name imports as `Getting Started`, so the premise — the name does not survive normalization, and therefore a path rebuilt from the title cannot find it — is pinned alongside. The test fails before the change (the reconstruction had no seam to drive, which is how the defect survived: `translationPath` was only ever tested on real paths) and passes after.

`vendor/bin/phpcs -sp` on the three changed files, `vendor/bin/minus-x check .`, `mago format --check` and `mago lint` are all clean. PHPUnit needs a MediaWiki install, so it is left to CI.

## Noticed but not fixed

- `maintenance/buildTranslations.php:50` reads `$GLOBALS['wgWikvenSourceDirectory']` while the rest of the script's collaborators take the directory as an argument; nothing is broken by it, so it is left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_