### PR TITLE
fix: stop the build when an image of yours did not import

### DIFF
--- a/includes/ImageImport.php
+++ b/includes/ImageImport.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * What the build hands core's image importer, and what its answer means.
+ *
+ * importImages.php reports "no suitable files could be found for import" with the same false it
+ * reports a failed import with, so its answer on its own cannot tell an image the wiki rejected
+ * from a site that simply ships none. The files the build found before running it settle which of
+ * the two happened.
+ */
+class ImageImport {
+	/**
+	 * The files core's importer will consider, found the way importImages.php finds them.
+	 *
+	 * It reads the top level of the directory only, since the build does not ask it to search
+	 * recursively, and matches on the extension without regard to case.
+	 *
+	 * @param string $directory Source directory, without a trailing slash.
+	 * @param string[] $extensions Allowed extensions, as $wgFileExtensions holds them.
+	 * @return string[] Absolute paths, in the order the directory lists them.
+	 */
+	public static function sources(string $directory, array $extensions): array {
+		if (!is_dir($directory)) {
+			return [];
+		}
+		$allowed = array_map('strtolower', $extensions);
+		$sources = [];
+		foreach (scandir($directory) ?: [] as $entry) {
+			$path = $directory . '/' . $entry;
+			if (!is_file($path)) {
+				continue;
+			}
+			if (in_array(strtolower(pathinfo($entry, PATHINFO_EXTENSION)), $allowed, true)) {
+				$sources[] = $path;
+			}
+		}
+		return $sources;
+	}
+
+	/**
+	 * Whether the importer's return value means an image did not import.
+	 *
+	 * @param mixed $result What ImportImages::execute() returned; false is its failure.
+	 * @param string[] $sources The files it was given, which a false about an empty source has none of.
+	 */
+	public static function failed(mixed $result, array $sources): bool {
+		return $result === false && $sources !== [];
+	}
+}

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -870,11 +870,23 @@ class Build extends Maintenance {
 
 	/** Import source-dir images into the File: namespace so pages render with local thumbnails. */
 	private function importImages(string $file): void {
+		$directory = rtrim($GLOBALS['wgWikvenSourceDirectory'], '/');
+		$extensions = $GLOBALS['wgFileExtensions'];
+		$sources = ImageImport::sources($directory, $extensions);
+
 		$child = $this->createChild(ImportImages::class, $file);
-		$child->setArg(0, rtrim($GLOBALS['wgWikvenSourceDirectory'], '/'));
-		$child->setOption('extensions', implode(',', $GLOBALS['wgFileExtensions']));
+		$child->setArg(0, $directory);
+		$child->setOption('extensions', implode(',', $extensions));
 		$child->setOption('skip-dupes', true);
-		$child->execute();
+		// An image the wiki rejected leaves every page embedding it with a red File: link, so this
+		// step aborts the build the way step() aborts it for a page that did not import. A source
+		// holding no image at all is answered with the same false and is not a failure.
+		if (ImageImport::failed($child->execute(), $sources)) {
+			// The count is of the images offered, not of the ones that failed: the importer's own
+			// summary above holds that number, and it named each file as it choked on it.
+			$count = count($sources);
+			$this->fatalError("Wikven: not all $count image(s) in $directory imported; aborting the build.");
+		}
 	}
 
 	/** Point the wiki's main page at $wgWikvenMainPage (imported later; see assertMainPageExists). */

--- a/tests/phpunit/unit/ImageImportTest.php
+++ b/tests/phpunit/unit/ImageImportTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\ImageImport;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\ImageImport
+ */
+class ImageImportTest extends MediaWikiUnitTestCase {
+	/** The file types a wikven build offers the importer, as $wgFileExtensions holds them. */
+	private const EXTENSIONS = ['png', 'gif', 'jpg', 'jpeg', 'webp', 'svg'];
+
+	private string $directory;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->directory = sys_get_temp_dir() . '/wikven-image-import-' . getmypid() . '-' . uniqid();
+		mkdir($this->directory, 0777, true);
+	}
+
+	protected function tearDown(): void {
+		foreach (glob($this->directory . '/*/*') ?: [] as $path) {
+			unlink($path);
+		}
+		foreach (glob($this->directory . '/*') ?: [] as $path) {
+			if (is_dir($path)) {
+				rmdir($path);
+			} else {
+				unlink($path);
+			}
+		}
+		rmdir($this->directory);
+		parent::tearDown();
+	}
+
+	/** The defect this class exists for: a truncated image aborts the build instead of red-linking. */
+	public function testAnImageTheWikiRejectedFailsTheBuild() {
+		touch($this->directory . '/diagram.png');
+		$sources = ImageImport::sources($this->directory, self::EXTENSIONS);
+
+		$this->assertTrue(ImageImport::failed(false, $sources));
+	}
+
+	/** The trap: core answers a source holding no image with the same false a failed import gets. */
+	public function testASourceWithoutImagesStillBuilds() {
+		touch($this->directory . '/Main Page.wikitext');
+		$sources = ImageImport::sources($this->directory, self::EXTENSIONS);
+
+		$this->assertSame([], $sources);
+		$this->assertFalse(ImageImport::failed(false, $sources));
+	}
+
+	/** Anything but false is the importer saying every image it was given went in. */
+	public function testAnImportThatWentThroughIsNotAFailure() {
+		touch($this->directory . '/diagram.png');
+		$sources = ImageImport::sources($this->directory, self::EXTENSIONS);
+
+		$this->assertFalse(ImageImport::failed(true, $sources));
+		$this->assertFalse(ImageImport::failed(null, $sources));
+	}
+
+	public function testItFindsTheImagesTheImporterWould() {
+		touch($this->directory . '/Bakery oven.jpg');
+		touch($this->directory . '/diagram.PNG');
+		touch($this->directory . '/Main Page.wikitext');
+		touch($this->directory . '/LICENSE');
+
+		$this->assertSame(
+			['Bakery oven.jpg', 'diagram.PNG'],
+			$this->basenames(ImageImport::sources($this->directory, self::EXTENSIONS))
+		);
+	}
+
+	/** The build does not pass --search-recursively, so a subdirectory holds nothing to import. */
+	public function testItLooksNoDeeperThanTheImporterDoes() {
+		mkdir($this->directory . '/Subpage');
+		touch($this->directory . '/Subpage/nested.png');
+
+		$this->assertSame([], ImageImport::sources($this->directory, self::EXTENSIONS));
+	}
+
+	/** A source directory that is not there yet offers nothing, rather than warning about it. */
+	public function testAMissingDirectoryHoldsNoImages() {
+		$this->assertSame([], ImageImport::sources($this->directory . '/gone', self::EXTENSIONS));
+	}
+
+	/**
+	 * @param string[] $paths
+	 * @return string[]
+	 */
+	private function basenames(array $paths): array {
+		$names = array_map('basename', $paths);
+		sort($names);
+		return $names;
+	}
+}


### PR DESCRIPTION
Every build step runs through `step()` (`maintenance/build.php:862`), whose comment states the contract:

```php
// A child returning false signals failure (e.g. a page didn't import); abort the build.
if ($child->execute() === false) {
	$this->fatalError("Wikven: $class reported failures; aborting the build.");
}
```

`importImages()` was the one populate step that bypassed it — `maintenance/build.php:877` called `$child->execute()` and discarded the result. Core's `ImportImages::execute()` ends with `return $statistics['failed'] === 0;`, commented "return false if there are any failed imports (= non-zero exit code)", so the one thing that knew an image had not gone in was thrown away.

### The failure

A source tree holds a truncated `diagram.png`, or one MediaWiki rejects on a MIME/extension mismatch. Core prints

```
Importing diagram.png...failed. (verification-error)
```

inside a wall of import chatter, and returns false. The build ran on to completion and **exited 0**, and every page carrying `[[File:diagram.png]]` shipped a red `File:` link to a page that does not exist. Meanwhile `maintenance/importWikitext.php:99` aborts the build for a page that fails to import, and `maintenance/storeImages.php:76` aborts it rather than "publish output that still hotlinks images". Images fell between those two gates.

### Why the return value cannot simply be read

`importImages.php:158-161` answers an empty source with the same false:

```php
$files = $this->findFiles( $dir, $extensions, $this->hasOption( 'search-recursively' ) );
if ( !$files->valid() ) {
	$this->output( "No suitable files could be found for import.\n" );
	return false;
}
```

Wiring `execute() === false` straight into `fatalError()` would therefore break every site that ships no images of its own — the docs' own `docs/` tree included, were it ever to lose its two photographs.

### The change

`includes/ImageImport.php` — a small class holding the two things the build needs to know:

- `sources()` lists the files core's importer will consider, scanned the way `importImages.php::findFiles()` scans: the top level of the directory only (the build passes no `--search-recursively`), matched on the extension without regard to case.
- `failed()` says whether a return value means an image did not import: false **and** files were offered.

`importImages()` now aborts on that verdict, and names what failed rather than leaning on `step()`'s generic message:

```
Wikven: not all 12 image(s) in /site/source imported; aborting the build.
```

The count is of the images offered, not of the ones that failed — the importer's own summary above it holds that number, and it named each file as it choked on it.

### The test

`tests/phpunit/unit/ImageImportTest.php`:

- `testAnImageTheWikiRejectedFailsTheBuild` — the regression itself: with an image in the source, a false is a failure. Before the fix nothing read that false at all.
- `testASourceWithoutImagesStillBuilds` — the trap: with only a `.wikitext` file in the source, the same false is not a failure.
- `testAnImportThatWentThroughIsNotAFailure` — true, and the null a maintenance script returns when it returns nothing, are both fine.
- `testItFindsTheImagesTheImporterWould` — an uppercase extension counts, a `.wikitext` file and an extensionless one do not.
- `testItLooksNoDeeperThanTheImporterDoes` — a subdirectory holds nothing to import, because the build does not pass `--search-recursively`.
- `testAMissingDirectoryHoldsNoImages`.

`mago format --check`, `mago lint`, `phpcs -sp` and `minus-x check .` are clean locally. PHPUnit needs a MediaWiki install, so it has not been run here.

### Noticed but not fixed

- Core's "a valid title cannot be produced" branch (e.g. an image named `photo[1].png`) does not increment `failed` at all, so even reading the return value misses that case — the file never imports and the page still red-links, with the build none the wiser.
- `skip-dupes` is passed unconditionally (`maintenance/build.php:876`), so a byte-identical image under a second name is silently skipped and its `[[File:…]]` red-links.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_