### PR TITLE
test: hold the tarball checksum to what the documentation promises

### DIFF
--- a/includes/TarballChecksum.php
+++ b/includes/TarballChecksum.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * The sha256 a WikvenRepositories tarball entry pins, and whether a download is the file it names.
+ *
+ * Configuration promises this: "64 hex characters; the build aborts on a mismatch", and tells a
+ * site to pin one "for a tamper-evident, reproducible build". A tarball is the one fetch method
+ * whose source can change under a site without its configuration changing -- a URL serves whatever
+ * it serves today -- so the pin is the only thing between a site and running code nobody chose.
+ *
+ * Kept here rather than inside the maintenance script so the promise can be held to a test: what a
+ * spec pins, what counts as a sha256, and whether a file answers to one are three questions with
+ * answers that do not need a wiki.
+ */
+class TarballChecksum {
+	/**
+	 * The checksum a spec pins, lowercased and trimmed, or null where it pins none.
+	 *
+	 * Says nothing about whether the value is a checksum; that is isValid()'s question, asked
+	 * separately so a spec that pins nonsense is told apart from one that pins nothing.
+	 *
+	 * @param array $spec One WikvenRepositories entry.
+	 */
+	public static function wanted(array $spec): ?string {
+		if (!isset($spec['sha256'])) {
+			return null;
+		}
+		if (is_array($spec['sha256']) || is_object($spec['sha256'])) {
+			return '';
+		}
+		return strtolower(trim((string)$spec['sha256']));
+	}
+
+	/** Whether a value is the 64 hex characters a sha256 is written as. */
+	public static function isValid(string $checksum): bool {
+		return preg_match('/^[0-9a-f]{64}$/', $checksum) === 1;
+	}
+
+	/**
+	 * Whether the file at $path is the one $wanted names.
+	 *
+	 * Compared with hash_equals, which takes the same time whichever character differs. A build
+	 * host is not a place anyone is timing, but a comparison that leaks where it stopped is not
+	 * worth keeping for the nanoseconds it saves.
+	 *
+	 * @param string $wanted A checksum isValid() accepts.
+	 * @param string $path The downloaded file.
+	 */
+	public static function matches(string $wanted, string $path): bool {
+		$actual = is_file($path) ? hash_file('sha256', $path) : false;
+		return $actual !== false && hash_equals($wanted, $actual);
+	}
+}

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -23,6 +23,7 @@ require_once "$IP/maintenance/Maintenance.php";
 require_once __DIR__ . '/../includes/Attempts.php';
 require_once __DIR__ . '/../includes/ComposerInstall.php';
 require_once __DIR__ . '/../includes/FetchPin.php';
+require_once __DIR__ . '/../includes/TarballChecksum.php';
 require_once __DIR__ . '/../includes/UserAgent.php';
 
 /** Fetch third-party extensions/skins declared in .wikven.yaml before MediaWiki loads them. */
@@ -265,11 +266,11 @@ class FetchExtensions extends Maintenance {
 
 	/** The lowercased, validated `sha256:` of a tarball spec, or null if absent. */
 	private function validatedSha256(array $spec, string $name, string $kind): ?string {
-		if (!isset($spec['sha256'])) {
+		$sha = TarballChecksum::wanted($spec);
+		if ($sha === null) {
 			return null;
 		}
-		$sha = strtolower(trim((string)$spec['sha256']));
-		if (!preg_match('/^[0-9a-f]{64}$/', $sha)) {
+		if (!TarballChecksum::isValid($sha)) {
 			$this->fatalError("Wikven: $kind '$name' has an invalid sha256 (expected 64 hex characters).");
 		}
 		return $sha;
@@ -295,8 +296,8 @@ class FetchExtensions extends Maintenance {
 		$tmp = tempnam(sys_get_temp_dir(), 'wikven');
 		$this->download($url, $tmp, "download $kind '$name'");
 		if ($sha256 !== null) {
-			$actual = hash_file('sha256', $tmp);
-			if (!hash_equals($sha256, (string)$actual)) {
+			if (!TarballChecksum::matches($sha256, $tmp)) {
+				$actual = is_file($tmp) ? hash_file('sha256', $tmp) : 'nothing';
 				unlink($tmp);
 				$this->fatalError(
 					"Wikven: $kind '$name' tarball sha256 mismatch (expected $sha256, got $actual)."

--- a/tests/phpunit/unit/TarballChecksumTest.php
+++ b/tests/phpunit/unit/TarballChecksumTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\TarballChecksum;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\TarballChecksum
+ */
+class TarballChecksumTest extends MediaWikiUnitTestCase {
+	/** sha256 of the string "wikven", which the fixtures below are written with. */
+	private const WIKVEN = '4aeacdc4e8c0957fd033b0ee00b8fcf38bbcd9513b6160c1150864b498b68dd2';
+
+	private string $file;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->file = sys_get_temp_dir() . '/wikven-tarball-' . getmypid() . '-' . uniqid();
+		file_put_contents($this->file, 'wikven');
+	}
+
+	protected function tearDown(): void {
+		if (is_file($this->file)) {
+			unlink($this->file);
+		}
+		parent::tearDown();
+	}
+
+	public function testASpecPinningNothingWantsNothing() {
+		$this->assertNull(TarballChecksum::wanted(['tarball' => 'https://example.test/x.tar.gz']));
+	}
+
+	/**
+	 * Told apart from pinning nothing on purpose: a spec whose sha256 is unreadable has said
+	 * something and got it wrong, and the build stops on it rather than fetching unverified.
+	 */
+	public function testASpecPinningSomethingUnreadableWantsAnEmptyString() {
+		$this->assertSame('', TarballChecksum::wanted(['sha256' => ['not', 'a', 'string']]));
+		$this->assertFalse(TarballChecksum::isValid(''));
+	}
+
+	public function testACheckSumIsTakenAsWrittenOnceLowercasedAndTrimmed() {
+		$upper = strtoupper(self::WIKVEN);
+
+		$this->assertSame(self::WIKVEN, TarballChecksum::wanted(['sha256' => $upper]));
+		$this->assertSame(self::WIKVEN, TarballChecksum::wanted(['sha256' => "  $upper\n"]));
+	}
+
+	public function testSixtyFourHexCharactersIsAChecksum() {
+		$this->assertTrue(TarballChecksum::isValid(self::WIKVEN));
+	}
+
+	public function testAnythingElseIsNot() {
+		$this->assertFalse(TarballChecksum::isValid(''), 'empty');
+		$this->assertFalse(TarballChecksum::isValid(substr(self::WIKVEN, 0, 63)), 'one short');
+		$this->assertFalse(TarballChecksum::isValid(self::WIKVEN . 'a'), 'one long');
+		$this->assertFalse(TarballChecksum::isValid(str_repeat('g', 64)), 'not hex');
+		$this->assertFalse(TarballChecksum::isValid(strtoupper(self::WIKVEN)), 'wanted() lowercases first');
+		$this->assertFalse(TarballChecksum::isValid('sha256:' . self::WIKVEN), 'carries a prefix');
+	}
+
+	public function testAFileThatHashesToThePinMatchesIt() {
+		$this->assertTrue(TarballChecksum::matches(self::WIKVEN, $this->file));
+	}
+
+	/**
+	 * The promise this exists to hold. Configuration says "the build aborts on a mismatch", and a
+	 * tarball is the one fetch method whose source can change without the site's configuration
+	 * changing -- so a comparison that stopped saying no would let a build run code nobody chose,
+	 * with the documentation still promising it could not.
+	 */
+	public function testAFileThatDoesNotIsRefused() {
+		file_put_contents($this->file, 'wikven, tampered with');
+
+		$this->assertFalse(TarballChecksum::matches(self::WIKVEN, $this->file));
+	}
+
+	/** Including when the difference is one character, which is the interesting mismatch. */
+	public function testOneCharacterOfDifferenceIsAMismatch() {
+		$almost = substr(self::WIKVEN, 0, 63) . ( self::WIKVEN[63] === 'a' ? 'b' : 'a' );
+
+		$this->assertFalse(TarballChecksum::matches($almost, $this->file));
+	}
+
+	/** A download that produced no file answers to no pin, rather than raising on hash_file. */
+	public function testAFileThatIsNotThereMatchesNothing() {
+		unlink($this->file);
+
+		$this->assertFalse(TarballChecksum::matches(self::WIKVEN, $this->file));
+	}
+}


### PR DESCRIPTION
The one test gap from the pre-1.0.0 review that the reviewer called a plausible blocker, on the grounds that the promise is written down.

## What was uncovered

> `sha256` — 64 hex characters; the build aborts on a mismatch.
> …pin a tarball with `sha256` for a tamper-evident, reproducible build.
> — `docs/Configuration.wikitext`

Nothing exercised it. No bake in this repository declares a `sha256` — `docs/.wikven.yaml` uses `repository`/`reference` and `commit` — so the comparison never ran in CI. It could have been inverted, skipped, or its fatal downgraded to a warning, and every check would have stayed green while the documentation still promised tamper evidence.

A tarball is also the one fetch method whose **source can change without the site's configuration changing**: a URL serves whatever it serves today. The pin is the only thing between a site and running code nobody chose.

## Why it had no test

The comparison lived inside a private method of a `Maintenance` subclass. `TarballChecksum` moves it beside the other pure classes `fetchExtensions.php` already `require_once`s by hand (`Attempts`, `ComposerInstall`, `FetchPin`, `UserAgent`), split into the three questions the old code answered at once:

| | |
| --- | --- |
| `wanted()` | what a spec pins, lowercased and trimmed |
| `isValid()` | what counts as a checksum |
| `matches()` | whether a file answers to one |

## One behavioural detail

Telling *pins nothing* from *pins something unreadable* is deliberate, and is the existing behaviour rather than a new one: an absent `sha256` fetches unverified, as documented, while a malformed one stops the build.

The change is at the edge: `sha256: [a, b]` used to reach `(string)` cast on an array — PHP's `"Array"` plus a notice — and now comes back as the empty string, which fails `isValid()` and stops the build like any other value that is not a checksum.

## Verification

- **9 cases green** under real PHPUnit 11.5.56: absent, unreadable, uppercase, whitespace-padded, exactly 64 hex, one short, one long, non-hex, prefixed, a matching file, a tampered file, a one-character difference, and a file that is not there.
- **Checked the test actually catches the regression it exists for**, rather than assuming: with `matches()` broken to `return true`, three of the nine fail. Restored, green again.
- The fixture's own hash was wrong in my first draft — I wrote a constant from nothing instead of computing it. `hash('sha256', 'wikven')` settled it.
- `typos`, `phpcs`, `mago fmt`, `mago lint` clean.

## Not covered, and worth saying

This holds the **comparison**, not the **wiring**. That `fetchTarball()` still calls it, on the file it downloaded, before extracting, would need the fetch itself to run.

The reviewer's neighbouring finding is untouched as well, since it is a change rather than a test: an unpinned tarball is silent where an unpinned Composer constraint warns, and nothing requires the URL to be `https:`. Both are one-line warnings if you want them.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_