### PR TITLE
feat: name a setting that belongs to no one

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -105,6 +105,15 @@ jobs:
           # The main page must land at the dist root (a failed import already aborted the build).
           test -s dist/index.html
 
+          # A bake with something to say about the site's own configuration says it and carries on,
+          # so a warning is only ever seen by whoever reads the log. docs/.wikven.yaml is the
+          # configuration wikven recommends; a warning about it is a mistake either in that file or
+          # in the code that reports on it, and both are worth stopping for.
+          if grep -h 'Wikven: WARNING' bake.log bake-again.log; then
+            echo "::error::the bake warned about docs/.wikven.yaml"
+            exit 1
+          fi
+
           # Dumped CSS must not reference load.php (a live-only endpoint); a leftover is an AssetLocalizer regression.
           if grep -rIl --include='*.css' 'load\.php' dist; then
             echo "::error::dumped CSS still references load.php (AssetLocalizer regression)"

--- a/docs/Troubleshooting.wikitext
+++ b/docs/Troubleshooting.wikitext
@@ -39,7 +39,7 @@ The standalone binary is Linux-only (x86_64 and arm64). On macOS or Windows, use
 == A setting in <code>.wikven.yaml</code> does nothing ==
 
 <!--T:13-->
-Read the build log first: it warns about the mistakes it can see. <code>unknown config 'Wikven...'</code> means a variable that is not one of {{SITENAME}}'s — a typo, most often, since a name it does not recognise is otherwise applied and ignored. <code>unknown top-level key</code> means a setting outside <code>config</code>, <code>extensions</code> or <code>skins</code>. A URL template warning means <code>WikvenEditUrl</code> and friends are missing their <code>$1</code>.
+Read the build log first: it warns about the mistakes it can see. <code>unknown config</code> means a name nothing loaded here defines — a typo, most often, since a name nobody owns is otherwise applied and ignored; the warning names the closest setting it does know of. It waits until every extension and skin your site lists is installed, because a setting can belong to any of them. <code>unknown top-level key</code> means a setting outside <code>config</code>, <code>extensions</code> or <code>skins</code>. A URL template warning means <code>WikvenEditUrl</code> and friends are missing their <code>$1</code>.
 
 <!--T:14-->
 A silent one to check by eye: a <code>config</code> value '''replaces''' the default rather than merging with it, so a list or map you set has to carry every entry you want, including the ones you were happy with. See [[<tvar name="1">Special:MyLanguage/Configuration</tvar>|Configuration]].

--- a/docs/Troubleshooting/ko.wikitext
+++ b/docs/Troubleshooting/ko.wikitext
@@ -37,8 +37,8 @@
 <!--T:12 @acfea82d-->
 == <code>.wikven.yaml</code>의 설정이 아무 일도 하지 않습니다 ==
 
-<!--T:13 @6b5fbe0e-->
-먼저 빌드 로그를 읽으십시오. 눈에 보이는 실수는 로그가 경고합니다. <code>unknown config 'Wikven...'</code>은 {{SITENAME}}의 변수가 아니라는 뜻이고, 대개 오타입니다. 알아보지 못한 이름도 그냥 적용된 뒤 무시되기 때문입니다. <code>unknown top-level key</code>는 <code>config</code>, <code>extensions</code>, <code>skins</code> 바깥에 있는 설정을 뜻합니다. URL 템플릿 경고는 <code>WikvenEditUrl</code>과 그 짝들에 <code>$1</code>이 빠졌다는 뜻입니다.
+<!--T:13 @551dd5c4-->
+먼저 빌드 로그를 읽으십시오. 눈에 보이는 실수는 로그가 경고합니다. <code>unknown config</code>는 여기에 불러온 것 중 어느 것도 정의하지 않는 이름이라는 뜻이고, 대개 오타입니다. 임자가 없는 이름도 그냥 적용된 뒤 무시되기 때문입니다. 경고는 알고 있는 설정 가운데 가장 가까운 이름을 함께 알려줍니다. 이 검사는 사이트가 나열한 확장 기능과 스킨이 모두 설치된 뒤에야 이루어집니다. 설정이 그중 어느 것에 속할 수도 있기 때문입니다. <code>unknown top-level key</code>는 <code>config</code>, <code>extensions</code>, <code>skins</code> 바깥에 있는 설정을 뜻합니다. URL 템플릿 경고는 <code>WikvenEditUrl</code>과 그 짝들에 <code>$1</code>이 빠졌다는 뜻입니다.
 
 <!--T:14 @e5404df9-->
 로그에 나오지 않아 직접 확인해야 하는 것이 하나 있습니다. <code>config</code> 값은 기본값과 합쳐지지 않고 '''대체'''하므로, 목록이나 맵을 설정할 때는 그대로 두고 싶었던 항목까지 모두 적어야 합니다. [[$1|설정]]을 참고하십시오.

--- a/includes/SiteConfig.php
+++ b/includes/SiteConfig.php
@@ -62,11 +62,14 @@ class SiteConfig {
 	/**
 	 * Lint decoded site-config contents, returning a warning per silently-dropped mistake.
 	 *
+	 * About shape and values only. Whether a name under "config" is one anything defines is
+	 * undefinedConfig()'s question, and it cannot be asked this early: the extensions that would
+	 * answer it are still queued when a site's file is read.
+	 *
 	 * @param mixed $data Decoded .wikven.yaml/.json contents.
-	 * @param string[] $knownConfig Canonical Wikven config variable names, from extension.json.
 	 * @return string[] Warning messages, empty when the file is sound.
 	 */
-	public static function lint($data, array $knownConfig): array {
+	public static function lint($data): array {
 		if (!is_array($data)) {
 			return ['the file is not a map; ignoring it.'];
 		}
@@ -89,8 +92,6 @@ class SiteConfig {
 		foreach (array_keys($config) as $cfgKey) {
 			if (in_array($cfgKey, self::DERIVED_CONFIG, true)) {
 				$warnings[] = "'$cfgKey' is worked out from WIKVEN_WORKDIR by the build; the value here is ignored.";
-			} elseif (str_starts_with($cfgKey, 'Wikven') && !in_array($cfgKey, $knownConfig, true)) {
-				$warnings[] = "unknown config '$cfgKey' (not a Wikven variable; typo?).";
 			}
 		}
 
@@ -154,6 +155,101 @@ class SiteConfig {
 			$errors[] = $parts === [] ? $failure->getKey() : implode(': ', $parts);
 		}
 		return $errors;
+	}
+
+	/**
+	 * Config names declared by a set of extension and skin manifests, as a lookup set.
+	 *
+	 * A manifest declares its settings in a "config" map, and ExtensionRegistry turns each name in
+	 * it straight into a global. Nothing on that path reaches the schema SettingsBuilder validates
+	 * against, so core is never in a position to say that a name a site wrote belongs to no one.
+	 * Reading the manifests is what is left.
+	 *
+	 * A manifest declaring a prefix other than "wg" is skipped whole. A site's file reaches globals
+	 * through $wgSettings, which writes that prefix and no other, so those settings cannot be
+	 * written from a config file at all, and counting them as known would say they can.
+	 *
+	 * @param string[] $manifestPaths Absolute paths to extension.json/skin.json files.
+	 * @return array<string,true> Config names, as keys.
+	 */
+	public static function manifestConfigNames(array $manifestPaths): array {
+		$names = [];
+		foreach ($manifestPaths as $manifestPath) {
+			$declared = is_readable($manifestPath)
+				? json_decode((string)file_get_contents($manifestPath), true)
+				: null;
+			if (!is_array($declared) || !is_array($declared['config'] ?? null)) {
+				continue;
+			}
+			$config = $declared['config'];
+			// Manifest version 1 spells the prefix inside the config map, version 2 beside it.
+			$prefix = $config['_prefix'] ?? $declared['config_prefix'] ?? 'wg';
+			unset($config['_prefix']);
+			if ($prefix !== 'wg') {
+				continue;
+			}
+			foreach (array_keys($config) as $name) {
+				$names[(string)$name] = true;
+			}
+		}
+		return $names;
+	}
+
+	/**
+	 * Config names a site wrote that nothing defines, each with a near miss where there is one.
+	 *
+	 * This is the quietest mistake a config file can make: the name is written into a global, no
+	 * code ever reads that global, and the build succeeds having ignored the line. Every other
+	 * report in this class is about a value; this one is about a name.
+	 *
+	 * @param string[] $configKeys The names under "config" in the site's file.
+	 * @param string[] $defined Every config name something here defines.
+	 * @return string[] One warning per undefined name, empty when every name is somebody's.
+	 */
+	public static function undefinedConfig(array $configKeys, array $defined): array {
+		$known = array_fill_keys($defined, true);
+		$warnings = [];
+		foreach ($configKeys as $configKey) {
+			$name = (string)$configKey;
+			if (isset($known[$name])) {
+				continue;
+			}
+			$nearest = self::nearestName($name, $defined);
+			$warnings[] = $nearest === null
+				? "unknown config '$name'; nothing loaded here defines it, and it is ignored."
+				: "unknown config '$name'; nothing loaded here defines it. Did you mean '$nearest'?";
+		}
+		return $warnings;
+	}
+
+	/**
+	 * The defined name closest to $name, or null when none of them is close enough to suggest.
+	 *
+	 * A misspelling is a character or two out. Past that a suggestion is a guess, and offering one
+	 * costs more than the warning gains: a site told it meant something else goes and reads about
+	 * a setting it never wanted. The allowance grows with the name, because a short name reaches an
+	 * unrelated one in fewer edits than a long one does.
+	 *
+	 * @param string $name A config name nothing defines.
+	 * @param string[] $defined Every config name something here defines.
+	 * @return ?string
+	 */
+	private static function nearestName(string $name, array $defined): ?string {
+		$allowed = max(1, intdiv(strlen($name), 4));
+		$nearest = null;
+		$distance = $allowed + 1;
+		foreach ($defined as $candidate) {
+			$candidate = (string)$candidate;
+			if (abs(strlen($candidate) - strlen($name)) > $allowed) {
+				continue;
+			}
+			$candidateDistance = levenshtein($name, $candidate);
+			if ($candidateDistance < $distance) {
+				$nearest = $candidate;
+				$distance = $candidateDistance;
+			}
+		}
+		return $nearest;
 	}
 
 	/**

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -362,8 +362,11 @@ if ($wikvenSiteFile !== null && $wikvenAllPresent) {
 			array_keys($wikvenUnaccounted),
 			array_keys($wikvenDefined)
 		);
+		// Named again rather than carried down from the read above: the name is only ever set
+		// alongside a file, and the guard on this block is the file.
+		$wikvenReportedFile = basename($wikvenSiteFile);
 		foreach ($wikvenUndefined as $wikvenWarning) {
-			error_log("Wikven: WARNING in $wikvenSiteName: $wikvenWarning");
+			error_log("Wikven: WARNING in $wikvenReportedFile: $wikvenWarning");
 		}
 	}
 }

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -155,10 +155,6 @@ if ($wikvenConvert === null || $wikvenRsvg === null) {
 // Load config: default.yml then the site file via $wgSettings; ext/skin lists loaded leniently.
 global $wgSettings;
 
-// Known config names from extension.json, used to flag misspelled keys.
-$wikvenManifest = json_decode(file_get_contents("$IP/extensions/Wikven/extension.json"), true);
-$wikvenKnownConfig = array_keys($wikvenManifest['config'] ?? []);
-
 // Autoloader not active yet at LocalSettings time; load the helper directly.
 require_once "$IP/extensions/Wikven/includes/SiteConfig.php";
 
@@ -183,7 +179,7 @@ if ($wikvenSiteFile !== null) {
 		: new MediaWiki\Settings\Source\Format\YamlFormat();
 	$wikvenSiteData = $wikvenSiteFormat->decode(file_get_contents($wikvenSiteFile));
 	$wikvenSiteName = basename($wikvenSiteFile);
-	foreach (MediaWiki\Extension\Wikven\SiteConfig::lint($wikvenSiteData, $wikvenKnownConfig) as $wikvenWarning) {
+	foreach (MediaWiki\Extension\Wikven\SiteConfig::lint($wikvenSiteData) as $wikvenWarning) {
 		error_log("Wikven: WARNING in $wikvenSiteName: $wikvenWarning");
 	}
 }
@@ -232,6 +228,10 @@ $config['skins'] = array_values(array_unique(array_filter($config['skins'], 'is_
 // error_log() is where this file reports the names it passes over, so a refused one lands beside
 // them.
 
+// Anything named below that is not on disk is a name whose settings nobody here can account for;
+// the report at the end of this file says why that silences it.
+$wikvenAllPresent = true;
+
 // Register each bundled skin; canonical name (may differ from dir) read from skin.json.
 $wgWikvenSkins = [];
 foreach ($config['skins'] ?? [] as $skin) {
@@ -240,10 +240,12 @@ foreach ($config['skins'] ?? [] as $skin) {
 	}
 	if (!MediaWiki\Extension\Wikven\SiteConfig::isComponentName($skin)) {
 		error_log("Wikven: refusing skin '$skin' (a name here is a directory in this image, not a path)");
+		$wikvenAllPresent = false;
 		continue;
 	}
 	if (!is_file("$IP/skins/$skin/skin.json")) {
 		error_log("Wikven: skipping skin '$skin' (not bundled in this image)");
+		$wikvenAllPresent = false;
 		continue;
 	}
 	wfLoadSkin($skin);
@@ -292,12 +294,14 @@ foreach ($config['extensions'] ?? [] as $extension) {
 	// The same directory-name check the skins above make; see there for why it is made here.
 	if (!MediaWiki\Extension\Wikven\SiteConfig::isComponentName($extension)) {
 		error_log("Wikven: refusing extension '$extension' (a name here is a directory in this image, not a path)");
+		$wikvenAllPresent = false;
 		continue;
 	}
 	if (is_file("$IP/extensions/$extension/extension.json")) {
 		wfLoadExtension($extension);
 	} else {
 		error_log("Wikven: skipping extension '$extension' (not bundled in this image)");
+		$wikvenAllPresent = false;
 	}
 }
 
@@ -330,6 +334,38 @@ if (
 	&& !array_key_exists('SifterSearchOutputDir', $wikvenSiteConfig)
 ) {
 	$GLOBALS['wgSifterSearchOutputDir'] = "$wikvenDist/pagefind";
+}
+
+// Say which config names nothing defines, now that everything that could define one is queued.
+// This is the quietest way a line in a site's file is lost: $wgSettings writes the name into a
+// global, no code ever reads that global, and the build succeeds having ignored the line. Core is
+// not in a position to report it -- validate() walks the schema's keys rather than the file's, and
+// an extension's settings never reach that schema at all, ExtensionRegistry writing them straight
+// to globals -- so the queued manifests are read here instead. getQueue() is the installer's, and
+// used here because at this point in the boot it is the only complete answer to what is about to
+// load; a wrong answer costs a warning either way and never a build.
+//
+// Silent while a name in this site's lists is missing from the image, because the extensions that
+// would account for its settings are exactly the ones that are not there. fetchExtensions.php
+// boots this file to install them, and so boots it before they exist.
+if ($wikvenSiteFile !== null && $wikvenAllPresent) {
+	// Core's names are already in hand, and most of a config file is core settings. Only what they
+	// leave over is worth opening two dozen manifests for, which is usually nothing at all -- and
+	// this runs in every process a build starts.
+	$wikvenDefined = array_fill_keys($wgSettings->getDefinedConfigKeys(), true);
+	$wikvenUnaccounted = array_diff_key($wikvenSiteConfig, $wikvenDefined);
+	if ($wikvenUnaccounted !== []) {
+		$wikvenDefined += MediaWiki\Extension\Wikven\SiteConfig::manifestConfigNames(
+			array_keys(MediaWiki\Registration\ExtensionRegistry::getInstance()->getQueue())
+		);
+		$wikvenUndefined = MediaWiki\Extension\Wikven\SiteConfig::undefinedConfig(
+			array_keys($wikvenUnaccounted),
+			array_keys($wikvenDefined)
+		);
+		foreach ($wikvenUndefined as $wikvenWarning) {
+			error_log("Wikven: WARNING in $wikvenSiteName: $wikvenWarning");
+		}
+	}
 }
 
 // WikvenLogos ($wgWikvenLogos) mirrors $wgLogos but each src is a source-dir file name, resolved

--- a/tests/phpunit/unit/SiteConfigTest.php
+++ b/tests/phpunit/unit/SiteConfigTest.php
@@ -11,15 +11,13 @@ use StatusValue;
  * @covers \MediaWiki\Extension\Wikven\SiteConfig
  */
 class SiteConfigTest extends MediaWikiUnitTestCase {
-	private const KNOWN = ['WikvenFooterUrl', 'WikvenEditUrl', 'WikvenMainPage', 'WikvenBuildFor'];
-
 	public function testSoundFileHasNoWarnings() {
 		$data = [
 			'config' => ['WikvenEditUrl' => 'https://example.org/edit/$1', 'Sitename' => 'S'],
 			'extensions' => ['Foo'],
 			'skins' => ['Vector']
 		];
-		$this->assertSame([], SiteConfig::lint($data, self::KNOWN));
+		$this->assertSame([], SiteConfig::lint($data));
 	}
 
 	/**
@@ -29,7 +27,7 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 	 */
 	public function testAPathTheBuildDerivesForItselfWarns() {
 		foreach (SiteConfig::DERIVED_CONFIG as $derived) {
-			$warnings = SiteConfig::lint(['config' => [$derived => '/elsewhere']], self::KNOWN);
+			$warnings = SiteConfig::lint(['config' => [$derived => '/elsewhere']]);
 			$this->assertCount(1, $warnings, "expected one warning for '$derived'");
 			$this->assertStringContainsString("'$derived' is worked out from WIKVEN_WORKDIR", $warnings[0]);
 		}
@@ -37,7 +35,7 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 
 	/** A derived key is a real Wikven variable, so it must not also be reported as a typo. */
 	public function testADerivedPathIsNotReportedAsAnUnknownVariable() {
-		$warnings = SiteConfig::lint(['config' => ['WikvenSourceDirectory' => '/elsewhere']], self::KNOWN);
+		$warnings = SiteConfig::lint(['config' => ['WikvenSourceDirectory' => '/elsewhere']]);
 		$this->assertCount(1, $warnings);
 		$this->assertStringNotContainsString('typo', $warnings[0]);
 	}
@@ -67,7 +65,7 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 
 	public function testEveryAudienceBuildForKnowsPassesLint() {
 		foreach (BuildFor::all() as $audience) {
-			$this->assertSame([], SiteConfig::lint(['config' => ['WikvenBuildFor' => $audience]], self::KNOWN));
+			$this->assertSame([], SiteConfig::lint(['config' => ['WikvenBuildFor' => $audience]]));
 		}
 	}
 
@@ -76,7 +74,7 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 	 * one. A near miss is exactly what a person wants told back to them.
 	 */
 	public function testAnAudienceBuildForDoesNotKnowIsNamed() {
-		$warnings = SiteConfig::lint(['config' => ['WikvenBuildFor' => 'sit']], self::KNOWN);
+		$warnings = SiteConfig::lint(['config' => ['WikvenBuildFor' => 'sit']]);
 		$this->assertCount(1, $warnings);
 		$this->assertStringContainsString("'WikvenBuildFor' is 'sit'", $warnings[0]);
 		$this->assertStringContainsString('skin-preview', $warnings[0]);
@@ -84,48 +82,45 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 
 	/** A value of the wrong kind is named by its type, so "true" does not read as the string 1. */
 	public function testAnAudienceOfTheWrongTypeIsNamedByItsType() {
-		$warnings = SiteConfig::lint(['config' => ['WikvenBuildFor' => true]], self::KNOWN);
+		$warnings = SiteConfig::lint(['config' => ['WikvenBuildFor' => true]]);
 		$this->assertCount(1, $warnings);
 		$this->assertStringContainsString('is bool;', $warnings[0]);
 	}
 
 	public function testUrlTemplateMissingPlaceholderWarns() {
-		$warnings = SiteConfig::lint(['config' => ['WikvenEditUrl' => 'https://example.org/edit']], self::KNOWN);
+		$warnings = SiteConfig::lint(['config' => ['WikvenEditUrl' => 'https://example.org/edit']]);
 		$this->assertCount(1, $warnings);
 		$this->assertStringContainsString("'WikvenEditUrl' should be a URL template containing", $warnings[0]);
 	}
 
 	public function testNonMapValueWarns() {
-		$warnings = SiteConfig::lint(['config' => ['WikvenLogos' => 'logo.png']], self::KNOWN);
+		$warnings = SiteConfig::lint(['config' => ['WikvenLogos' => 'logo.png']]);
 		$this->assertContains("'WikvenLogos' must be a map.", $warnings);
 	}
 
 	public function testNonMapIsRejected() {
-		$this->assertSame(['the file is not a map; ignoring it.'], SiteConfig::lint('oops', self::KNOWN));
+		$this->assertSame(['the file is not a map; ignoring it.'], SiteConfig::lint('oops'));
 	}
 
 	public function testUnknownTopLevelKeyWarns() {
-		$warnings = SiteConfig::lint(['extension' => ['Foo']], self::KNOWN);
+		$warnings = SiteConfig::lint(['extension' => ['Foo']]);
 		$this->assertCount(1, $warnings);
 		$this->assertStringContainsString("unknown top-level key 'extension'", $warnings[0]);
 	}
 
 	public function testWrongTypedListWarns() {
-		$warnings = SiteConfig::lint(['extensions' => 'Foo'], self::KNOWN);
+		$warnings = SiteConfig::lint(['extensions' => 'Foo']);
 		$this->assertContains("'extensions' must be a list.", $warnings);
 	}
 
-	public function testMisspelledWikvenVariableWarns() {
-		$warnings = SiteConfig::lint(['config' => ['WikvenFooterURL' => 'x']], self::KNOWN);
-		$this->assertCount(1, $warnings);
-		$this->assertStringContainsString("unknown config 'WikvenFooterURL'", $warnings[0]);
-	}
-
-	public function testNonWikvenConfigKeyIsNotFlagged() {
-		$this->assertSame(
-			[],
-			SiteConfig::lint(['config' => ['Sitename' => 'S', 'Localtimezone' => 'UTC']], self::KNOWN)
-		);
+	/**
+	 * Whose a name is takes reading the manifests of everything queued, which is not something
+	 * lint() is in a position to do: it runs while a site's file is being read, and the extensions
+	 * that would answer are still queued. undefinedConfig() below is where that question is asked.
+	 */
+	public function testLintDoesNotJudgeWhetherAConfigNameExists() {
+		$this->assertSame([], SiteConfig::lint(['config' => ['WikvenFooterURL' => 'x']]));
+		$this->assertSame([], SiteConfig::lint(['config' => ['Sitename' => 'S', 'Localtimezone' => 'UTC']]));
 	}
 
 	public function testAPlainDirectoryNameIsAComponentName() {
@@ -172,6 +167,114 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 		$this->assertSame(["$dir/.wikven.yml", "$dir/wikven.json"], $located['ignored']);
 	}
 
+	public function testManifestConfigNamesCollectsEveryNameDeclared() {
+		$names = SiteConfig::manifestConfigNames([
+			$this->makeManifest([
+				'config' => ['SifterSearchOutputDir' => ['value' => ''], 'SifterSearchBinary' => ['value' => '']]
+			]),
+			$this->makeManifest(['config' => ['CitizenEnableManifest' => ['value' => true]]])
+		]);
+		$this->assertSame(
+			['SifterSearchOutputDir', 'SifterSearchBinary', 'CitizenEnableManifest'],
+			array_keys($names)
+		);
+	}
+
+	/**
+	 * A site's file reaches globals through $wgSettings, which writes the "wg" prefix and no other,
+	 * so a setting behind a different prefix cannot be written from one at all. Counting it as
+	 * known would tell a site that wrote it that the line was taken.
+	 */
+	public function testManifestConfigNamesSkipsAManifestBehindAnotherPrefix() {
+		$this->assertSame(
+			[],
+			SiteConfig::manifestConfigNames([
+				$this->makeManifest(['config_prefix' => 'eg', 'config' => ['Something' => ['value' => 1]]])
+			])
+		);
+		$this->assertSame(
+			[],
+			SiteConfig::manifestConfigNames([
+				$this->makeManifest(['config' => ['_prefix' => 'eg', 'Something' => 1]])
+			])
+		);
+	}
+
+	/** manifest_version 1 declares the prefix inside the map; the names beside it are still names. */
+	public function testManifestConfigNamesReadsAVersionOneManifest() {
+		$names = SiteConfig::manifestConfigNames([
+			$this->makeManifest(['config' => ['_prefix' => 'wg', 'FooBar' => 1]])
+		]);
+		$this->assertSame(['FooBar'], array_keys($names));
+	}
+
+	public function testManifestConfigNamesIgnoresAnUnreadableOrConfiglessManifest() {
+		$this->assertSame(
+			[],
+			SiteConfig::manifestConfigNames([
+				'/nonexistent/extension.json',
+				$this->makeManifest(['name' => 'NoSettingsHere'])
+			])
+		);
+	}
+
+	public function testANameSomethingDefinesIsNotReported() {
+		$this->assertSame(
+			[],
+			SiteConfig::undefinedConfig(['Sitename', 'WikvenEditUrl'], ['Sitename', 'WikvenEditUrl'])
+		);
+	}
+
+	/**
+	 * The whole point: a name nobody defines is written into a global that nothing reads, and the
+	 * build then succeeds having ignored the line.
+	 */
+	public function testANameNothingDefinesIsReportedWithItsNearestMatch() {
+		$warnings = SiteConfig::undefinedConfig(['EnableUpoads'], ['EnableUploads', 'Sitename']);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString("unknown config 'EnableUpoads'", $warnings[0]);
+		$this->assertStringContainsString("Did you mean 'EnableUploads'?", $warnings[0]);
+	}
+
+	/** Nothing is close, so nothing is suggested: a wrong suggestion sends a site off reading. */
+	public function testANameLikeNothingDefinedIsReportedWithoutASuggestion() {
+		$warnings = SiteConfig::undefinedConfig(['Nonsense'], ['EnableUploads', 'Sitename']);
+		$this->assertCount(1, $warnings);
+		$this->assertStringNotContainsString('Did you mean', $warnings[0]);
+	}
+
+	/** Two candidates are near; the nearer one is the one worth naming. */
+	public function testTheNearestOfSeveralCandidatesIsSuggested() {
+		$warnings = SiteConfig::undefinedConfig(
+			['WikvenFooterUrl'],
+			['WikvenFooterURL', 'WikvenFooterText']
+		);
+		$this->assertStringContainsString("Did you mean 'WikvenFooterURL'?", $warnings[0]);
+	}
+
+	/**
+	 * A short name reaches an unrelated one in very few edits, so the allowance grows with length:
+	 * "Foo" must not be answered with "Bar".
+	 */
+	public function testAShortNameIsNotMatchedToAnUnrelatedOne() {
+		$warnings = SiteConfig::undefinedConfig(['Foo'], ['Bar']);
+		$this->assertStringNotContainsString('Did you mean', $warnings[0]);
+	}
+
+	/**
+	 * @param array $manifest Decoded manifest contents.
+	 * @return string Path to a file holding it.
+	 */
+	private function makeManifest(array $manifest): string {
+		$path = sys_get_temp_dir() . '/wikven-manifest-' . uniqid() . '.json';
+		file_put_contents($path, json_encode($manifest));
+		$this->filesToClean[] = $path;
+		return $path;
+	}
+
+	/** @var string[] */
+	private array $filesToClean = [];
+
 	private function makeTempDir(): string {
 		$dir = sys_get_temp_dir() . '/wikven-locate-' . uniqid();
 		mkdir($dir);
@@ -183,6 +286,11 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 	private array $dirsToClean = [];
 
 	protected function tearDown(): void {
+		foreach ($this->filesToClean as $file) {
+			if (is_file($file)) {
+				unlink($file);
+			}
+		}
 		foreach ($this->dirsToClean as $dir) {
 			foreach (SiteConfig::CONFIG_FILENAMES as $name) {
 				if (is_file("$dir/$name")) {


### PR DESCRIPTION
A config file's quietest mistake is a misspelled name. `$wgSettings` writes it into a global, nothing ever reads that global, and the build succeeds having ignored the line — the site is left looking for the effect of a setting it believes it made.

## Why nothing reported it

- `SettingsBuilder::validate()` walks the **schema's** keys (`ConfigSchemaAggregator::validateConfig()` does `foreach ($this->getDefinedKeys() as $key)`), so a name core does not define is never visited.
- An extension's settings never reach that schema at all: `ExtensionProcessor::extractConfig2()` hands each one to `addConfigGlobal()`, and `ExtensionRegistry::exportExtractedData()` writes it straight to `$GLOBALS`.
- `SiteConfig::lint()` covered the one case it could reach on its own — names beginning with `Wikven` — by reading wikven's own `extension.json`. It runs while the site's file is being read, when every other extension is still queued.

## What this does

Asks the question where it can be answered in full: at the end of `WikvenSettings.php`, with everything that could define a setting queued.

- Core's own names come from `$wgSettings->getDefinedConfigKeys()` (core's schema is loaded before `LocalSettings.php`, at `Setup.php:148`).
- Whatever they leave over — usually nothing, since most of a config file is core settings — is looked for in the `config` map of every queued manifest. A manifest behind a `config_prefix` other than `wg` is skipped whole: a site's file reaches globals through `$wgSettings`, which writes that prefix and no other, so those settings cannot be written from a config file at all.
- A name still unaccounted for is reported with the nearest defined name, where one is close enough to be worth the guess (`levenshtein` within `strlen / 4`, minimum 1).

```
Wikven: WARNING in .wikven.yaml: unknown config 'EnableUpoads'; nothing loaded here defines it. Did you mean 'EnableUploads'?
Wikven: WARNING in .wikven.yaml: unknown config 'Nonsense'; nothing loaded here defines it, and it is ignored.
```

It stays silent while a name in the site's own `extensions:`/`skins:` lists is missing from the image, because the extensions that would account for those settings are exactly the ones that are not there — `maintenance/fetchExtensions.php` boots this file to install them, and so boots it before they exist.

`lint()` loses its `$knownConfig` parameter and its `Wikven`-prefix branch along with it; it is now about shape and values only, and one place owns the question of whose a name is.

## Verification

- The four `undefinedConfig()` cases and the manifest-reading cases were run against the real code before being written as tests, so the asserted strings are the strings produced.
- `MinervaTypeahead` and friends in `docs/.wikven.yaml` were checked against MinervaNeue's own `skin.json` — the docs site's configuration is clean under the new check.
- `mago fmt`, `mago lint`, `phpcs`, `typos` and `biome` all pass locally.
- The smoke bake now fails on any `Wikven: WARNING` line, so `docs/.wikven.yaml` — the configuration wikven recommends — has to stay clean of them. That assertion is also this change's end-to-end test: CI bakes the docs site twice with the real image.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_