### PR TITLE
docs: bring the skin-preview readme back in line with its own config file

### DIFF
--- a/examples/skin-preview/README.md
+++ b/examples/skin-preview/README.md
@@ -8,8 +8,8 @@ floating one, thumbnails on both sides, a frameless image, a gallery, a block qu
 preformatted text and an unbreakable token — so you can bake it once and see the surface all at
 once, instead of finding out three sites later that nobody gave the definition lists a margin.
 
-`.wikven.yaml` sets `WikvenSkinPreview`, so wikven leaves the chrome alone: the personal menu, the
-toolbox, the tabs and the footer are your skin's own work, not wikven's reading of them.
+`.wikven.yaml` sets `WikvenBuildFor: skin-preview`, so wikven leaves the chrome alone: the personal
+menu, the toolbox, the tabs and the footer are your skin's own work, not wikven's reading of them.
 
 ## Using it
 
@@ -33,18 +33,22 @@ where `/workspace/src` is this directory and the site is written to `/workspace/
 workflow, point the bake action at it:
 
 ```yaml
-- uses: chaotic-ground/wikven/actions/bake@main
+- uses: chaotic-ground/wikven/actions/bake@nightly-YYYY-MM-DD
   with:
     source: examples/skin-preview
 ```
+
+Pin the action to a tag rather than a branch. Until a version of wikven is released that tag is a
+nightly — the dated pre-releases on the releases page, newest first; once one is released, `@1.2.3`
+on its own is enough.
 
 Open `dist/index.html`, and `dist/<your-skin>/index.html` for every skin after the first.
 
 ## What you will see that a real site would not
 
 A toolbox full of `Special:` links that go nowhere, a login that does nothing, a talk tab with
-nothing behind it. That is the point: it is what your skin renders. `WikvenSkinPreview` is off by
-default for exactly this reason, and a published site should leave it off.
+nothing behind it. That is the point: it is what your skin renders. `WikvenBuildFor` is `site` by
+default for exactly this reason, and a published site should leave it there.
 
 ## Editing it
 


### PR DESCRIPTION
Found by sweeping every `Wikven[A-Z]…` name in `docs/`, `examples/`, `README.md`, `default.yml` and `i18n/` against the keys `extension.json` actually declares, before 1.0.0 freezes them. Three names came back; two were false alarms and this is the third.

## `WikvenSkinPreview` no longer exists

#575 replaced it with `WikvenBuildFor`. The example's own `.wikven.yaml` was updated then:

```yaml
WikvenBuildFor: skin-preview
```

The readme sitting beside it was not, and still told a skin author to set a key wikven does not have — twice, once as the thing the tree is built on and once as the thing a published site should leave off.

Since #578 an unknown config key is warned about by name during the build, so following the readme now produces a `Wikven: WARNING` rather than a silent no-op. Better, but still not what the reader was promised.

## The snippet pinned the action at `@main`

Every other workflow snippet in the project — *Commands* twice, *Deploying* once — uses `@nightly-YYYY-MM-DD` and explains why. This example was the only one steering a reader onto a moving ref, on the action that runs a container. Pinned, with the same note the other pages carry.

## The two false alarms, for the record

Neither needed changing, and both are worth knowing about before someone else sweeps:

- **`WikvenSettings`** in `default.yml` and *Development* is `includes/WikvenSettings.php`, the file. Not a config key.
- **`<span id="WikvenStyleDirectory">`** in *Configuration* is deliberate: #584 kept the old anchor beside the new `WikvenAssetDirectory` one so existing links still resolve.

The sweep's other direction came back clean — every key `extension.json` declares is named somewhere in `docs/`.

*(One inconsistency it did surface, not fixed here because nothing is released yet and so no link to either can be stale: `WikvenStyleDirectory` kept a legacy anchor, while `WikvenAboutPage` and `WikvenSkinPreview` did not.)*

## Verification

`typos` clean. This is the first change to exercise #586 — `examples/skin-preview/README.md` matches the `*.md` rule, so every file here is documentation and a `feat:` or `fix:` title would be refused. The title is `docs:`, so the check should pass; the `docs-only` job runs from `main`, which now carries it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_