### PR TITLE
fix: fail when a composer package lands where nothing loads it

### DIFF
--- a/docs/Configuration.wikitext
+++ b/docs/Configuration.wikitext
@@ -212,6 +212,12 @@ Each entry chooses one of three methods by the key it carries:
 <!--T:23-->
 A name in <code>WikvenRepositories</code> that is already bundled with wikven is left untouched. A name that is not also listed in <code>extensions</code> or <code>skins</code> is an error.
 
+<!--T:63-->
+With <code>package</code>, the name is Composer's to choose rather than yours: a <code>mediawiki-extension</code> package is installed into a CamelCased directory with any trailing <code>-extension</code> cut off (<code>mediawiki/tabber-neue-extension</code> becomes <code>extensions/TabberNeue</code>), while a <code>mediawiki-skin</code> package is not CamelCased at all (<code>mediawiki/chameleon-skin</code> becomes <code>skins/chameleon</code>). The name you list has to be that directory, because that is what the build loads. It is checked after the install and named if it does not match, so this is a build that stops rather than a site published without the component.
+
+<!--T:64-->
+A <code>package</code> constraint that is not an exact version — <code>~4.1</code>, <code>^4</code>, <code>*</code> — is warned about in the build log for the reason the note below gives. It is not an error: taking whatever the registry serves is a bargain you are entitled to make, the same one a moving <code>reference</code> makes, and the build only says you have made it.
+
 <!--T:24-->
 Each method needs a host tool present at build time: <code>tarball</code> uses <code>curl</code> and <code>tar</code>, <code>repository</code> uses <code>git</code> (and [<tvar name="2">https://getcomposer.org/</tvar> Composer] when <code>composer: true</code>), and <code>package</code> uses Composer. The Docker image bundles all of these; with the standalone [[<tvar name="1">Special:MyLanguage/Standalone binary</tvar>|binary]] they must be on your <code>PATH</code>.
 

--- a/docs/Configuration/ko.wikitext
+++ b/docs/Configuration/ko.wikitext
@@ -133,6 +133,12 @@ $1
 <!--T:23 @cae25472-->
 이미 wikven에 번들된 <code>WikvenRepositories</code> 속 이름은 건드리지 않습니다. <code>extensions</code>나 <code>skins</code>에도 나열되지 않은 이름은 오류입니다.
 
+<!--T:63 @fffd8549-->
+<code>package</code>에서는 그 이름을 여러분이 아니라 Composer가 정합니다. <code>mediawiki-extension</code> 패키지는 뒤에 붙은 <code>-extension</code>을 떼고 CamelCase로 바꾼 디렉터리에 설치되고(<code>mediawiki/tabber-neue-extension</code>은 <code>extensions/TabberNeue</code>가 됩니다), <code>mediawiki-skin</code> 패키지는 CamelCase로 바뀌지 않습니다(<code>mediawiki/chameleon-skin</code>은 <code>skins/chameleon</code>이 됩니다). 빌드가 불러오는 것은 그 디렉터리이므로, 나열하는 이름도 그것이어야 합니다. 설치가 끝난 뒤에 검사해서 맞지 않으면 이름을 알려 주므로, 구성 요소 없이 사이트가 게시되는 대신 빌드가 멈춥니다.
+
+<!--T:64 @14923229-->
+정확한 버전이 아닌 <code>package</code> 제약 — <code>~4.1</code>, <code>^4</code>, <code>*</code> — 은 아래 알림이 말하는 이유로 빌드 로그에 경고가 남습니다. 오류는 아닙니다. 레지스트리가 주는 대로 받는 것은 여러분이 택할 수 있는 거래이고, 움직이는 <code>reference</code>가 하는 것과 같은 거래이며, 빌드는 그 거래를 했다는 사실만 말해 줄 뿐입니다.
+
 <!--T:24 @07beb890-->
 각 방법은 빌드 시점에 존재하는 호스트 도구가 필요합니다. <code>tarball</code>은 <code>curl</code>과 <code>tar</code>를, <code>repository</code>는 <code>git</code>을(그리고 <code>composer: true</code>일 때 [$2 Composer]를), <code>package</code>는 Composer를 씁니다. Docker 이미지는 이 모두를 번들하지만, 단독 실행 [[$1|바이너리]]에서는 이들이 <code>PATH</code>에 있어야 합니다.
 

--- a/includes/ComposerInstall.php
+++ b/includes/ComposerInstall.php
@@ -35,11 +35,11 @@ class ComposerInstall {
 			return [];
 		}
 		$decoded = json_decode((string)file_get_contents($record), true);
-		// Composer 2 wraps the list in "packages"; older records are the list itself.
-		$entries = is_array($decoded['packages'] ?? null) ? $decoded['packages'] : $decoded;
-		if (!is_array($entries)) {
+		if (!is_array($decoded)) {
 			return [];
 		}
+		// Composer 2 wraps the list in "packages"; older records are the list itself.
+		$entries = is_array($decoded['packages'] ?? null) ? $decoded['packages'] : $decoded;
 		$locations = [];
 		foreach ($entries as $entry) {
 			if (!is_array($entry) || !is_string($entry['name'] ?? null)) {

--- a/includes/ComposerInstall.php
+++ b/includes/ComposerInstall.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * Where composer put the packages a site asked for, and whether that is where the build looks.
+ *
+ * A name in a site's extensions: or skins: list is a directory name, and WikvenSettings.php turns
+ * it straight into a path under $IP. A composer package names its own directory instead, through
+ * composer/installers, and the two do not have to agree: a "mediawiki-extension" is CamelCased
+ * with a trailing "-extension" cut off (mediawiki/tabber-neue-extension -> extensions/TabberNeue),
+ * a "mediawiki-skin" is not CamelCased at all (mediawiki/chameleon-skin -> skins/chameleon), and a
+ * package declaring neither type lands in vendor/ like any other library.
+ *
+ * So a site listing "Chameleon" and asking for "mediawiki/chameleon-skin" got skins/chameleon,
+ * which on a case-sensitive filesystem is a different directory. Every step succeeded: the package
+ * installed, the log said "skipping skin 'Chameleon' (not bundled in this image)", the build
+ * carried on, and the site went out without its skin.
+ */
+class ComposerInstall {
+	/**
+	 * Where composer put each package it installed, keyed by package name.
+	 *
+	 * Read from composer's own record rather than worked out from the package name, because the
+	 * directory depends on the type the package declares as much as on what it is called, and only
+	 * the package knows its type.
+	 *
+	 * @param string $installPath MediaWiki's install directory ($IP).
+	 * @return array<string,array{version:string,path:string}> Absolute paths, by package name; a
+	 *   package composer recorded without a path has an empty one.
+	 */
+	public static function locations(string $installPath): array {
+		$record = rtrim($installPath, '/') . '/vendor/composer/installed.json';
+		if (!is_readable($record)) {
+			return [];
+		}
+		$decoded = json_decode((string)file_get_contents($record), true);
+		// Composer 2 wraps the list in "packages"; older records are the list itself.
+		$entries = is_array($decoded['packages'] ?? null) ? $decoded['packages'] : $decoded;
+		if (!is_array($entries)) {
+			return [];
+		}
+		$locations = [];
+		foreach ($entries as $entry) {
+			if (!is_array($entry) || !is_string($entry['name'] ?? null)) {
+				continue;
+			}
+			// install-path is written relative to vendor/composer, which is where the record lives.
+			$path = (string)( $entry['install-path'] ?? '' );
+			$resolved = $path === ''
+				? ''
+				: (string)realpath(rtrim($installPath, '/') . "/vendor/composer/$path");
+			$locations[$entry['name']] = [
+				'version' => (string)( $entry['version'] ?? '?' ),
+				'path' => $resolved
+			];
+		}
+		return $locations;
+	}
+
+	/**
+	 * What to tell a site whose package did not land where the build loads it from, or null.
+	 *
+	 * @param string $installPath MediaWiki's install directory ($IP).
+	 * @param array{package:string,name:string,kind:string,dest:string} $asked The package, the name
+	 *   the site listed it under, whether it is an extension or a skin, and the directory this
+	 *   build will look in.
+	 * @param array<string,array{version:string,path:string}> $installed From locations().
+	 * @return ?string
+	 */
+	public static function misplaced(string $installPath, array $asked, array $installed): ?string {
+		$package = $asked['package'];
+		$name = $asked['name'];
+		$kind = $asked['kind'];
+		if (!isset($installed[$package])) {
+			return (
+				"$kind '$name' asked for composer package $package, which composer did not install."
+				. ' Check the package name, and that the registry serves a version matching the constraint.'
+			);
+		}
+		$landed = $installed[$package]['path'];
+		$wanted = realpath($asked['dest']);
+		if ($landed !== '' && $wanted !== false && $landed === $wanted) {
+			return null;
+		}
+		$where = $landed === '' ? 'nowhere this build can see' : self::relativeTo($installPath, $landed);
+		$expected = self::relativeTo($installPath, $asked['dest']);
+		return (
+			"$kind '$name' asked for composer package $package, which installed into $where."
+			. " A name in {$kind}s: is the directory this build loads from, and it looks in $expected,"
+			. ' so nothing would load it.'
+			. self::suggestion($installPath, $kind, $landed)
+		);
+	}
+
+	/**
+	 * What the site could write instead, where there is something worth writing.
+	 *
+	 * Only a package composer put directly under extensions/ or skins/ has a name to offer: one
+	 * that landed in vendor/ declared neither MediaWiki type, and renaming the entry would not make
+	 * it a component. A package that landed in the other of the two is a component, just not the
+	 * kind it was listed as, and the list it belongs in is the more useful half of that answer.
+	 *
+	 * @param string $installPath MediaWiki's install directory ($IP).
+	 * @param string $kind 'extension' or 'skin', as the site listed it.
+	 * @param string $landed Where composer put it, or '' where composer recorded no path.
+	 */
+	private static function suggestion(string $installPath, string $kind, string $landed): string {
+		if ($landed === '' || dirname($landed, 2) !== rtrim($installPath, '/')) {
+			return '';
+		}
+		$under = basename(dirname($landed));
+		if ($under === "{$kind}s") {
+			return " List it as '" . basename($landed) . "' instead.";
+		}
+		if ($under === 'extensions' || $under === 'skins') {
+			return ' It is a ' . rtrim($under, 's') . ", so list '" . basename($landed) . "' under $under: instead.";
+		}
+		return '';
+	}
+
+	/**
+	 * Whether a version constraint names one release and no other.
+	 *
+	 * A tarball is pinned by its sha256 and a repository by its commit; for a package the pin is an
+	 * exact version, and anything looser takes whatever the registry serves on the day. That is a
+	 * bargain a site is entitled to make -- the same one a moving `reference` makes -- so this only
+	 * decides whether the build says so.
+	 *
+	 * @param string $constraint What follows the colon in "vendor/name:constraint", or "*".
+	 */
+	public static function isExactVersion(string $constraint): bool {
+		return preg_match('/^v?\d+\.\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?$/', trim($constraint)) === 1;
+	}
+
+	/** $path written against $installPath where it is under it, for a message about this install. */
+	private static function relativeTo(string $installPath, string $path): string {
+		$prefix = rtrim($installPath, '/') . '/';
+		return str_starts_with($path, $prefix) ? substr($path, strlen($prefix)) : $path;
+	}
+}

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -21,6 +21,7 @@ require_once "$IP/maintenance/Maintenance.php";
 // what this script is for, so it runs before that. Loaded directly for the same reason loadConfig()
 // loads SiteConfig directly below, and both classes are dependency-free so that is all it takes.
 require_once __DIR__ . '/../includes/Attempts.php';
+require_once __DIR__ . '/../includes/ComposerInstall.php';
 require_once __DIR__ . '/../includes/FetchPin.php';
 require_once __DIR__ . '/../includes/UserAgent.php';
 
@@ -57,7 +58,10 @@ class FetchExtensions extends Maintenance {
 		// Composer's superuser warning would otherwise abort under set -e.
 		putenv('COMPOSER_ALLOW_SUPERUSER=1');
 
+		// Which component each package was asked for, so the directory composer chose can be held
+		// against the name the site listed once the install is done.
 		$packages = [];
+		$asked = [];
 		foreach ($repos as $name => $spec) {
 			if (!is_string($name) || !is_array($spec)) {
 				$this->fatalError('Wikven: each WikvenRepositories entry must be a name mapped to a source.');
@@ -69,13 +73,23 @@ class FetchExtensions extends Maintenance {
 			[$baseDir, $kind] = $this->target($name, $extensionNames, $skinNames);
 
 			if (isset($spec['package'])) {
-				// Composer picks the install dir from the package; just collect the requirement.
+				// Composer picks the install dir from the package, not from the name here, so where it
+				// went is checked afterwards rather than chosen now.
 				if (!is_string($spec['package']) || $spec['package'] === '') {
 					$this->fatalError("Wikven: $kind '$name' has an empty 'package'.");
 				}
 				[$pkgName, $constraint] = $this->splitPackage($spec['package']);
 				$packages[$pkgName] = $constraint;
+				$asked[$pkgName] = ['name' => $name, 'kind' => $kind, 'dest' => "$baseDir/$name"];
 				$this->output("Wikven: will install $kind '$name' as composer package $pkgName ($constraint)\n");
+				// A tarball is pinned by sha256 and a repository by commit; for a package the pin is
+				// an exact version, and anything else takes whatever the registry serves that day.
+				if (!ComposerInstall::isExactVersion($constraint)) {
+					$this->output(
+						"Wikven: WARNING: $kind '$name' asks for $pkgName '$constraint', which is not an exact"
+						. " version; two builds of this source tree can install different code\n"
+					);
+				}
 				continue;
 			}
 
@@ -109,7 +123,7 @@ class FetchExtensions extends Maintenance {
 		}
 
 		if ($packages !== []) {
-			$this->installPackages($IP, $packages);
+			$this->installPackages($IP, $packages, $asked);
 		}
 	}
 
@@ -337,7 +351,18 @@ class FetchExtensions extends Maintenance {
 		}
 	}
 
-	private function installPackages(string $IP, array $packages): void {
+	/**
+	 * Install the composer packages a site asked for, and check each one landed where it is loaded.
+	 *
+	 * Where a package goes is composer's answer, not this file's, so it is asked afterwards rather
+	 * than assumed; ComposerInstall says why the two can differ.
+	 *
+	 * @param string $IP MediaWiki's install directory.
+	 * @param array<string,string> $packages Package name to version constraint.
+	 * @param array<string,array{name:string,kind:string,dest:string}> $asked Which component each
+	 *   package was asked for, and the directory this build will look for that component in.
+	 */
+	private function installPackages(string $IP, array $packages, array $asked): void {
 		// Core merges composer.local.json via composer-merge-plugin; require there, then update.
 		$localFile = "$IP/composer.local.json";
 		$local = is_file($localFile)
@@ -353,6 +378,18 @@ class FetchExtensions extends Maintenance {
 			['composer', 'update', '--no-dev', '--no-interaction', '--working-dir=' . $IP],
 			'composer update'
 		);
+
+		$installed = ComposerInstall::locations($IP);
+		foreach ($asked as $pkgName => $want) {
+			$problem = ComposerInstall::misplaced($IP, ['package' => $pkgName] + $want, $installed);
+			if ($problem !== null) {
+				$this->fatalError("Wikven: $problem");
+			}
+			$this->output(
+				"Wikven: installed {$want['kind']} '{$want['name']}' from $pkgName"
+				. " {$installed[$pkgName]['version']}\n"
+			);
+		}
 	}
 
 	/** Download $url to $dest, streaming the body to disk instead of buffering it in memory. */

--- a/tests/phpunit/unit/ComposerInstallTest.php
+++ b/tests/phpunit/unit/ComposerInstallTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\ComposerInstall;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\ComposerInstall
+ */
+class ComposerInstallTest extends MediaWikiUnitTestCase {
+	/** @var string[] */
+	private array $treesToClean = [];
+
+	/** @dataProvider provideIsExactVersion */
+	public function testIsExactVersion(string $constraint, bool $expected) {
+		$this->assertSame($expected, ComposerInstall::isExactVersion($constraint));
+	}
+
+	public static function provideIsExactVersion(): array {
+		return [
+			'a release' => ['4.1.0', true],
+			'a release with composer\'s fourth part' => ['4.1.0.0', true],
+			'a tagged release' => ['v4.1.0', true],
+			'a prerelease' => ['4.1.0-beta.2', true],
+			// Every one of these can install different code tomorrow.
+			'a caret range' => ['^4.1', false],
+			'a tilde range' => ['~4.1', false],
+			'anything at all' => ['*', false],
+			'a wildcard patch' => ['4.1.*', false],
+			'a branch' => ['dev-main', false],
+			'two majors' => ['>=4.1 <6.0', false]
+		];
+	}
+
+	public function testLocationsAreEmptyWithoutARecord() {
+		$this->assertSame([], ComposerInstall::locations($this->makeTree()['ip']));
+	}
+
+	/**
+	 * install-path is written relative to vendor/composer, which is where the record itself lives,
+	 * so resolving it is what turns composer's answer into a path this build can compare.
+	 */
+	public function testLocationsResolveEachInstallPath() {
+		$tree = $this->makeTree([
+			'extensions/TabberNeue',
+			'skins/chameleon'
+		], [
+			[
+				'name' => 'example/tabber-neue-extension',
+				'version' => '1.0.0',
+				'install-path' => '../../extensions/TabberNeue'
+			],
+			['name' => 'example/chameleon-skin', 'version' => '2.0.0', 'install-path' => '../../skins/chameleon']
+		]);
+		$locations = ComposerInstall::locations($tree['ip']);
+
+		$this->assertSame(
+			['example/tabber-neue-extension', 'example/chameleon-skin'],
+			array_keys($locations)
+		);
+		$this->assertSame("{$tree['ip']}/extensions/TabberNeue", $locations['example/tabber-neue-extension']['path']);
+		$this->assertSame('2.0.0', $locations['example/chameleon-skin']['version']);
+	}
+
+	/**
+	 * The one this exists for. composer/installers does not CamelCase a skin, so a site listing
+	 * "Chameleon" and asking for "mediawiki/chameleon-skin" gets skins/chameleon, which on a
+	 * case-sensitive filesystem is a different directory. Nothing failed: the package installed,
+	 * the log said "skipping skin 'Chameleon'", and the site went out without its skin.
+	 */
+	public function testASkinInstalledUnderAnotherNameIsNamed() {
+		$tree = $this->makeTree(['skins/chameleon'], [
+			['name' => 'mediawiki/chameleon-skin', 'version' => '4.5.0', 'install-path' => '../../skins/chameleon']
+		]);
+		$problem = ComposerInstall::misplaced(
+			$tree['ip'],
+			[
+				'package' => 'mediawiki/chameleon-skin',
+				'name' => 'Chameleon',
+				'kind' => 'skin',
+				'dest' => "{$tree['ip']}/skins/Chameleon"
+			],
+			ComposerInstall::locations($tree['ip'])
+		);
+
+		$this->assertNotNull($problem);
+		$this->assertStringContainsString('installed into skins/chameleon', $problem);
+		$this->assertStringContainsString('it looks in skins/Chameleon', $problem);
+		$this->assertStringContainsString("List it as 'chameleon' instead.", $problem);
+	}
+
+	public function testAPackageThatLandedWhereTheBuildLooksIsNoProblem() {
+		$tree = $this->makeTree(['extensions/TabberNeue'], [
+			[
+				'name' => 'mediawiki/tabber-neue-extension',
+				'version' => '4.0.2',
+				'install-path' => '../../extensions/TabberNeue'
+			]
+		]);
+		$this->assertNull(ComposerInstall::misplaced(
+			$tree['ip'],
+			[
+				'package' => 'mediawiki/tabber-neue-extension',
+				'name' => 'TabberNeue',
+				'kind' => 'extension',
+				'dest' => "{$tree['ip']}/extensions/TabberNeue"
+			],
+			ComposerInstall::locations($tree['ip'])
+		));
+	}
+
+	public function testAPackageComposerNeverInstalledIsNamed() {
+		$tree = $this->makeTree();
+		$problem = ComposerInstall::misplaced(
+			$tree['ip'],
+			[
+				'package' => 'example/absent',
+				'name' => 'Absent',
+				'kind' => 'extension',
+				'dest' => "{$tree['ip']}/extensions/Absent"
+			],
+			[]
+		);
+		$this->assertNotNull($problem);
+		$this->assertStringContainsString('composer did not install', $problem);
+	}
+
+	/**
+	 * A package declaring neither MediaWiki type lands in vendor/ like any other library. Renaming
+	 * the entry would not make it an extension, so no name is suggested.
+	 */
+	public function testAPackageThatIsNotAComponentIsNotAnsweredWithARename() {
+		$tree = $this->makeTree(['vendor/example/helper'], [
+			['name' => 'example/helper', 'version' => '1.0.0', 'install-path' => '../example/helper']
+		]);
+		$problem = ComposerInstall::misplaced(
+			$tree['ip'],
+			[
+				'package' => 'example/helper',
+				'name' => 'Helper',
+				'kind' => 'extension',
+				'dest' => "{$tree['ip']}/extensions/Helper"
+			],
+			ComposerInstall::locations($tree['ip'])
+		);
+		$this->assertNotNull($problem);
+		$this->assertStringContainsString('installed into vendor/example/helper', $problem);
+		$this->assertStringNotContainsString('List it as', $problem);
+	}
+
+	/**
+	 * Composer's record is read defensively because it is not this build's file: an entry without a
+	 * name is nothing this can act on, and one without a path is a package that is installed but
+	 * nowhere this build can point at.
+	 */
+	public function testAnEntryWithoutANameOrAPathIsHandled() {
+		$tree = $this->makeTree([], [
+			['version' => '1.0.0', 'install-path' => '../../extensions/Nameless'],
+			['name' => 'example/pathless', 'version' => '1.0.0']
+		]);
+		$locations = ComposerInstall::locations($tree['ip']);
+		$this->assertSame(['example/pathless'], array_keys($locations));
+		$this->assertSame('', $locations['example/pathless']['path']);
+
+		$problem = ComposerInstall::misplaced(
+			$tree['ip'],
+			[
+				'package' => 'example/pathless',
+				'name' => 'Pathless',
+				'kind' => 'extension',
+				'dest' => "{$tree['ip']}/extensions/Pathless"
+			],
+			$locations
+		);
+		$this->assertNotNull($problem);
+		$this->assertStringContainsString('nowhere this build can see', $problem);
+		$this->assertStringNotContainsString('List it as', $problem);
+	}
+
+	/**
+	 * A package that landed under the other of the two directories is a component, just not the
+	 * kind it was listed as, and which list it belongs in is the useful half of that answer.
+	 */
+	public function testAComponentListedUnderTheWrongKindIsSentToTheOtherList() {
+		$tree = $this->makeTree(['skins/chameleon'], [
+			['name' => 'mediawiki/chameleon-skin', 'version' => '4.5.0', 'install-path' => '../../skins/chameleon']
+		]);
+		$problem = ComposerInstall::misplaced(
+			$tree['ip'],
+			[
+				'package' => 'mediawiki/chameleon-skin',
+				'name' => 'chameleon',
+				'kind' => 'extension',
+				'dest' => "{$tree['ip']}/extensions/chameleon"
+			],
+			ComposerInstall::locations($tree['ip'])
+		);
+		$this->assertNotNull($problem);
+		$this->assertStringContainsString("It is a skin, so list 'chameleon' under skins: instead.", $problem);
+	}
+
+	/**
+	 * @param string[] $directories Paths under the install directory to create.
+	 * @param list<array<string,string>> $packages Entries for vendor/composer/installed.json.
+	 * @return array{ip:string}
+	 */
+	private function makeTree(array $directories = [], array $packages = []): array {
+		$ip = sys_get_temp_dir() . '/wikven-composer-' . uniqid();
+		$this->treesToClean[] = $ip;
+		foreach ($directories as $directory) {
+			mkdir("$ip/$directory", 0777, true);
+		}
+		if ($packages !== []) {
+			mkdir("$ip/vendor/composer", 0777, true);
+			file_put_contents(
+				"$ip/vendor/composer/installed.json",
+				json_encode(['packages' => $packages])
+			);
+		}
+		if (!is_dir($ip)) {
+			mkdir($ip, 0777, true);
+		}
+		return ['ip' => $ip];
+	}
+
+	protected function tearDown(): void {
+		foreach ($this->treesToClean as $tree) {
+			self::removeTree($tree);
+		}
+		parent::tearDown();
+	}
+
+	private static function removeTree(string $path): void {
+		if (!is_dir($path)) {
+			return;
+		}
+		foreach (scandir($path) ?: [] as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			$child = "$path/$entry";
+			is_dir($child) ? self::removeTree($child) : unlink($child);
+		}
+		rmdir($path);
+	}
+}


### PR DESCRIPTION
A name in `extensions:` or `skins:` is a directory name, and `WikvenSettings.php` turns it straight into a path. A composer package names its own directory instead, through `composer/installers`, and the two do not have to agree.

I verified the rules by installing real packages with composer here rather than reading them off:

| package | type | lands in |
| --- | --- | --- |
| `example/tabber-neue-extension` | `mediawiki-extension` | `extensions/TabberNeue` — CamelCased, `-extension` stripped |
| `example/chameleon-skin` | `mediawiki-skin` | `skins/chameleon` — **not** CamelCased |
| `example/helper` | (none) | `vendor/example/helper` |

So a site listing `Chameleon` and asking for `mediawiki/chameleon-skin` got `skins/chameleon`, which on a case-sensitive filesystem is a different directory. Every step succeeded — the package installed, the log said `skipping skin 'Chameleon' (not bundled in this image)`, the build carried on — and the site went out without its skin.

## What this does

Where a package went is now read from composer's own record after the install (`vendor/composer/installed.json`, because the directory follows the *type* a package declares as much as its name, and only the package knows its type) and held against the directory this build will look in. A mismatch stops the build:

```
Wikven: skin 'Chameleon' asked for composer package mediawiki/chameleon-skin, which installed into
skins/chameleon. A name in skins: is the directory this build loads from, and it looks in
skins/Chameleon, so nothing would load it. List it as 'chameleon' instead.
```

and, when the component turns out to be the other kind, says which list it belongs in instead:

```
… It is a skin, so list 'chameleon' under skins: instead.
```

A package that landed in `vendor/` gets no rename suggested — it declared neither MediaWiki type, and renaming the entry would not make it a component.

It also says so when a `package` constraint is not an exact version. A tarball is pinned by `sha256` and a repository by `commit`; for a package the pin is an exact version. Not an error — it is the same bargain a moving `reference` makes, and the build only says it has been made.

The logic is a pure `ComposerInstall` class under `includes/`, like `FetchPin`, `Attempts` and `BuildPaths`, so it is unit-testable; `fetchExtensions.php` requires it by hand for the same reason it requires those.

## On the other half — reproducibility

I looked into narrowing `composer update --working-dir=$IP` so it could not re-resolve core's tree, and **it cannot be done**. The MediaWiki 1.46.0 release tarball ships `composer.json` and `vendor/composer.lock`, but **no root `composer.lock`** — I checked the tarball's file list. Without a root lock, composer cannot do a partial update: `composer install` needs a lock and `composer update <package>` needs one to hold the rest still. `composer update` is also MediaWiki's own documented procedure for `composer.local.json`, which ships a `composer.local.json-sample` for exactly this.

The exposure is narrower than it looks, though: **every one of core's ~55 direct requirements is an exact pin** (`guzzlehttp/guzzle 7.12.3`, `symfony/yaml 7.4.12`, …), so what can actually move between two builds is transitive dependencies and the package the site asked for. The second is the site's to pin, which is what the new warning is about.

## Verification

- Every assertion in `ComposerInstallTest` was run against the real class before being written as a test.
- One of them failed and found a bug in my own first cut: the "don't suggest a rename for a `vendor/` package" guard tested for a `/` in the path, and `vendor/example/helper` has one. Replaced with the correct test — that the package sits directly under `extensions/` or `skins/`.
- `mago fmt`, `mago lint`, `phpcs`, `typos`, `biome` pass locally.

Documented in **Configuration**, in both languages, marked by `StalenessComputer::mark()` and stamped by `restamp()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_