### PR TITLE
fix: answer symlinks where a source tree is read, not where a path is bounded

### DIFF
--- a/docs/Pages.wikitext
+++ b/docs/Pages.wikitext
@@ -27,7 +27,7 @@ Link with <code><nowiki>[[Title]]</nowiki></code>, or <code><nowiki>[[Title|labe
 == Subpages ==
 
 <!--T:9-->
-Put a file in a subdirectory to create a [<tvar name="1">https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Subpages</tvar> subpage]: <code>src/Guide/Setup.wikitext</code> becomes the page "Guide/Setup". Images in a subdirectory are imported too, but a picture is named by its file name alone -- <code>src/Guide/diagram.png</code> is <code>[[File:diagram.png]]</code>, not "Guide/diagram.png" -- so two directories cannot both hold a <code>diagram.png</code>. The build stops and names both rather than publish one page showing the other's picture.
+Put a file in a subdirectory to create a [<tvar name="1">https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Subpages</tvar> subpage]: <code>src/Guide/Setup.wikitext</code> becomes the page "Guide/Setup". Images in a subdirectory are imported too, but a picture is named by its file name alone -- <code>src/Guide/diagram.png</code> is <code>[[File:diagram.png]]</code>, not "Guide/diagram.png" -- so two directories cannot both hold a <code>diagram.png</code>. The build stops and names both rather than publish one page showing the other's picture. An image has to be a file rather than a link to one, for the same reason: what a link points at is not part of what you are publishing, and the build refuses it by name instead of uploading it.
 
 <!--T:24-->
 <span id="reserved-names"></span>

--- a/docs/Pages/ko.wikitext
+++ b/docs/Pages/ko.wikitext
@@ -25,8 +25,8 @@
 <!--T:8 @654ede6a-->
 == 하위 문서 ==
 
-<!--T:9 @ed4749ad-->
-파일을 하위 디렉터리에 두면 [$1 하위 문서]가 만들어집니다. <code>src/Guide/Setup.wikitext</code>는 "Guide/Setup" 문서가 됩니다. 하위 디렉터리의 그림도 함께 가져오지만, 그림의 이름은 파일 이름뿐입니다. <code>src/Guide/diagram.png</code>는 "Guide/diagram.png"가 아니라 <code>[[File:diagram.png]]</code>이므로, 두 디렉터리가 같은 <code>diagram.png</code>를 가질 수 없습니다. 그런 경우 빌드는 한 문서가 다른 문서의 그림을 보여주는 사이트를 발행하는 대신, 둘 다 이름을 대고 멈춥니다.
+<!--T:9 @b1193e6c-->
+파일을 하위 디렉터리에 두면 [$1 하위 문서]가 만들어집니다. <code>src/Guide/Setup.wikitext</code>는 "Guide/Setup" 문서가 됩니다. 하위 디렉터리의 그림도 함께 가져오지만, 그림의 이름은 파일 이름뿐입니다. <code>src/Guide/diagram.png</code>는 "Guide/diagram.png"가 아니라 <code>[[File:diagram.png]]</code>이므로, 두 디렉터리가 같은 <code>diagram.png</code>를 가질 수 없습니다. 그런 경우 빌드는 한 문서가 다른 문서의 그림을 보여주는 사이트를 발행하는 대신, 둘 다 이름을 대고 멈춥니다. 그림은 링크가 아니라 파일이어야 하는데, 이유는 같습니다. 링크가 가리키는 것은 여러분이 발행하는 것의 일부가 아니므로, 빌드는 그것을 올리는 대신 이름을 대고 거부합니다.
 
 <!--T:24 @938e2292-->
 <span id="reserved-names"></span>

--- a/includes/ContainedPath.php
+++ b/includes/ContainedPath.php
@@ -13,6 +13,14 @@ namespace MediaWiki\Extension\Wikven;
  * is published with the site.
  *
  * The answer is not to trust the path but to bound where it can reach, which is what this does.
+ *
+ * The path is judged, not where the filesystem would take it. A symlink under the root pointing out
+ * of it escapes this, and is left to: neither root holds anything the author of a path put there.
+ * MediaWiki writes a file's contents into the upload directory rather than a link to them, and the
+ * install root is the build's own. What a source tree can bring is refused where the source tree is
+ * read, by ImageImport, which can name the file it refused -- while a check here would have refused
+ * the symlinked skins/ and extensions/ of a MediaWiki someone develops against, silently, which is
+ * the kind of failure this class exists against.
  */
 class ContainedPath {
 	/**
@@ -31,20 +39,17 @@ class ContainedPath {
 		if ($root === '' || $path === '' || $path[0] !== '/') {
 			return null;
 		}
-		// Lexical first, and on segments rather than a substring: "/..%2Fx" is one segment and no
-		// climb, while "/a/../../x" is two of them and reaches above $root however deep $root is.
-		if (in_array('..', explode('/', $path), true)) {
-			return null;
+		// On segments rather than as a substring: "/..%2Fx" is one segment and no climb, while
+		// "/a/../../x" is two of them and reaches above $root however deep $root is. The leading
+		// empty one is the leading slash; an empty one after that is a path naming a directory
+		// ("/images/") or a doubled slash, and names no file either way.
+		$segments = explode('/', $path);
+		array_shift($segments);
+		foreach ($segments as $segment) {
+			if ($segment === '..' || $segment === '') {
+				return null;
+			}
 		}
-		$joined = $root . $path;
-		// A symlink under $root can point anywhere, and only the filesystem knows where. Judged
-		// only where both ends resolve; a path that resolves to nothing has nothing to escape with,
-		// and is left to the caller to find missing.
-		$realRoot = realpath($root);
-		$real = realpath($joined);
-		if ($realRoot !== false && $real !== false && !str_starts_with($real, rtrim($realRoot, '/') . '/')) {
-			return null;
-		}
-		return $joined;
+		return $root . $path;
 	}
 }

--- a/includes/ImageImport.php
+++ b/includes/ImageImport.php
@@ -35,7 +35,7 @@ class ImageImport {
 				continue;
 			}
 			$path = $directory . '/' . $entry;
-			if (is_dir($path)) {
+			if (is_dir($path) && !is_link($path)) {
 				$sources = array_merge($sources, self::sources($path, $extensions));
 				continue;
 			}
@@ -78,6 +78,32 @@ class ImageImport {
 			}
 		}
 		return $shared;
+	}
+
+	/**
+	 * Files among $sources that are symlinks, which is not a thing to import.
+	 *
+	 * is_file() follows a link, so a source tree can offer one named picture.png and have the build
+	 * upload whatever it points at -- a file outside the tree, on the machine doing the building,
+	 * published with the site. A tree of wiki content has no use for one, so rather than resolve
+	 * them they are refused, by name, where the tree is read.
+	 *
+	 * This is where wikven answers symlinks at all. ContainedPath, which bounds the paths that come
+	 * back out of rendered pages, does not: the directories it bounds hold nothing an author put
+	 * there, and a check in it would silently refuse the symlinked skins/ of a MediaWiki checkout
+	 * somebody develops against.
+	 *
+	 * @param string[] $sources Absolute paths, as sources() returns them.
+	 * @return string[] Those of them that are links.
+	 */
+	public static function links(array $sources): array {
+		$links = [];
+		foreach ($sources as $path) {
+			if (is_link($path)) {
+				$links[] = $path;
+			}
+		}
+		return $links;
 	}
 
 	/**

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -918,6 +918,19 @@ class Build extends Maintenance {
 		$extensions = $GLOBALS['wgFileExtensions'];
 		$sources = ImageImport::sources($directory, $extensions);
 
+		// is_file() follows a link, so an image that is one would have the build upload whatever it
+		// points at -- a file outside the source tree, on this machine -- and publish it.
+		$links = ImageImport::links($sources);
+		if ($links !== []) {
+			foreach ($links as $link) {
+				$this->error("Wikven: '$link' is a link rather than an image");
+			}
+			$this->fatalError(
+				'Wikven: an image has to be a file in the source tree, since what a link points at is'
+				. ' not part of what you are publishing. Replace each with the file; aborting the build.'
+			);
+		}
+
 		// A File: title is the file's name alone, so two images sharing a name in two directories
 		// are one page, and --skip-dupes below would take the first and drop the second with a line
 		// nobody reads. Said here, with both paths, before anything is imported.

--- a/tests/phpunit/unit/ContainedPathTest.php
+++ b/tests/phpunit/unit/ContainedPathTest.php
@@ -68,11 +68,15 @@ class ContainedPathTest extends MediaWikiUnitTestCase {
 	}
 
 	/**
-	 * Counting ".." segments cannot see this one: every segment stays inside the directory and the
-	 * filesystem is what knows where the link points.
+	 * A link is followed rather than refused, deliberately. Neither directory this bounds holds
+	 * anything the author of a path put there -- MediaWiki writes a file's contents into the upload
+	 * directory rather than a link to them, and the install root is the build's own -- while
+	 * refusing links here would have silently dropped the assets of a MediaWiki whose skins/ and
+	 * extensions/ are symlinked, which is how people develop against one. What a source tree can
+	 * bring is refused by ImageImport, where the file can be named.
 	 */
-	public function testASymlinkPointingOutOfTheDirectoryIsRefused() {
-		$this->assertNull(ContainedPath::under($this->root, '/link/secret.txt'));
+	public function testALinkIsThisDirectoryToAnswerFor() {
+		$this->assertSame("$this->root/link/secret.txt", ContainedPath::under($this->root, '/link/secret.txt'));
 	}
 
 	/**

--- a/tests/phpunit/unit/ImageImportTest.php
+++ b/tests/phpunit/unit/ImageImportTest.php
@@ -26,7 +26,10 @@ class ImageImportTest extends MediaWikiUnitTestCase {
 			\RecursiveIteratorIterator::CHILD_FIRST
 		);
 		foreach ($entries as $entry) {
-			$entry->isDir() ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+			// A link to a directory reports itself as one; it is unlinked, not descended into.
+			$entry->isDir() && !$entry->isLink()
+				? rmdir($entry->getPathname())
+				: unlink($entry->getPathname());
 		}
 		rmdir($this->directory);
 		parent::tearDown();
@@ -125,6 +128,46 @@ class ImageImportTest extends MediaWikiUnitTestCase {
 		touch($this->directory . '/Diagram.png');
 
 		$this->assertSame([], ImageImport::collisions(ImageImport::sources($this->directory, self::EXTENSIONS)));
+	}
+
+	/**
+	 * is_file() follows a link, so this one would have had the build upload whatever it points at
+	 * -- a file outside the tree, on the machine doing the building -- and publish it with the site.
+	 */
+	public function testAnImageThatIsALinkIsFoundAndRefused() {
+		mkdir($this->directory . '/Guide');
+		touch($this->directory . '/real.png');
+		symlink('/etc/passwd', $this->directory . '/Guide/picture.png');
+
+		$sources = ImageImport::sources($this->directory, self::EXTENSIONS);
+
+		$this->assertSame(['picture.png', 'real.png'], $this->basenames($sources));
+		$this->assertSame(
+			[$this->directory . '/Guide/picture.png'],
+			ImageImport::links($sources)
+		);
+	}
+
+	/** A tree of real files has none, so nothing is refused. */
+	public function testFilesThatAreFilesAreNotLinks() {
+		touch($this->directory . '/real.png');
+
+		$this->assertSame([], ImageImport::links(ImageImport::sources($this->directory, self::EXTENSIONS)));
+	}
+
+	/**
+	 * The walk does not follow a linked directory either: it would leave the source tree entirely,
+	 * and every file under it would import as though the site shipped it.
+	 */
+	public function testTheWalkDoesNotFollowALinkedDirectory() {
+		mkdir($this->directory . '/real');
+		touch($this->directory . '/real/inside.png');
+		symlink('/etc', $this->directory . '/elsewhere');
+
+		$this->assertSame(
+			['inside.png'],
+			$this->basenames(ImageImport::sources($this->directory, self::EXTENSIONS))
+		);
 	}
 
 	/** A source directory that is not there yet offers nothing, rather than warning about it. */


### PR DESCRIPTION
Settles the open question from #588, where I flagged the cost and said I would drop the check if asked. Rather than only dropping it, this moves the concern to the doorway it actually belongs at.

## Why the check comes out

#588 gave `ContainedPath::under()` two checks: a lexical `..` refusal, and a `realpath()` containment test for symlinks. **The lexical one is what closed the reported hole.** The second was belt and braces, and re-reading it, the belt costs more than it holds:

- It refuses the assets of a MediaWiki whose `skins/` or `extensions/` are symlinks elsewhere — which is how people develop against a local checkout.
- It refuses them **silently**: a `url()` that cannot be localized is left as it was, and the export ships with a broken image and nothing in the log.

A security check that fails closed and invisibly is the same defect class the rest of this work has been closing.

It was also guarding the wrong doorway. Neither directory it bounds holds anything the author of a path put there — MediaWiki writes a file's **contents** into the upload directory rather than a link to them, and the install root is the build's own. The attacker never gets to plant a link in either.

## Where it goes instead

What a source tree can bring is a symlink **in the source tree**, and `is_file()` follows one. So an image that is a link had the build upload whatever it pointed at — a file elsewhere on the machine doing the building — and publish it with the site. That is the same primitive #588 closed, through a door #588 did not cover.

`ImageImport::links()` finds them and the build stops, naming each. Two differences from the check being removed: it can **say what it refused**, and it is where a person would look for it.

The walk also no longer descends into a **linked directory** (`is_dir($path) && !is_link($path)`). Without that, recursion — new in #590 — could leave the source tree entirely and import everything under wherever the link pointed.

## A second thing the realpath check had been doing

Removing it turned up that `under($root, '/')` came back as the root rather than `null`. Unreachable through either caller (both patterns need a character after the slash), but `ContainedPathTest` asserted `null` with the reason *"the directory itself is not a file in it"* — and that reason is right. It is now refused lexically, along with the doubled slash and trailing slash that share its shape.

**The test is what found it.** It failed on the first run after the check came out, which is the whole point of having written it.

## Verification

- 20 tests green under real PHPUnit 11.5.56, after two failures I had to fix:
  1. the `/` case above — the code was wrong, not the test;
  2. `ImageImportTest`'s own teardown treated a link-to-a-directory as a directory and left temp dirs behind. Same distinction as the walk itself needs.
- `ContainedPathTest`'s symlink case now asserts the opposite and carries the reasoning, rather than being deleted.
- Exercised against real trees: a `picture.png` symlinked to `/etc/passwd` is found as a source and reported as a link; a directory symlinked to `/etc` is not descended into; a tree of real files reports none.
- `typos`, `phpcs` (whole tree, as CI runs it), `mago fmt`, `mago lint` clean.
- *Pages* gains the rule in both languages, beside the image-name rule from #590; `analyze()` reports every unit `ok`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_