### PR TITLE
feat: settle the actions' inputs before 1.0.0 freezes them

### DIFF
--- a/actions/bake/action.yml
+++ b/actions/bake/action.yml
@@ -20,15 +20,23 @@ inputs:
   cache:
     description: >-
       Cache the pulled image between runs, keyed on the image ref. Set to
-      "false" to always pull fresh.
+      "false" to always pull fresh. Takes "true" or "false" and refuses
+      anything else, rather than reading it as "false" and going quiet.
     default: "true"
-  date-epoch:
+  source-date-epoch:
     description: >-
       Unix time the built site should claim its content was last written, as
       SOURCE_DATE_EPOCH (https://reproducible-builds.org/docs/source-date-epoch/).
       Defaults to the commit date of HEAD, which makes the "last edited" dates
       true of the commit and identical for every bake of it. Left unset if the
       checkout has no git history, and the bake then uses a fixed date.
+    default: ""
+  jobs:
+    description: >-
+      How many skin passes to render beside each other, as WIKVEN_BUILD_JOBS.
+      A pass is a MediaWiki boot with a boot's worth of memory, so a runner
+      that runs out of it renders one at a time with "1". Left unset the build
+      counts the processors it is allowed and uses one pass per processor.
     default: ""
 
 runs:
@@ -46,8 +54,35 @@ runs:
         OUTPUT: ${{ inputs.output }}
         IMAGE: ${{ inputs.image }}
         CACHE: ${{ inputs.cache }}
-        DATE_EPOCH: ${{ inputs.date-epoch }}
+        SOURCE_DATE_EPOCH_IN: ${{ inputs.source-date-epoch }}
+        JOBS: ${{ inputs.jobs }}
       run: |
+        # A value neither "true" nor "false" used to read as "false", so `cache: npm` -- the
+        # spelling setup-node and setup-python take, where the value names what to cache -- turned
+        # caching off and said nothing. Refuse it instead: a workflow that meant something by a
+        # value deserves to hear that this action did not take it.
+        require_boolean() {
+          case "$2" in
+            true | false) ;;
+            *)
+              echo "::error::wikven: '$1' takes \"true\" or \"false\", not \"$2\"."
+              exit 1
+              ;;
+          esac
+        }
+        require_boolean cache "$CACHE"
+        # The same shape the build accepts, so a value it would drop back from is refused here
+        # instead: WIKVEN_BUILD_JOBS reads /^[1-9]\d*$/ on a trimmed value and silently counts
+        # processors otherwise, which would leave "0" or "007" looking like it had been taken.
+        # `read` does the trimming the build does, so the two agree on every string.
+        read -r JOBS <<< "$JOBS" || true
+        case "$JOBS" in
+          '' | [1-9] | [1-9][0-9]*) ;;
+          *)
+            echo "::error::wikven: 'jobs' takes a whole number of passes from 1 up, not \"$JOBS\"."
+            exit 1
+            ;;
+        esac
         tar="$HOME/.cache/wikven/image.tar"
         if [ "$CACHE" = "true" ] && [ -f "$tar" ]; then
           docker load -i "$tar"
@@ -61,14 +96,18 @@ runs:
         fi
         mkdir -p "$OUTPUT"
         # Unset unless resolved: the bake falls back to a fixed date rather than the build clock.
-        if [ -z "$DATE_EPOCH" ]; then
-          DATE_EPOCH=$(git log -1 --format=%ct 2>/dev/null || true)
+        if [ -z "$SOURCE_DATE_EPOCH_IN" ]; then
+          SOURCE_DATE_EPOCH_IN=$(git log -1 --format=%ct 2>/dev/null || true)
         fi
         epoch=()
-        case "$DATE_EPOCH" in
+        case "$SOURCE_DATE_EPOCH_IN" in
           '' | *[!0-9]*) ;;
-          *) epoch=(-e "SOURCE_DATE_EPOCH=$DATE_EPOCH") ;;
+          *) epoch=(-e "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH_IN") ;;
         esac
+        jobs=()
+        if [ -n "$JOBS" ]; then
+          jobs=(-e "WIKVEN_BUILD_JOBS=$JOBS")
+        fi
         # Each page is dated at the commit that last touched its source file, and credited to that
         # commit's author. Only this side can see the history -- the container is given the source
         # directory alone, with no .git beside it -- so dump the log for it here. Paths come out
@@ -91,5 +130,6 @@ runs:
           -v "$PWD/$SOURCE:/workspace/src" \
           -v "$PWD/$OUTPUT:/workspace/dist" \
           "${epoch[@]}" \
+          "${jobs[@]}" \
           "${history[@]}" \
           "$IMAGE"

--- a/actions/check-translations/action.yml
+++ b/actions/check-translations/action.yml
@@ -19,7 +19,8 @@ inputs:
       Fail the step (non-zero exit) when a source page is broken: one Translate
       cannot parse, or one the two readings disagree on. A translation that is
       stale or missing is always reported and never fails the step. Set to
-      "false" to report even a broken page without failing.
+      "false" to report even a broken page without failing. Takes "true" or
+      "false" and refuses anything else.
     default: "true"
   comment:
     description: >-
@@ -32,7 +33,8 @@ inputs:
       with an all-clear once the findings are answered. The comment is about
       the files the pull request touches -- and the translations of any source
       page it touches -- rather than about the whole tree, so a page that fell
-      behind long before this change is left to the annotations.
+      behind long before this change is left to the annotations. Takes "true"
+      or "false" and refuses anything else.
     default: "false"
   comment-languages:
     description: >-
@@ -54,7 +56,8 @@ inputs:
   cache:
     description: >-
       Cache the pulled image between runs, keyed on the image ref. Set to
-      "false" to always pull fresh.
+      "false" to always pull fresh. Takes "true" or "false" and refuses
+      anything else, rather than reading it as "false" and going quiet.
     default: "true"
 
 runs:
@@ -78,6 +81,22 @@ runs:
         REPOSITORY: ${{ github.repository }}
         PULL_REQUEST: ${{ github.event.pull_request.number }}
       run: |
+        # A value neither "true" nor "false" used to read as "false", so `cache: npm` -- the
+        # spelling setup-node and setup-python take, where the value names what to cache -- turned
+        # caching off and said nothing. Refuse it instead: a workflow that meant something by a
+        # value deserves to hear that this action did not take it.
+        require_boolean() {
+          case "$2" in
+            true | false) ;;
+            *)
+              echo "::error::wikven: '$1' takes \"true\" or \"false\", not \"$2\"."
+              exit 1
+              ;;
+          esac
+        }
+        require_boolean cache "$CACHE"
+        require_boolean gate "$GATE"
+        require_boolean comment "$COMMENT"
         tar="$HOME/.cache/wikven/image.tar"
         if [ "$CACHE" = "true" ] && [ -f "$tar" ]; then
           docker load -i "$tar"

--- a/docs/Commands.wikitext
+++ b/docs/Commands.wikitext
@@ -178,8 +178,13 @@ Bakes a source tree with the Docker image, on a GitHub Actions runner. See [[<tv
 |-
 | <code>cache</code> || <code>true</code> || Cache the pulled image between runs, keyed on the image reference. Set to <code>false</code> to always pull fresh.
 |-
-| <code>date-epoch</code> || the commit date of <code>HEAD</code> || <code>SOURCE_DATE_EPOCH</code> for the bake, so every bake of a commit dates its pages identically.
+| <code>source-date-epoch</code> || the commit date of <code>HEAD</code> || <code>SOURCE_DATE_EPOCH</code> for the bake, so every bake of a commit dates its pages identically.
+|-
+| <code>jobs</code> || one per processor || <code>WIKVEN_BUILD_JOBS</code> for the bake: how many skin passes render beside each other. A runner short of memory renders one at a time with <code>1</code>.
 |}
+
+<!--T:31-->
+An input that takes <code>true</code> or <code>false</code> — <code>cache</code> here, and <code>gate</code> and <code>comment</code> on the other action below — takes nothing else. A value that is neither used to read as <code>false</code>, so <code>cache: npm</code>, the spelling <code>setup-node</code> and <code>setup-python</code> take where the value names what to cache, turned caching off without saying so. Both actions now stop and name the input instead.
 
 <!--T:25-->
 The action also dumps the source tree's <code>git log</code> and hands it to the build, which is how each page is dated at the commit that last changed it. That needs the whole history: check out with <code>fetch-depth: 0</code>, or every page is dated at the commit being built. The action says so in the log when it happens.

--- a/docs/Commands/ko.wikitext
+++ b/docs/Commands/ko.wikitext
@@ -86,7 +86,7 @@ GitHub Actions 러너에서 Docker 이미지로 소스 트리를 굽습니다. �
 <!--T:29 @bd75cf1a-->
 {{note|두 액션 모두 태그로 고정합니다. {{SITENAME}}의 버전이 릴리스되기 전까지 그 태그는 나이틀리, 곧 날짜가 붙은 사전 릴리스 <code>nightly-YYYY-MM-DD</code>이며, 가장 최근 것은 [$2 릴리스 페이지]에서 고를 수 있습니다. 이미지도 같은 나이틀리로 함께 지정하십시오. 기본값에 맡기면 액션이 잘려 나온 릴리스의 이미지를 실행하는데, 아직 릴리스된 버전이 없습니다. 릴리스가 나온 뒤에는 <code>@1.2.3</code>만으로 충분합니다.}}
 
-<!--T:24 @07a27602-->
+<!--T:24 @bfca7f25-->
 {| class="wikitable"
 ! 입력 !! 기본값 !! 하는 일
 |-
@@ -98,8 +98,13 @@ GitHub Actions 러너에서 Docker 이미지로 소스 트리를 굽습니다. �
 |-
 | <code>cache</code> || <code>true</code> || 이미지 참조를 키로 삼아 받아 온 이미지를 실행 사이에 캐시합니다. 항상 새로 받으려면 <code>false</code>로 두십시오.
 |-
-| <code>date-epoch</code> || <code>HEAD</code>의 커밋 시각 || 굽기에 쓸 <code>SOURCE_DATE_EPOCH</code>. 한 커밋을 몇 번 구워도 문서 날짜가 같아집니다.
+| <code>source-date-epoch</code> || <code>HEAD</code>의 커밋 시각 || 굽기에 쓸 <code>SOURCE_DATE_EPOCH</code>. 한 커밋을 몇 번 구워도 문서 날짜가 같아집니다.
+|-
+| <code>jobs</code> || 프로세서당 하나 || 굽기에 쓸 <code>WIKVEN_BUILD_JOBS</code>. 스킨 렌더링을 몇 개까지 나란히 돌릴지를 정합니다. 메모리가 모자란 러너에서는 <code>1</code>로 한 번에 하나씩 렌더링합니다.
 |}
+
+<!--T:31 @42406439-->
+<code>true</code>나 <code>false</code>를 받는 입력은 — 여기서는 <code>cache</code>, 아래 다른 액션에서는 <code>gate</code>와 <code>comment</code> — 그 둘 말고는 받지 않습니다. 예전에는 둘 중 어느 것도 아닌 값이 <code>false</code>로 읽혔습니다. 그래서 <code>setup-node</code>와 <code>setup-python</code>이 값으로 캐시할 대상을 받는 철자대로 <code>cache: npm</code>이라고 쓰면, 아무 말 없이 캐시가 꺼졌습니다. 이제는 두 액션 모두 멈춰 서서 어느 입력인지 알려 줍니다.
 
 <!--T:25 @84f8a7eb-->
 액션은 소스 트리의 <code>git log</code>를 덤프해 빌드에 넘기기도 합니다. 각 문서가 그것을 마지막으로 바꾼 커밋의 날짜를 갖는 것이 그 덕분입니다. 그러려면 전체 역사가 필요하므로 <code>fetch-depth: 0</code>으로 체크아웃하십시오. 그러지 않으면 모든 문서가 빌드 중인 커밋의 날짜를 갖게 됩니다. 그런 일이 생기면 액션이 로그에 그렇게 적습니다.


### PR DESCRIPTION
The composite actions' inputs live in other people's workflow files, which makes them the hardest part of the surface to change after a release. #557 §6 asks for them to be confirmed; three things are worth doing while it is still free.

## `date-epoch` → `source-date-epoch`

The value **is** `SOURCE_DATE_EPOCH` — a name the [reproducible-builds convention](https://reproducible-builds.org/docs/source-date-epoch/) already owns, and one the input's own description already cited. `date-epoch` was a second spelling of a standard term, and someone who has met reproducible builds recognises the first spelling and not the second.

Nothing in this repository passed the old name — the docs' example workflows and `deploy-docs.yml` all rely on the default — so the whole cost today is four lines. After 1.0.0 it is a deprecation window plus a wait for the next core bump, per the policy in #557 §0.

One thing worth knowing: a composite action **cannot** detect an input it does not declare. GitHub logs `Unexpected input(s) 'date-epoch'` as a warning and carries on. So a workflow on `@main` that passes the old name will go green and quietly fall back to the default (which is the same commit date it was probably passing anyway). There is no way to make that an error.

## Booleans take `true` or `false` and nothing else

A value that was neither read as `false`. So `cache: npm` — the spelling `setup-node` and `setup-python` take, where the value names *what* to cache — turned caching off and said nothing about it. That is the failure this repository has spent the week removing.

Both actions now stop and name the input:

```
::error::wikven: 'cache' takes "true" or "false", not "npm".
```

Applied to `gate` and `comment` as well as `cache`, since all three had it. This is a behaviour change rather than a name change, so it was not strictly a freeze question — but it is the same one line of code in both actions and it belongs with them.

## A new `jobs` input

`docs/Troubleshooting` tells a site whose runner is short of memory to set `WIKVEN_BUILD_JOBS=1`, and the bake action gave it no way to reach that. A knob the documentation promises and the interface withholds.

Its accepted shape is the build's own. `BuildConcurrency::limit()` reads `/^[1-9]\d*$/` on a trimmed value and silently counts processors otherwise, so `0` or `007` would have looked as though they had been taken. I ran both the action's `case` and the real PHP over thirteen strings and they agree on every one:

| input | action | build |
| --- | --- | --- |
| *(unset)* | accept | ignored → counts processors |
| `1` `4` `12` | accept | used |
| `" 4"` `"4 "` `"  "` | accept (trimmed) | used / ignored — same as the action |
| `0` `007` `two` `-1` `1.5` `1 2` | **refuse** | ignored |

The trimming is `read -r`, which does what `trim()` does on the other side; without it the action refused `" 4"` while the build would have used it.

## Verification

- Both actions' `run:` blocks pass `bash -n`.
- `require_boolean` exercised over `true`, `false`, `npm`, `""`, `TRUE`, `yes`, `1` — the last five refused with the input named.
- No file anywhere still passes `date-epoch`.
- `typos`, `yaml-lint`, `mago fmt`, `mago lint`, `biome check` clean locally.

Documented in **Commands** in both languages: the bake table gains `jobs` and renames the epoch row, and a new paragraph says the boolean inputs are strict and why. Markers assigned by `StalenessComputer::mark()`, Korean stamped by `restamp()` — `T:24` restamped because its table changed, `T:31` new.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_