### PR TITLE
fix: refuse an image or asset path that climbs out of its directory

### DIFF
--- a/actions/bake/action.yml
+++ b/actions/bake/action.yml
@@ -126,8 +126,11 @@ runs:
           echo "wikven: no per-file history for '$SOURCE'; every page will be dated at the commit" \
                "being built. Check the repository out with fetch-depth: 0 for per-page dates."
         fi
+        # Source read-only. A bake runs the third-party code WikvenRepositories names, and a
+        # writable mount would let that code edit the checkout this job goes on to use. Only the
+        # translate subcommands write into src/, and this action never runs one.
         docker run --rm \
-          -v "$PWD/$SOURCE:/workspace/src" \
+          -v "$PWD/$SOURCE:/workspace/src:ro" \
           -v "$PWD/$OUTPUT:/workspace/dist" \
           "${epoch[@]}" \
           "${jobs[@]}" \

--- a/examples/skin-preview/README.md
+++ b/examples/skin-preview/README.md
@@ -8,8 +8,8 @@ floating one, thumbnails on both sides, a frameless image, a gallery, a block qu
 preformatted text and an unbreakable token — so you can bake it once and see the surface all at
 once, instead of finding out three sites later that nobody gave the definition lists a margin.
 
-`.wikven.yaml` sets `WikvenSkinPreview`, so wikven leaves the chrome alone: the personal menu, the
-toolbox, the tabs and the footer are your skin's own work, not wikven's reading of them.
+`.wikven.yaml` sets `WikvenBuildFor: skin-preview`, so wikven leaves the chrome alone: the personal
+menu, the toolbox, the tabs and the footer are your skin's own work, not wikven's reading of them.
 
 ## Using it
 
@@ -33,18 +33,22 @@ where `/workspace/src` is this directory and the site is written to `/workspace/
 workflow, point the bake action at it:
 
 ```yaml
-- uses: chaotic-ground/wikven/actions/bake@main
+- uses: chaotic-ground/wikven/actions/bake@nightly-YYYY-MM-DD
   with:
     source: examples/skin-preview
 ```
+
+Pin the action to a tag rather than a branch. Until a version of wikven is released that tag is a
+nightly — the dated pre-releases on the releases page, newest first; once one is released, `@1.2.3`
+on its own is enough.
 
 Open `dist/index.html`, and `dist/<your-skin>/index.html` for every skin after the first.
 
 ## What you will see that a real site would not
 
 A toolbox full of `Special:` links that go nowhere, a login that does nothing, a talk tab with
-nothing behind it. That is the point: it is what your skin renders. `WikvenSkinPreview` is off by
-default for exactly this reason, and a published site should leave it off.
+nothing behind it. That is the point: it is what your skin renders. `WikvenBuildFor` is `site` by
+default for exactly this reason, and a published site should leave it there.
 
 ## Editing it
 

--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -159,8 +159,10 @@ class AssetLocalizer {
 	 * @return string|null Relative url() target, or null if the file is missing.
 	 */
 	private static function copyAsset(string $mwRoot, string $path, string $dir, bool $inline = false): ?string {
-		$src = $mwRoot . $path;
-		if (!is_readable($src)) {
+		// $path is whatever a url() in the dumped CSS said, and one of those files is the site's own
+		// MediaWiki:Common.css, so bound it to the install root before reading a file at it.
+		$src = ContainedPath::under($mwRoot, $path);
+		if ($src === null || !is_readable($src)) {
 			return null;
 		}
 		$bytes = file_get_contents($src);

--- a/includes/ContainedPath.php
+++ b/includes/ContainedPath.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * Joins a web path onto the directory it is supposed to name, or refuses it for climbing out.
+ *
+ * Two steps take a path out of content and look for a file at it: storeImages reads the rendered
+ * HTML for $wgUploadPath references, and AssetLocalizer reads dumped CSS for url()s under /skins,
+ * /resources and /extensions. Both paths come from something a site author wrote -- a page's body,
+ * or MediaWiki:Common.css -- so neither is the build's own, and concatenating one onto a directory
+ * hands whoever wrote it every file the build can read: the copy lands in the output directory and
+ * is published with the site.
+ *
+ * The answer is not to trust the path but to bound where it can reach, which is what this does.
+ */
+class ContainedPath {
+	/**
+	 * The file a web path names under a root directory, or null where it does not stay under it.
+	 *
+	 * Null is not "missing": a path that names nothing still comes back joined, because whether the
+	 * file is there is the caller's question and its own to report. Null means the path was never
+	 * this directory's to answer for.
+	 *
+	 * @param string $root Absolute path of the directory the web path is relative to.
+	 * @param string $path A web path, leading slash and all, as it appeared in the content.
+	 * @return string|null The absolute path to read, or null where it climbs out of $root.
+	 */
+	public static function under(string $root, string $path): ?string {
+		$root = rtrim($root, '/');
+		if ($root === '' || $path === '' || $path[0] !== '/') {
+			return null;
+		}
+		// Lexical first, and on segments rather than a substring: "/..%2Fx" is one segment and no
+		// climb, while "/a/../../x" is two of them and reaches above $root however deep $root is.
+		if (in_array('..', explode('/', $path), true)) {
+			return null;
+		}
+		$joined = $root . $path;
+		// A symlink under $root can point anywhere, and only the filesystem knows where. Judged
+		// only where both ends resolve; a path that resolves to nothing has nothing to escape with,
+		// and is left to the caller to find missing.
+		$realRoot = realpath($root);
+		$real = realpath($joined);
+		if ($realRoot !== false && $real !== false && !str_starts_with($real, rtrim($realRoot, '/') . '/')) {
+			return null;
+		}
+		return $joined;
+	}
+}

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -56,7 +56,14 @@ class StoreImages extends Maintenance {
 					// Key by storage path (no ?query) so sizes/timestamps of one file dedupe.
 					$path = $m[1];
 					if (!array_key_exists($path, $map)) {
-						$map[$path] = $this->storeLocal($uploadDir . $path, $path, $dir);
+						// The path came out of a page's rendered HTML, so it is whatever someone
+						// wrote there rather than something MediaWiki stored. Bound it to the
+						// upload directory before reading a file at it.
+						$src = ContainedPath::under($uploadDir, $path);
+						if ($src === null) {
+							$this->output("  refusing: $path (reaches outside the upload directory)\n");
+						}
+						$map[$path] = $src === null ? null : $this->storeLocal($src, $path, $dir);
 					}
 					return $map[$path] ?? $m[0];
 				},

--- a/tests/phpunit/unit/ContainedPathTest.php
+++ b/tests/phpunit/unit/ContainedPathTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\ContainedPath;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\ContainedPath
+ */
+class ContainedPathTest extends MediaWikiUnitTestCase {
+	private string $root;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$base = sys_get_temp_dir() . '/wikven-contained-' . uniqid();
+		$this->root = "$base/uploads";
+		mkdir("$this->root/sub", 0777, true);
+		mkdir("$base/outside", 0777, true);
+		touch("$this->root/Logo.png");
+		touch("$this->root/sub/Deep.png");
+		file_put_contents("$base/outside/secret.txt", 'x');
+		symlink("$base/outside", "$this->root/link");
+	}
+
+	protected function tearDown(): void {
+		$base = dirname($this->root);
+		if (is_dir($base)) {
+			$files = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS),
+				\RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($files as $file) {
+				$file->isDir() && !$file->isLink() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+			}
+			rmdir($base);
+		}
+		parent::tearDown();
+	}
+
+	public function testAPathInsideTheDirectoryIsJoinedOntoIt() {
+		$this->assertSame("$this->root/Logo.png", ContainedPath::under($this->root, '/Logo.png'));
+		$this->assertSame("$this->root/sub/Deep.png", ContainedPath::under($this->root, '/sub/Deep.png'));
+	}
+
+	/**
+	 * A path that names nothing still comes back joined: whether the file is there is the caller's
+	 * question, and storeImages reports it as missing rather than as refused.
+	 */
+	public function testAPathThatNamesNoFileIsStillThisDirectoryToAnswerFor() {
+		$this->assertSame("$this->root/nosuch.png", ContainedPath::under($this->root, '/nosuch.png'));
+	}
+
+	/**
+	 * The failure this exists to catch. storeImages matches $wgUploadPath references in a page's
+	 * rendered HTML, and the text of a page is whatever someone wrote: "/images/../../../etc/passwd"
+	 * needs no markup to get there, since neither dots nor slashes are escaped on the way out. Left
+	 * unbounded, the file is copied into the output directory and published with the site.
+	 */
+	public function testAPathThatClimbsOutOfTheDirectoryIsRefused() {
+		$this->assertNull(ContainedPath::under($this->root, '/../outside/secret.txt'));
+		$this->assertNull(ContainedPath::under($this->root, '/../../../../../../etc/passwd'));
+	}
+
+	/** Refused wherever the climb appears, not only at the front. */
+	public function testAClimbInTheMiddleIsRefusedEvenWhereItLandsBackInside() {
+		$this->assertNull(ContainedPath::under($this->root, '/sub/../Logo.png'));
+	}
+
+	/**
+	 * Counting ".." segments cannot see this one: every segment stays inside the directory and the
+	 * filesystem is what knows where the link points.
+	 */
+	public function testASymlinkPointingOutOfTheDirectoryIsRefused() {
+		$this->assertNull(ContainedPath::under($this->root, '/link/secret.txt'));
+	}
+
+	/**
+	 * Matched on segments rather than as a substring: this names a directory whose name happens to
+	 * contain the characters, which climbs nowhere and is nothing to refuse.
+	 */
+	public function testAnEncodedClimbIsANameRatherThanAClimb() {
+		$this->assertSame(
+			"$this->root/..%2Foutside/x.png",
+			ContainedPath::under($this->root, '/..%2Foutside/x.png')
+		);
+	}
+
+	public function testAPathThatIsNotOneIsRefused() {
+		$this->assertNull(ContainedPath::under($this->root, 'relative.png'), 'no leading slash');
+		$this->assertNull(ContainedPath::under($this->root, ''), 'empty path');
+		$this->assertNull(ContainedPath::under($this->root, '/'), 'the directory itself is not a file in it');
+		$this->assertNull(ContainedPath::under('', '/Logo.png'), 'no root to be under');
+	}
+
+	/** A trailing slash on the root is spelled away rather than doubling the separator. */
+	public function testTheRootMayBeSpelledWithATrailingSlash() {
+		$this->assertSame("$this->root/Logo.png", ContainedPath::under("$this->root/", '/Logo.png'));
+	}
+}


### PR DESCRIPTION
Three findings from the pre-1.0.0 review. Two are the same bug in two places; the third is a mount flag.

## 1. `storeImages` read any file the build could reach, and published it

`maintenance/storeImages.php:35` matches `$wgUploadPath` references in every page's **rendered HTML**:

```php
$localPattern = '~(?:(?:https?:)?//[^/\s"]+)?' . preg_quote($wgUploadPath, '~') . '(/[^\s"?]+)(?:\?[^\s"]*)?~';
```

`[^\s"?]+` admits `.` and `/`, and `:143` joined the result onto the upload directory with no normalisation:

```php
$map[$path] = $this->storeLocal($uploadDir . $path, $path, $dir);
```

The regex runs over rendered HTML, so **no markup is needed** — a page whose body contains `/images/../../../../etc/passwd` is enough, since neither dots nor slashes are escaped on the way out. Whoever can add a page to the source tree gets an arbitrary file read whose result is written into `dist/` and published.

Reproduced against the real code path, with the upload directory in place:

```
/../../../../../../../../etc/passwd   is_file=true  size=1238
/../../src/evil.php                   is_file=true  size=21
content read back: <?php echo "planted";
would write: img-dd34a0272e53.php
```

The second line is the worse half. `extension()` (`:165`) accepts any `[a-z0-9]+`, `php` included, and `importWikitext` silently ignores a `src/evil.php` as not being a page file — so it sits in the mounted source tree until a page reaches back for it, and lands in the output directory as `img-<hash>.php`. `bin/entrypoint:15` serves that directory with `php -S`.

## 2. `AssetLocalizer::copyAsset` is the same shape one layer down

`includes/AssetLocalizer.php:58` matches `url()` targets under `/skins`, `/resources`, `/extensions` with `[^)'"?]+`, and `:161` joined them onto `$IP`. One of the files it rewrites is the site's own `MediaWiki:Common.css` (`buildStyles.php:73-90` dumps it and then localises the directory), so the same author reaches the same primitive. Narrower — the path must end in an image or font extension — but the same one-line fix.

## The fix

`ContainedPath::under($root, $path)` answers the question both call sites were assuming, and returns `null` where the path was never that directory's to answer for:

- Refuses a `..` **segment** — matched on segments rather than as a substring, so `/..%2Fx` is a directory name that climbs nowhere, while `/a/../../x` is refused however deep the root is.
- Refuses a target that leaves the root by a **symlink**, which counting segments cannot see.
- A path naming no file still comes back joined: whether the file is there is the caller's question, and `storeImages` already reports that as missing.

A refused image makes `$map[$path]` null, which `storeImages.php:73-77` already turns into a failed build — the same path a missing image took.

### One cost, stated plainly

The symlink half will refuse a legitimate asset in an install whose `skins/` or `extensions/` entries are symlinks elsewhere — a normal way to develop against a local MediaWiki, though not how the image or the binary is built. Segment-counting alone closes the reported hole; the symlink check is there because a symlink under a directory that holds imported files is not something I wanted to reason about twice. Say the word and I will drop it to the lexical check.

## 3. `actions/bake` mounted the consumer's source tree writable

`actions/bake/action.yml:129` used `-v "$PWD/$SOURCE:/workspace/src"`, while the sibling `check-translations` action (`:156`) and this repo's own `smoke.yml:83` both mount it `:ro`.

A bake **runs** the third-party code `WikvenRepositories` names — the docs say so — so that code could rewrite the checkout the rest of the job goes on to read, commit or publish, as root (the image sets no `USER`). Checked the write is unnecessary rather than assuming: the only things that write into the source directory are `markTranslations.php:66`, `scaffoldTranslations.php:82` and `stampTranslations.php:69`, all `translate` subcommands, and this action runs the default `build`.

`zizmor` does not cover this — it audits expression and permission hygiene, not mount flags inside a `run:` block.

## Verification

- **8 new tests**, run green under real PHPUnit 11.5.56 before being committed: inside, nested, nonexistent-but-inside, a leading climb, a climb in the middle that lands back inside, a symlink out, an encoded climb that is a name, a relative path, an empty path, the bare root, no root, and a trailing-slash root.
- My first run of that harness was **invalid** — the shell variable holding the root was not exported, so the root did not exist, `realpath()` returned false and the symlink case passed for the wrong reason. Re-run against the real directory it is refused. Worth recording, since a containment test that silently tests nothing is the failure mode here.
- `typos`, `yamllint`, `mago fmt`, `mago lint` clean locally.
- `smoke` and `preview` are the real proof of no regression: both bake the docs site through the image, with images and CSS that must still localise.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_