### PR TITLE
feat: name the setting core cannot accept

### DIFF
--- a/includes/SiteConfig.php
+++ b/includes/SiteConfig.php
@@ -2,6 +2,8 @@
 
 namespace MediaWiki\Extension\Wikven;
 
+use StatusValue;
+
 /** Helpers for a site's configuration file (accepted .wikven.* names; see CONFIG_FILENAMES). */
 class SiteConfig {
 	/** Top-level keys the settings format recognises. */
@@ -100,6 +102,40 @@ class SiteConfig {
 			}
 		}
 		return $warnings;
+	}
+
+	/**
+	 * Config-schema failures, as lines naming the setting that is wrong.
+	 *
+	 * SettingsBuilder::validate() checks the settings core defines against their schema, which is
+	 * how a site hears that it wrote a list where a number belongs instead of meeting a stack trace
+	 * further into the boot with nothing in it about its own file. Core renders a StatusValue as a
+	 * debug table wrapped at twenty-five characters; the name and the reason are what a person
+	 * needs, so they are pulled out here.
+	 *
+	 * Only errors are read. The validator also warns that it declined to check a map with integer
+	 * keys, which is not something a site can act on and would be printed by every build.
+	 *
+	 * @param StatusValue $status What SettingsBuilder::validate() returned.
+	 * @return string[] One line per failed setting, empty when the config conforms.
+	 */
+	public static function schemaErrors(StatusValue $status): array {
+		$errors = [];
+		foreach ($status->getMessages('error') as $failure) {
+			$parts = [];
+			foreach ($failure->getParams() as $param) {
+				// A parameter reaches here either as the scalar it was raised with or wrapped in a
+				// MessageParam, depending on the version; both carry the same thing to say.
+				if (is_object($param) && method_exists($param, 'getValue')) {
+					$param = $param->getValue();
+				}
+				$parts[] = is_scalar($param) ? (string)$param : get_debug_type($param);
+			}
+			// The message key names the kind of failure, not the setting, so it stands in only when
+			// there is nothing better to show.
+			$errors[] = $parts === [] ? $failure->getKey() : implode(': ', $parts);
+		}
+		return $errors;
 	}
 
 	/**

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -211,6 +211,14 @@ $wgWikvenSourceDirectory = $wikvenPaths['source'];
 $wgWikvenHtmlDirectory = $wikvenPaths['dist'];
 $wgWikvenSourceHistoryFile = $wikvenPaths['history'];
 
+// Say which setting core cannot accept, while the site's file is still the obvious suspect. Without
+// this a wrong-typed value is carried until something reads it, and what the site sees is a stack
+// trace from a part of MediaWiki it never named. This cannot catch a misspelled key: validate()
+// walks the schema's keys rather than the file's, so a name core does not define is never visited.
+foreach (MediaWiki\Extension\Wikven\SiteConfig::schemaErrors($wgSettings->validate()) as $wikvenBadSetting) {
+	error_log("Wikven: WARNING in configuration: $wikvenBadSetting");
+}
+
 // Dedupe so each extension/skin loads at most once.
 $config['extensions'] = array_values(array_unique(array_filter($config['extensions'], 'is_string'), SORT_STRING));
 $config['skins'] = array_values(array_unique(array_filter($config['skins'], 'is_string'), SORT_STRING));

--- a/tests/phpunit/unit/SiteConfigTest.php
+++ b/tests/phpunit/unit/SiteConfigTest.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\Wikven\Tests\Unit;
 
 use MediaWiki\Extension\Wikven\SiteConfig;
 use MediaWikiUnitTestCase;
+use StatusValue;
 
 /**
  * @covers \MediaWiki\Extension\Wikven\SiteConfig
@@ -38,6 +39,29 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 		$warnings = SiteConfig::lint(['config' => ['WikvenSourceDirectory' => '/elsewhere']], self::KNOWN);
 		$this->assertCount(1, $warnings);
 		$this->assertStringNotContainsString('typo', $warnings[0]);
+	}
+
+	public function testAConformingConfigHasNoSchemaErrors() {
+		$this->assertSame([], SiteConfig::schemaErrors(StatusValue::newGood()));
+	}
+
+	public function testASchemaErrorNamesTheSettingAndTheReason() {
+		$status = StatusValue::newGood();
+		$status->fatal('config-invalid-value', 'Sitename', 'expected string, got array');
+		$errors = SiteConfig::schemaErrors($status);
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Sitename', $errors[0]);
+		$this->assertStringContainsString('expected string, got array', $errors[0]);
+	}
+
+	/**
+	 * The validator warns that it skipped a map with integer keys, which no site can act on. Every
+	 * build sets such a map, so reporting warnings would put a line in every build log.
+	 */
+	public function testAValidatorWarningIsNotReportedAsAnError() {
+		$status = StatusValue::newGood();
+		$status->warning('config-invalid-key', 'WikvenLogos', 'Skipping validation of object with integer keys');
+		$this->assertSame([], SiteConfig::schemaErrors($status));
 	}
 
 	public function testUrlTemplateMissingPlaceholderWarns() {


### PR DESCRIPTION
## What was wrong

A site writes MediaWiki settings under `config:` in `.wikven.yaml`, and nothing checked them. `SiteConfig::lint()` catches a few Wikven-specific shapes; everything else went straight to `$wgSettings->loadArray()` and `apply()` unexamined.

**Failure scenario.** A site writes `config: {ContentNamespaces: 0}` where a list belongs. Nothing objects. The value is carried through the boot until something iterates it, and what the site sees is a `foreach` on an integer somewhere inside core — with `.wikven.yaml`, the file that actually needs editing, named nowhere in the trace.

## What changed

`includes/WikvenSettings.php` asks `$wgSettings->validate()` once the merged config has been applied, and prints what it found through the same `error_log()` channel the other config warnings use.

`includes/SiteConfig.php` gains `schemaErrors()`, which turns the returned `StatusValue` into lines naming the setting. Two decisions in there are worth spelling out:

- **Only errors are read** (`getMessages('error')`). `ConfigSchemaAggregator::validateValue()` *warns* — not errors — that it skipped validating a map with integer keys. wikven sets such maps, so reporting warnings would put a line in every build log that no site can act on.
- **Parameters are unwrapped defensively.** A parameter arrives either as the scalar it was raised with or wrapped in a `MessageParam`, depending on the version; both are reduced to the same text. Core's own `StatusValue::__toString()` was not used — it renders a debug table wrapped at 25 characters, which is not what belongs in a build log.

## What this does *not* do

**It does not catch a misspelled key**, and that limit is worth stating because it is the more likely mistake. `ConfigSchemaAggregator::validateConfig()` is:

```php
foreach ( $this->getDefinedKeys() as $key ) {   // the schema's keys, not the file's
```

A name core does not define — `SiteName` for `Sitename` — is never visited, so it cannot be reported. The obvious alternative, comparing the file's keys against `getDefinedConfigKeys()`, does not work at this point either: extensions are still queued when `WikvenSettings.php` runs, so every setting belonging to an extension (`SifterSearchOutputDir`, a skin's options) would be reported as a typo. Catching misspellings needs the check to happen after extensions load, which is a separate change.

## How the tests cover it

Three cases in `tests/phpunit/unit/SiteConfigTest.php`: a good status yields nothing, an error names both the setting and the reason, and a validator *warning* yields nothing.

PHPUnit only runs inside a MediaWiki install, so I exercised `schemaErrors()` directly against stubs shaped like the two parameter forms it has to survive. Both produce the same line:

```
scalar params  -> ["Sitename: expected string, got array"]
wrapped params -> ["Sitename: expected string, got array"]
no params      -> ["config-missing-key"]
warning only   -> []
```

## One thing to watch

Core documents `validate()` as *"slow, so you probably don't want to do this on every request."* `WikvenSettings.php` is loaded once per process, and a build runs the parent plus roughly fifteen child maintenance scripts, so this runs about sixteen times per bake. I could not measure it here — MediaWiki does not boot in this container — so the build timings on this PR are the first real evidence. If it shows, the call is easy to narrow to the parent process or to sites that supplied a `config:` block at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_