### PR TITLE
ci: give every commit type a changelog heading

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -13,7 +13,15 @@
 			"changelog-sections": [
 				{ "type": "feat", "section": "Features" },
 				{ "type": "fix", "section": "Bugfixes" },
-				{ "type": "perf", "section": "Performance" }
+				{ "type": "perf", "section": "Performance" },
+				{ "type": "refactor", "section": "Refactoring", "hidden": true },
+				{ "type": "docs", "section": "Documentation", "hidden": true },
+				{ "type": "build", "section": "Build", "hidden": true },
+				{ "type": "ci", "section": "Continuous integration", "hidden": true },
+				{ "type": "chore", "section": "Chores", "hidden": true },
+				{ "type": "test", "section": "Tests", "hidden": true },
+				{ "type": "style", "section": "Styling", "hidden": true },
+				{ "type": "revert", "section": "Reverts", "hidden": true }
 			]
 		}
 	}


### PR DESCRIPTION
The 1.0.0 notes carry a lower-case `### refactor` heading between the title-case sections around it. This is why, and it is not specific to `refactor`.

## What is happening

`.release-please-config.json` declares three types, and release-please hands that list straight to conventional-changelog's preset as its `types`. The preset's writer then does this:

```js
let discard = true
const entry = findTypeEntry(finalConfig.types, commit)
const notes = getNotes(commit).map((note) => { discard = false; ... })

if (discard && (entry === undefined || isTypeEffect(entry, 'hidden')) || !matchScope(...)) {
  return undefined
}

const type = entry ? entry.section : commit.type
```

Two things follow.

**A commit with a BREAKING CHANGE note is never dropped.** `discard` is set false the moment the commit has notes, and only then is the type consulted. So `refactor!: group the composite actions under actions/` appears no matter what the configuration says.

**Its heading is the raw type when nobody declared it.** `entry ? entry.section : commit.type` — with no entry for `refactor`, the word `refactor` becomes the heading.

Every undeclared type was one breaking change away from the same thing: `docs!`, `chore!`, `ci!`, `build!`, `test!`, `style!`.

## What changed

The ten types this repository actually uses now each have a section name. `feat`, `fix` and `perf` keep the headings and the visibility they already had; the other seven are `hidden: true`, as is `revert`, which the repository has not used yet but the format defines.

`hidden` decides only whether an *ordinary* commit of that type is listed, and that is unchanged — a `docs:` commit is still not in the notes. The one thing this adds is the heading a breaking change of that type will wear when it comes.

## Effect on the pending 1.0.0 notes

One heading: `### refactor` becomes `### Refactoring`. Nothing is added and nothing is removed, because the only breaking commit of an undeclared type is that one.

Two historical types are left undeclared on purpose: `deploy` and `action`, one commit each from before the semantic-pull-request check was in place. Neither is breaking, so neither can surface, and the check will not let a third one in.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_