### PR TITLE
chore: keep agent worktrees out of the working tree's status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /.tf/.terraform/
 /.tf/terraform.tfstate
 /.tf/terraform.tfstate.backup
+
+# Claude Code agent worktrees
+/.claude/worktrees/


### PR DESCRIPTION
## What was wrong

Claude Code checks its agents out into `.claude/worktrees/agent-*/`. Those are `git worktree` checkouts of this repository, created and removed around a session, but `git status` reports them as untracked files for as long as they exist — in this session, eight of them at once.

That is noise at best, and at worst an invitation to commit a directory that must never be committed.

## What changed

One entry in `.gitignore`:

```gitignore
# Claude Code agent worktrees
/.claude/worktrees/
```

Scoped to that directory rather than to `.claude/`, so anything a project later chooses to keep under `.claude/` — settings, skills — is still tracked.

## Testing

`git status --porcelain` is empty with eight worktrees present, where it previously listed all eight.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_