### PR TITLE
fix: keep the build's chrome off a licenses page the site wrote

### DIFF
--- a/includes/LicensesPage.php
+++ b/includes/LicensesPage.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven;
 
+use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
 use MediaWiki\Title\Title;
 
 /**
@@ -59,5 +60,34 @@ class LicensesPage {
 			return null;
 		}
 		return $language;
+	}
+
+	/**
+	 * The copies the build wrote, keyed by the language each one is in.
+	 *
+	 * The languages are the ones the source tree carries translations in, because those are the
+	 * ones build.php writes a copy for. Which of those copies are the build's own is the question
+	 * above, asked once per language: a site that provides its own page, or its own copy in one
+	 * language, keeps it, and a caller that re-rendered it would be dressing someone else's page in
+	 * a language nobody asked for.
+	 *
+	 * @param string $sourceDir
+	 * @param callable(string):bool $isKnownLanguage
+	 * @return array<string,Title> Language code => the copy written in it.
+	 */
+	public static function generatedCopies(string $sourceDir, callable $isKnownLanguage): array {
+		$page = self::title();
+		if ($page === null) {
+			return [];
+		}
+
+		$copies = [];
+		foreach (TranslationSource::languages($sourceDir, $isKnownLanguage) as $language) {
+			$title = Title::newFromText(self::inLanguage($page, $language));
+			if ($title && self::generatedLanguage($title, $isKnownLanguage) !== null) {
+				$copies[$language] = $title;
+			}
+		}
+		return $copies;
 	}
 }

--- a/maintenance/retranslateChrome.php
+++ b/maintenance/retranslateChrome.php
@@ -73,27 +73,21 @@ class RetranslateChrome extends Maintenance {
 	 * language all the same -- the Declarer hook answers for them -- so the chrome around them has
 	 * to follow, or a Korean page keeps an English menu and footer.
 	 *
-	 * Skipped where the site wrote its own licenses page, because then the build wrote no copies
-	 * and whatever sits under that title is the site's, or Translate's, and is handled above.
+	 * Only the copies the build wrote: a page the source tree provided, under that title or under
+	 * one of its language subpages, is the site's or Translate's, and is handled above. LicensesPage
+	 * is asked which those are, the same as the Declarer hook asks it, so the chrome a copy wears
+	 * and the language it declares cannot end up disagreeing.
 	 *
 	 * @param string $source
 	 * @param string $contentLang
 	 * @param callable(string):bool $isKnownLanguage
 	 */
 	private function recacheGeneratedLicenses(string $source, string $contentLang, callable $isKnownLanguage): void {
-		$page = LicensesPage::title();
-		if ($page === null || SourceFile::exists($page->getPrefixedText())) {
-			return;
-		}
-
-		foreach (TranslationSource::languages($source, $isKnownLanguage) as $lang) {
-			if ($lang === $contentLang) {
+		foreach (LicensesPage::generatedCopies($source, $isKnownLanguage) as $lang => $title) {
+			if ($lang === $contentLang || !$title->exists()) {
 				continue;
 			}
-			$title = Title::newFromText(LicensesPage::inLanguage($page, $lang));
-			if ($title && $title->exists()) {
-				$this->recache($title, $lang);
-			}
+			$this->recache($title, $lang);
 		}
 	}
 

--- a/tests/phpunit/integration/LicensesPageTest.php
+++ b/tests/phpunit/integration/LicensesPageTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\LicensesPage;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\LicensesPage
+ */
+class LicensesPageTest extends MediaWikiIntegrationTestCase {
+	/** A page the build has copies to write for: translatable, so the site is built in ko. */
+	private const TRANSLATABLE = "<languages/>\n<translate>\n<!--T:1-->\nHi.\n</translate>\n";
+
+	/**
+	 * The copies are the ones the build wrote, in every language the source tree carries.
+	 *
+	 * retranslateChrome re-renders these with their own language as the interface language, so this
+	 * is the list of pages whose chrome the build is entitled to change.
+	 */
+	public function testTheCopiesAreTheOnesTheBuildWrote() {
+		$source = $this->sourceTreeTranslatedIntoKorean();
+
+		$copies = LicensesPage::generatedCopies($source, $this->isKnownLanguage());
+
+		$this->assertSame(['ko'], array_keys($copies));
+		$this->assertSame('Licenses/ko', $copies['ko']->getPrefixedText());
+	}
+
+	/**
+	 * A copy the site provided itself is the site's, and re-rendering it is not the build's to do.
+	 *
+	 * This is the page the Declarer hook keeps its hands off (#561): English prose about Korean
+	 * licensing terms, sitting at the title a Korean copy would have had. Re-rendering it in ko
+	 * would wrap Korean chrome around English prose and leave the html lang saying en, because the
+	 * hook still -- rightly -- calls the page English.
+	 */
+	public function testASourceCopyIsNotTheBuildsToRecache() {
+		$source = $this->sourceTreeTranslatedIntoKorean();
+		mkdir("$source/Licenses");
+		file_put_contents("$source/Licenses/ko.wikitext", "What Korean law asks of us.\n");
+
+		$this->assertSame([], LicensesPage::generatedCopies($source, $this->isKnownLanguage()));
+	}
+
+	/** A site that wrote its own licenses page got no copies from the build, so there are none. */
+	public function testASourceLicensesPageLeavesNoCopies() {
+		$source = $this->sourceTreeTranslatedIntoKorean();
+		file_put_contents("$source/Licenses.wikitext", "Ours, thanks.\n");
+
+		$this->assertSame([], LicensesPage::generatedCopies($source, $this->isKnownLanguage()));
+	}
+
+	/** Set the name empty and the build writes no page, so there is nothing under it either. */
+	public function testNoLicensesPageMeansNoCopies() {
+		$source = $this->sourceTreeTranslatedIntoKorean();
+		$this->overrideConfigValue('WikvenLicensesPage', '');
+
+		$this->assertSame([], LicensesPage::generatedCopies($source, $this->isKnownLanguage()));
+	}
+
+	/** A source tree with one translated page, which is what makes ko a language the site is built in. */
+	private function sourceTreeTranslatedIntoKorean(): string {
+		$source = $this->getNewTempDirectory();
+		mkdir("$source/Intro");
+		file_put_contents("$source/Intro.wikitext", self::TRANSLATABLE);
+		file_put_contents("$source/Intro/ko.wikitext", "<!--T:1-->\n안녕.\n");
+		$this->overrideConfigValue('WikvenLicensesPage', 'Licenses');
+		$this->overrideConfigValue('WikvenSourceDirectory', $source);
+
+		return $source;
+	}
+
+	/** @return callable(string):bool */
+	private function isKnownLanguage(): callable {
+		return [$this->getServiceContainer()->getLanguageNameUtils(), 'isKnownLanguageTag'];
+	}
+}


### PR DESCRIPTION
## What was wrong

Three places ask whether the page at `Licenses/<lang>` is the build's or the site's, and `retranslateChrome` answered it differently from the other two:

- `maintenance/build.php:1068` checks the copy (`$copy->exists()`), so it leaves a site-provided copy alone.
- `includes/LicensesPage.php:58` (`generatedLanguage`) checks both the parent and the copy, so the page-language hook stays quiet for a site-provided copy.
- `maintenance/retranslateChrome.php:85` (`recacheGeneratedLicenses`) checked the parent only, and then re-rendered whatever sat at `Licenses/<lang>`.

## The failure

`WikvenLicensesPage` is left at `Licenses`. The source tree has no `src/Licenses.wikitext`, but it does have `src/Licenses/ko.wikitext` -- an English page about Korean licensing terms -- plus another page with a `ko` translation, so `TranslationSource::languages()` reports `ko`.

The build generates `Licenses` and correctly leaves `Licenses/ko` to the site, and `generatedLanguage` correctly returns null so the page's `<html lang>` stays `en`. But `recacheGeneratedLicenses` passed its parent-only guard, found `Licenses/ko` in the wiki, and re-rendered it with Korean as the interface language, overwriting its view cache. The published `dist/Licenses/ko.html` shipped with `lang="en"` on `<html>` and a wholly Korean sidebar, footer and tab labels wrapped around English prose.

## What changed

- `LicensesPage::generatedCopies()` is new: given the source directory it returns the copies the build wrote, keyed by language, by asking `generatedLanguage()` about each one. The rule stays in the class that already owns it, so the three callers cannot drift again.
- `recacheGeneratedLicenses()` now walks that list instead of deriving its own guard from `SourceFile::exists()` on the parent. Its `$lang === $contentLang` skip and the wiki-existence check are unchanged; the ownership question is no longer answered twice.

## How the test covers it

`tests/phpunit/integration/LicensesPageTest.php` drives `generatedCopies()` over a source tree with one translated page (which is what makes `ko` a language the site is built in):

- `testTheCopiesAreTheOnesTheBuildWrote` -- with nothing under `Licenses` in the source tree, `Licenses/ko` is the build's to re-render.
- `testASourceCopyIsNotTheBuildsToRecache` -- the regression: add `Licenses/ko.wikitext` to the source tree and the list is empty, so nothing re-renders it in Korean. Under the old parent-only guard this page was recached, which is the bug. It is the mirror of `DeclarerTest::testASourceCopyIsLeftToTheSite`, which asserted the same source file silences the page-language hook.
- `testASourceLicensesPageLeavesNoCopies` and `testNoLicensesPageMeansNoCopies` pin the two cases the old guard already got right, so the move into `LicensesPage` does not lose them.

`vendor/bin/phpcs -sp` and `vendor/bin/minus-x check .` are clean on the changed files. PHPUnit needs a MediaWiki install, so it was not run here; mago, biome, rumdl and taplo are not installed in this environment either, so the pre-commit hook was skipped for those tasks only.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_