### PR TITLE
ci: let the release pull request go green

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,8 @@
 [files]
-extend-exclude = ["package-lock.json"]
+# CHANGELOG.md is generated from a year of commit subjects, and every entry carries the commit's
+# short hash: "b5d3ba3" reads as a misspelling of "by". The subjects are in history and cannot be
+# corrected now, so nothing here is actionable.
+extend-exclude = ["package-lock.json", "CHANGELOG.md"]
 
 [default]
 extend-ignore-re = [

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": true,
-		"includes": ["**", "!package-lock.json"]
+		"includes": ["**", "!package-lock.json", "!extension.json"]
 	},
 	"formatter": {
 		"enabled": true


### PR DESCRIPTION
**#30, the 1.0.0 release pull request, is red** — `biome` and `typos` both fail on it. Neither failure is about the release; both are two tools disagreeing about a generated file. Until they are fixed, 1.0.0 cannot merge.

## `biome` — `extension.json`

`biome.json` includes `"**"` with the formatter on, so it formats `extension.json` and wants a short array on one line. release-please rewrites the same file to bump the version, parsing and re-dumping it, which expands every array. Its own log names the collision:

```
185 │ - → → ]
    150 │ + → → "Wikven":·["i18n"]
```

Only one of the two can own that file's shape, and it has to be release-please, because **the version it writes is not decoration**. `maintenance/build.php:1198` lists every registered extension on the Licenses page of every site wikven builds — wikven among them — reading exactly this field:

```php
foreach (ExtensionRegistry::getInstance()->getAllThings() as $thingName => $credits) { ... }
// ... $credits['version'] ?? ''
```

Left unwritten it would say `0.1.0` on every built site forever; removed, it would leave a blank where a version goes. So biome steps back from this one file and keeps the other forty.

*(I had originally proposed the opposite — dropping `extension.json` from release-please's `extra-files` — and reversed it on finding that call site. `UserAgent.php` also reads the field, but that one could have moved; the Licenses page is what settles it.)*

## `typos` — the generated `CHANGELOG.md`

```
error: `ba` should be `by`, `be`
222 │ …([b5d3ba3](https://github.com/chaotic-ground/wikven/commit/b5d3ba32…
```

release-please generates the changelog from a year of commit subjects, each carrying its commit's short hash, and a spell checker reads `b5d3ba3` as a misspelling of `by`. Five of them fail the run. Those subjects are in history and cannot be corrected now, so there is nothing actionable in the file.

`CHANGELOG.md` joins `package-lock.json` in the exclusions — beside the two hex-shaped exceptions `.typos.toml` already carries, for translation stamps and Pagefind index names.

## Verified against the release pull request's own files

I installed the pinned `biome` (2.5.10) and `typos` (1.40.1), put #30's `extension.json` and `CHANGELOG.md` into the tree, and ran both:

| | before | after |
|---|---|---|
| `typos` | 5 errors | exit 0 |
| `biome ci` | 41 files, 1 error | 40 files, clean |

`jsonlint` and `taplo check` are clean on the two edited files.

## What this does not do

It does not stop the release commit reflowing `extension.json` — after this, that is release-please's file to shape, so the first release expands it once and every release after that is a one-line version change. It also does not touch the changelog's contents; that is [#8 on the list](https://github.com/chaotic-ground/wikven/pull/30) and comes last, after everything else has landed on main.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_