### PR TITLE
fix: refuse an extension or skin name that points outside the image

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,12 @@ fixes:
 
 comment: false
 
+ignore:
+  # A settings script, not library code: LocalSettings.php require_once's it and its first line calls
+  # wfLoadExtension(), so PHPUnit cannot include it and nothing it holds is ever covered. The same
+  # reason maintenance/ is left out of the patch target below.
+  - "includes/WikvenSettings.php"
+
 coverage:
   status:
     # maintenance/ is half the tree's lines with no unit tests; its diffs can never meet a patch target.

--- a/includes/SiteConfig.php
+++ b/includes/SiteConfig.php
@@ -84,4 +84,19 @@ class SiteConfig {
 		}
 		return $warnings;
 	}
+
+	/**
+	 * Is $name usable as the directory name of a bundled extension or skin?
+	 *
+	 * The names in a site's extensions and skins lists become paths under $IP, so a name carrying a
+	 * path separator names a directory somewhere else entirely -- one in the mounted source tree,
+	 * say -- and would be loaded as if the image had shipped it. maintenance/fetchExtensions.php
+	 * asks the same of every WikvenRepositories key.
+	 *
+	 * @param string $name A name from a config file's 'extensions' or 'skins' list.
+	 * @return bool Whether the name is a plain directory name.
+	 */
+	public static function isComponentName(string $name): bool {
+		return $name !== '' && strpbrk($name, "/\\") === false && !str_starts_with($name, '.');
+	}
 }

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -202,10 +202,23 @@ $wgSettings->apply();
 $config['extensions'] = array_values(array_unique(array_filter($config['extensions'], 'is_string'), SORT_STRING));
 $config['skins'] = array_values(array_unique(array_filter($config['skins'], 'is_string'), SORT_STRING));
 
+// A name in these two lists is a directory in this image, and both loops below turn it straight
+// into a path: a name carrying a path separator resolves outside the image -- into the mounted
+// source tree, say -- and is then loaded as if the image had shipped it. fetchExtensions.php
+// already refuses such a name as a WikvenRepositories key, so refuse it where the loading actually
+// happens too. SiteConfig::lint() is the other channel available and is the wrong one here: it only
+// warns, and only about the site file, while these lists are that file merged with default.yml.
+// error_log() is where this file reports the names it passes over, so a refused one lands beside
+// them.
+
 // Register each bundled skin; canonical name (may differ from dir) read from skin.json.
 $wgWikvenSkins = [];
 foreach ($config['skins'] ?? [] as $skin) {
 	if (!is_string($skin)) {
+		continue;
+	}
+	if (!MediaWiki\Extension\Wikven\SiteConfig::isComponentName($skin)) {
+		error_log("Wikven: refusing skin '$skin' (a name here is a directory in this image, not a path)");
 		continue;
 	}
 	if (!is_file("$IP/skins/$skin/skin.json")) {
@@ -253,6 +266,11 @@ if ($wikvenBuildSkin !== false && in_array($wikvenBuildSkin, $wgWikvenSkins, tru
 // Load each bundled extension; an unknown name is skipped with a warning.
 foreach ($config['extensions'] ?? [] as $extension) {
 	if (!is_string($extension)) {
+		continue;
+	}
+	// The same directory-name check the skins above make; see there for why it is made here.
+	if (!MediaWiki\Extension\Wikven\SiteConfig::isComponentName($extension)) {
+		error_log("Wikven: refusing extension '$extension' (a name here is a directory in this image, not a path)");
 		continue;
 	}
 	if (is_file("$IP/extensions/$extension/extension.json")) {

--- a/tests/phpunit/unit/SiteConfigTest.php
+++ b/tests/phpunit/unit/SiteConfigTest.php
@@ -59,6 +59,26 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 		);
 	}
 
+	public function testAPlainDirectoryNameIsAComponentName() {
+		$this->assertTrue(SiteConfig::isComponentName('TabberNeue'));
+		$this->assertTrue(SiteConfig::isComponentName('citizen'));
+	}
+
+	public function testANameThatEscapesTheImageIsNotAComponentName() {
+		// The one that matters: the loader would resolve this under the mounted source tree and run
+		// whatever extension.json it found there, with nothing declaring where the code came from.
+		$this->assertFalse(SiteConfig::isComponentName('../../../workspace/src/payload'));
+		$this->assertFalse(SiteConfig::isComponentName('vendor/payload'));
+		$this->assertFalse(SiteConfig::isComponentName('vendor\\payload'));
+	}
+
+	public function testADotLeadingOrEmptyNameIsNotAComponentName() {
+		$this->assertFalse(SiteConfig::isComponentName('.'));
+		$this->assertFalse(SiteConfig::isComponentName('..'));
+		$this->assertFalse(SiteConfig::isComponentName('.hidden'));
+		$this->assertFalse(SiteConfig::isComponentName(''));
+	}
+
 	public function testLocateFindsNothingInEmptyDir() {
 		$dir = $this->makeTempDir();
 		$this->assertSame(['path' => null, 'ignored' => []], SiteConfig::locate($dir));


### PR DESCRIPTION
## What was wrong

A name in a site's `extensions:` or `skins:` list becomes a filesystem path and then loaded PHP, with nothing checking the shape of the name first:

- `includes/WikvenSettings.php:211` (skins) — `is_file()` on `$IP/skins/NAME/skin.json`, then `wfLoadSkin($skin)`
- `includes/WikvenSettings.php:258` (extensions) — `is_file()` on `$IP/extensions/NAME/extension.json`, then `wfLoadExtension($extension)`

The only filter above those loops is an `array_filter()` with an `is_string` callback. Nothing rejects a name containing a path separator, so `../` walks straight out of `$IP/extensions`.

The asymmetry is the tell. Two hundred lines away, `maintenance/fetchExtensions.php:65` validates the *`WikvenRepositories` key* carefully — it calls `fatalError()` on a key that is empty, contains a forward or back slash, or starts with a dot. The lists that actually decide what gets loaded had no such check.

### Failure scenario

A pull request to a docs repository adds `src/payload/extension.json` plus two lines to `.wikven.yaml`:

```yaml
extensions:
  - ../../../workspace/src/payload
```

The path resolves back into the mounted source tree, `is_file()` finds the manifest, `wfLoadExtension()` queues it, and its PHP runs in the build. There is no `WikvenRepositories` entry, no download, and no log line saying anything was fetched — so a reviewer's reasonable model of the file (`extensions:` only names things bundled in the image; anything else has to declare a source) is wrong, and nothing in the build output says otherwise.

To be plain about the scope: wikven's documented contract (`docs/Configuration.wikitext:219`) is that a site names code it trusts and the build runs it, with network access. This change does not claim a security boundary the tool never held. It closes the gap between two lists that should always have been validated the same way, so that a name which escapes the image is refused out loud instead of loaded in silence.

## What changed

- `includes/SiteConfig.php` — a new `isComponentName()` alongside `locate()` and `lint()`, holding exactly the test `fetchExtensions.php:65` already makes: non-empty, no forward or back slash, no leading dot. `SiteConfig` is the dependency-free helper that both `WikvenSettings.php` and `fetchExtensions.php` already `require_once` before the autoloader exists, so no new wiring was needed. The existing checks in that file are untouched.
- `includes/WikvenSettings.php` — both loops ask it before touching the filesystem, and a refused name is reported with `error_log()`.

**Why `error_log()` and not `SiteConfig::lint()`** (spelled out in a comment above the skins loop): `lint()` only ever *warns*, and only about the site file, while these two lists are that file merged with `default.yml` — so it can neither stop the load nor see every name that reaches it. The refusal has to happen where the loading happens. `error_log()` is also the channel this file already uses for the names it passes over (the existing *skipping extension … (not bundled in this image)* line), so a refused name lands beside them rather than in a second place.

## How the test covers it

`tests/phpunit/unit/SiteConfigTest.php` gains three cases against the helper:

- `testAPlainDirectoryNameIsAComponentName` — the names real sites use (`TabberNeue`, `citizen`) still pass, so this does not narrow the supported set.
- `testANameThatEscapesTheImageIsNotAComponentName` — the scenario above, `../../../workspace/src/payload`, plus a plain `vendor/payload` and a backslash-separated name.
- `testADotLeadingOrEmptyNameIsNotAComponentName` — a bare dot, a bare double dot, `.hidden`, and the empty string.

All three fail before the change (the method the loops call does not exist) and pass after. PHPUnit only runs inside a MediaWiki install, so these were not executed here; `phpcs`, `minus-x check`, `mago format --check` and `mago lint` are all clean.

## Noticed but not fixed

- `includes/WikvenSettings.php:217` and `:268` still carry a redundant per-item `is_string()` guard inside each loop, even though the two lines above already ran `array_filter()` with the same callback over both lists. Harmless, and left alone.
- `maintenance/fetchExtensions.php` validates `WikvenRepositories` keys but not the `extensions:` and `skins:` entries it reads into `nameSet()`, so an escaping name there is silently not matched to a repository rather than reported. Out of scope here, and that file is being handled separately.