### PR TITLE
ci: refuse a docs-only pull request that calls itself a feature or a fix

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -49,3 +49,56 @@ jobs:
         with:
           header: pr-title-lint-error
           delete: true
+
+  # A change to the documentation alone is not a feature or a fix of wikven, but naming it one
+  # says it is: the title becomes the squash commit's subject, release-please reads that, and the
+  # change lands in the changelog and moves the version. So refuse the two types that do, and
+  # leave every other type alone -- this is not an opinion about what a docs-only change should
+  # be called, only about the two things it cannot be.
+  docs-only:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: read
+    steps:
+      - shell: bash
+        env:
+          # Through the environment rather than into the script: a title is whatever the author
+          # typed, and interpolating it would be running it.
+          TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+        run: |
+          # The type is everything before the first "(", "!" or ":" -- covering "feat:",
+          # "fix(build):" and "feat!:" alike. A title too malformed to have one is the sibling
+          # job's to complain about, not this one's.
+          type=${TITLE%%[(:!]*}
+          type=$(printf '%s' "$type" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+          case "$type" in
+            feat | fix) ;;
+            *) echo "wikven: '$type' neither bumps the version nor reaches the changelog; nothing to check."; exit 0 ;;
+          esac
+
+          files=$(mktemp)
+          gh api "repos/$REPOSITORY/pulls/$PULL_REQUEST/files" --paginate --jq '.[].filename' > "$files"
+          if [ ! -s "$files" ]; then
+            echo "wikven: this pull request touches no files; nothing to check."
+            exit 0
+          fi
+
+          # Everything the documentation is made of: the wiki source the site is built from, every
+          # Markdown file (the readmes), and the licence text. A pull request touching one file
+          # outside this is a change to wikven and may call itself what it likes.
+          while IFS= read -r file; do
+            case "$file" in
+              docs/* | *.md | LICENSE) ;;
+              *) echo "wikven: '$file' is not documentation; '$type' is fine here."; exit 0 ;;
+            esac
+          done < "$files"
+
+          echo "::error::wikven: this pull request changes documentation only, so it cannot be" \
+               "'$type'. A '$type' title becomes the squash commit's subject, which release-please" \
+               "reads: the change would be listed in the changelog and would move wikven's version," \
+               "and neither is true of it. Use 'docs:' instead."
+          exit 1


### PR DESCRIPTION
A new `docs-only` job in the existing Semantic Pull Request workflow, beside the check that already reads the title.

## Why

The title becomes the squash commit's subject, and release-please reads that. So a `feat:` or `fix:` on a change to the documentation alone gets listed in the changelog and moves wikven's version — claiming the software changed when it did not.

The cost lands at release time, in `CHANGELOG.md`, by hand, in a file release-please regenerates on every push to `main` — so the correction has to be re-applied after each merge until the release is cut. Cheaper to refuse the title.

## What it refuses

Only `feat` and `fix`, and only when **every** file the pull request touches is documentation:

| | |
| --- | --- |
| `docs/*` | the wiki source the site is built from |
| `*.md` | the readmes |
| `LICENSE` | |

One file outside that and the pull request may call itself what it likes. Every other type — `docs`, `chore`, `ci`, `refactor` — is left alone: this is not an opinion about what a docs-only change *should* be called, only about the two things it cannot be.

The failure says why and what to use instead, as a GitHub error annotation.

## The title is untrusted

It is whatever the author typed, so it reaches the script through `env:` rather than `${{ }}` interpolation, and the type is taken with parameter expansion, which does not re-evaluate. `feat$(touch PWNED): x` reads as type `feat$`, falls through as "not feat or fix", and creates no file — verified.

## Verification

**This job cannot run on its own pull request.** `pull_request_target` uses the workflow definition from the base branch, so `docs-only` does not exist for this run and is absent from the checks below — it starts existing only once this is merged. An earlier version of this description said it "passes trivially on itself"; that was wrong, and worth stating plainly because it means CI is not evidence here.

What is evidence: the job's script, run locally over fourteen title/file-set pairs before being written.

| title | files | |
| --- | --- | --- |
| `feat:`, `fix:`, `feat!:`, `fix(docs):` | docs only | refused |
| `Feat:`, `␣␣feat:` | docs only | refused (case and leading space normalised) |
| `feat:` | `README.md` | refused |
| `docs:`, `chore:` | docs only | allowed |
| `no conventional type here` | docs only | allowed — malformed titles are the sibling job's complaint |
| `feat:` | `includes/SiteConfig.php` | allowed |
| `feat:` | docs **and** code | allowed |
| `feat:` | `i18n/en.json` | allowed — message strings are not documentation |
| `feat:` | no files | allowed |
| `feat$(touch PWNED):` | docs only | allowed, and nothing ran |

`yamllint` and `typos` clean locally. `zizmor` does run against this diff — the `lint` workflow triggers on `pull_request` and lints the checked-out file — so the security shape of the new job is checked here even though its behaviour is not. `actionlint` is not installed locally.

The job checks nothing out, so `pull_request_target` gains no new exposure: it reads the title and a list of file names, with `pull-requests: read`.

**The first real exercise is the first docs-only pull request after this merges.** If it misfires, it misfires by refusing a title, which is visible and costs an edit rather than a bad release.