### PR TITLE
fix: refuse images the source tree only points at

### DIFF
--- a/includes/ImageImport.php
+++ b/includes/ImageImport.php
@@ -17,8 +17,14 @@ class ImageImport {
 	 * Subdirectories included, because pages are read from them too: a source tree where
 	 * "Guide/Setup.wikitext" is the page "Guide/Setup" is one where "Guide/diagram.png" is the
 	 * image that page embeds, and reading one and not the other left the page with a red link and
-	 * the build with nothing to say about it. Matches on the extension without regard to case, and
-	 * follows the directory order the importer's own walk follows.
+	 * the build with nothing to say about it. Matches on the extension without regard to case.
+	 *
+	 * Walks exactly what core's importImages walks, symlinked directories included, because the
+	 * point of this list is to be the same files core is about to import. It refused to follow a
+	 * linked directory once, which sounds safer and was not: core follows one (its findFiles tests
+	 * is_dir, which a link to a directory satisfies), so every file under it was imported while
+	 * this list -- and therefore outside(), collisions() and failed() -- could not see any of them.
+	 * Where a walk stops is not where to answer a symlink; outside() is.
 	 *
 	 * @param string $directory Source directory, without a trailing slash.
 	 * @param string[] $extensions Allowed extensions, as $wgFileExtensions holds them.
@@ -35,7 +41,7 @@ class ImageImport {
 				continue;
 			}
 			$path = $directory . '/' . $entry;
-			if (is_dir($path) && !is_link($path)) {
+			if (is_dir($path)) {
 				$sources = array_merge($sources, self::sources($path, $extensions));
 				continue;
 			}
@@ -58,10 +64,13 @@ class ImageImport {
 	 * embedded it shows the other one's picture. Reading subdirectories is what makes this
 	 * reachable, so it is answered where it becomes reachable.
 	 *
-	 * Names are compared as written. default.yml sets CapitalLinks to false -- the entry page is the
-	 * lowercase "index" -- so "diagram.png" and "Diagram.png" are two titles here rather than one,
-	 * and reporting them as a collision would fail a build that is fine. A site that turns
-	 * CapitalLinks back on makes that pair one page again, and this will not say so.
+	 * The name a file claims is the name after core normalises it, not the name on disk: a title
+	 * collapses every run of space, underscore and the other whitespace it knows to one underscore
+	 * and trims those off the ends, so "Bakery oven.png" and "Bakery_oven.png" are one page and
+	 * comparing the two strings would have said they were two. Case is left alone: default.yml sets
+	 * CapitalLinks to false -- the entry page is the lowercase "index" -- so "diagram.png" and
+	 * "Diagram.png" really are two titles here, and reporting them would fail a build that is fine.
+	 * A site that turns CapitalLinks back on makes that pair one page again, and this will not say so.
 	 *
 	 * @param string[] $sources Absolute paths, as sources() returns them.
 	 * @return array<string, string[]> Shared name => the paths that claim it, two or more of them.
@@ -69,7 +78,7 @@ class ImageImport {
 	public static function collisions(array $sources): array {
 		$byName = [];
 		foreach ($sources as $path) {
-			$byName[basename($path)][] = $path;
+			$byName[self::title(basename($path))][] = $path;
 		}
 		$shared = [];
 		foreach ($byName as $name => $paths) {
@@ -81,29 +90,64 @@ class ImageImport {
 	}
 
 	/**
-	 * Files among $sources that are symlinks, which is not a thing to import.
+	 * The File: page a file of this name imports as, as far as two of them being one page goes.
 	 *
-	 * is_file() follows a link, so a source tree can offer one named picture.png and have the build
-	 * upload whatever it points at -- a file outside the tree, on the machine doing the building,
-	 * published with the site. A tree of wiki content has no use for one, so rather than resolve
-	 * them they are refused, by name, where the tree is read.
+	 * MediaWiki\Title\TitleParser does this to every title it makes: runs of space, underscore and
+	 * the space-like characters listed here collapse to a single underscore, and those are trimmed
+	 * off both ends. Kept to that one rule -- the parser also normalises Unicode and rejects titles
+	 * outright, neither of which changes whether two files answer to one name often enough to carry
+	 * a copy of core's parser in here.
+	 *
+	 * @param string $name A file's base name.
+	 * @return string The name two files have to share to be one page.
+	 */
+	private static function title(string $name): string {
+		$collapsed = preg_replace(
+			'/[ _\x{00A0}\x{1680}\x{180E}\x{2000}-\x{200A}\x{2028}\x{2029}\x{202F}\x{205F}\x{3000}]+/u',
+			'_',
+			$name
+		);
+		// preg_replace answers invalid UTF-8 with null; such a name is no title, and is its own name.
+		return $collapsed === null ? $name : trim($collapsed, '_');
+	}
+
+	/**
+	 * Files among $sources that are not really in the source tree, which is not a thing to import.
+	 *
+	 * is_file() follows a link and so does the walk, so a source tree can offer one named
+	 * picture.png, or a whole linked directory of them, and have the build upload whatever is on the
+	 * other side -- files outside the tree, on the machine doing the building, published with the
+	 * site. A tree of wiki content has no use for one, so rather than resolve them they are refused,
+	 * by name, where the tree is read.
+	 *
+	 * Asked of the resolved path rather than of each entry, because the file at the end is what gets
+	 * uploaded: a link to a file and a real file under a linked directory both leave the tree, and
+	 * only one of the two is itself a link. A name that resolves to nothing -- a link with nothing on
+	 * the other side -- is refused here too, since containment cannot be shown for it.
 	 *
 	 * This is where wikven answers symlinks at all. ContainedPath, which bounds the paths that come
 	 * back out of rendered pages, does not: the directories it bounds hold nothing an author put
 	 * there, and a check in it would silently refuse the symlinked skins/ of a MediaWiki checkout
 	 * somebody develops against.
 	 *
+	 * @param string $directory Source directory, as sources() was given it.
 	 * @param string[] $sources Absolute paths, as sources() returns them.
-	 * @return string[] Those of them that are links.
+	 * @return string[] Those of them that are not files inside $directory.
 	 */
-	public static function links(array $sources): array {
-		$links = [];
+	public static function outside(string $directory, array $sources): array {
+		$root = realpath($directory);
+		if ($root === false) {
+			return $sources;
+		}
+		$root = rtrim($root, '/') . '/';
+		$outside = [];
 		foreach ($sources as $path) {
-			if (is_link($path)) {
-				$links[] = $path;
+			$real = realpath($path);
+			if ($real === false || !str_starts_with($real, $root)) {
+				$outside[] = $path;
 			}
 		}
-		return $links;
+		return $outside;
 	}
 
 	/**

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -918,12 +918,13 @@ class Build extends Maintenance {
 		$extensions = $GLOBALS['wgFileExtensions'];
 		$sources = ImageImport::sources($directory, $extensions);
 
-		// is_file() follows a link, so an image that is one would have the build upload whatever it
-		// points at -- a file outside the source tree, on this machine -- and publish it.
-		$links = ImageImport::links($sources);
-		if ($links !== []) {
-			foreach ($links as $link) {
-				$this->error("Wikven: '$link' is a link rather than an image");
+		// The walk follows links, as core's does, so an image that is one -- or one under a linked
+		// directory -- would have the build upload whatever is on the other side: a file outside the
+		// source tree, on this machine, published with the site.
+		$outside = ImageImport::outside($directory, $sources);
+		if ($outside !== []) {
+			foreach ($outside as $one) {
+				$this->error("Wikven: '$one' is not a file in $directory");
 			}
 			$this->fatalError(
 				'Wikven: an image has to be a file in the source tree, since what a link points at is'
@@ -937,7 +938,7 @@ class Build extends Maintenance {
 		$collisions = ImageImport::collisions($sources);
 		if ($collisions !== []) {
 			foreach ($collisions as $name => $paths) {
-				$this->error("Wikven: '$name' is the name of more than one image: " . implode(', ', $paths));
+				$this->error("Wikven: more than one image would import as '$name': " . implode(', ', $paths));
 			}
 			$this->fatalError(
 				'Wikven: an image is named by its file name alone, so each of those would be the same'
@@ -949,7 +950,7 @@ class Build extends Maintenance {
 		$child->setArg(0, $directory);
 		$child->setOption('extensions', implode(',', $extensions));
 		$child->setOption('skip-dupes', true);
-		// Subdirectories, because pages are read from them: sources() above counts the same files.
+		// Subdirectories, because pages are read from them; sources() above walked the same way.
 		$child->setOption('search-recursively', true);
 		// An image the wiki rejected leaves every page embedding it with a red File: link, so this
 		// step aborts the build the way step() aborts it for a page that did not import. A source

--- a/tests/phpunit/unit/ImageImportTest.php
+++ b/tests/phpunit/unit/ImageImportTest.php
@@ -14,25 +14,44 @@ class ImageImportTest extends MediaWikiUnitTestCase {
 
 	private string $directory;
 
+	/** Somewhere a link out of the source tree can point at, so no test reads the real machine. */
+	private string $outside;
+
 	protected function setUp(): void {
 		parent::setUp();
-		$this->directory = sys_get_temp_dir() . '/wikven-image-import-' . getmypid() . '-' . uniqid();
+		$stem = sys_get_temp_dir() . '/wikven-image-import-' . getmypid() . '-' . uniqid();
+		$this->directory = $stem . '/src';
+		$this->outside = $stem . '/elsewhere';
 		mkdir($this->directory, 0777, true);
+		mkdir($this->outside, 0777, true);
 	}
 
 	protected function tearDown(): void {
-		$entries = new \RecursiveIteratorIterator(
-			new \RecursiveDirectoryIterator($this->directory, \FilesystemIterator::SKIP_DOTS),
-			\RecursiveIteratorIterator::CHILD_FIRST
-		);
-		foreach ($entries as $entry) {
-			// A link to a directory reports itself as one; it is unlinked, not descended into.
-			$entry->isDir() && !$entry->isLink()
-				? rmdir($entry->getPathname())
-				: unlink($entry->getPathname());
-		}
-		rmdir($this->directory);
+		self::remove(dirname($this->directory));
 		parent::tearDown();
+	}
+
+	/**
+	 * Delete a temporary tree without walking through a link out of it.
+	 *
+	 * A link to a directory answers is_dir(), so descending on that alone would empty whatever the
+	 * test pointed it at; it is unlinked as the name it is.
+	 */
+	private static function remove(string $directory): void {
+		foreach (scandir($directory) ?: [] as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			$path = $directory . '/' . $entry;
+			is_dir($path) && !is_link($path) ? self::remove($path) : unlink($path);
+		}
+		rmdir($directory);
+	}
+
+	/** A file outside the source tree, returned by the path a link in the tree can name. */
+	private function outsideFile(string $name): string {
+		touch($this->outside . '/' . $name);
+		return $this->outside . '/' . $name;
 	}
 
 	/** The defect this class exists for: a truncated image aborts the build instead of red-linking. */
@@ -137,36 +156,84 @@ class ImageImportTest extends MediaWikiUnitTestCase {
 	public function testAnImageThatIsALinkIsFoundAndRefused() {
 		mkdir($this->directory . '/Guide');
 		touch($this->directory . '/real.png');
-		symlink('/etc/passwd', $this->directory . '/Guide/picture.png');
+		symlink($this->outsideFile('secret.png'), $this->directory . '/Guide/picture.png');
 
 		$sources = ImageImport::sources($this->directory, self::EXTENSIONS);
 
 		$this->assertSame(['picture.png', 'real.png'], $this->basenames($sources));
 		$this->assertSame(
 			[$this->directory . '/Guide/picture.png'],
-			ImageImport::links($sources)
+			ImageImport::outside($this->directory, $sources)
 		);
 	}
 
 	/** A tree of real files has none, so nothing is refused. */
-	public function testFilesThatAreFilesAreNotLinks() {
+	public function testFilesThatAreFilesAreNotOutside() {
+		mkdir($this->directory . '/Guide');
 		touch($this->directory . '/real.png');
+		touch($this->directory . '/Guide/nested.png');
 
-		$this->assertSame([], ImageImport::links(ImageImport::sources($this->directory, self::EXTENSIONS)));
+		$this->assertSame(
+			[],
+			ImageImport::outside($this->directory, ImageImport::sources($this->directory, self::EXTENSIONS))
+		);
 	}
 
 	/**
-	 * The walk does not follow a linked directory either: it would leave the source tree entirely,
-	 * and every file under it would import as though the site shipped it.
+	 * The defect a walk that stopped at linked directories had: core's findFiles tests is_dir, which
+	 * a link to a directory satisfies, so core imported every file under one while this list saw
+	 * none of them -- and the refusal, the collision check and the failure count all looked past a
+	 * whole directory of files that were about to be published.
 	 */
-	public function testTheWalkDoesNotFollowALinkedDirectory() {
-		mkdir($this->directory . '/real');
-		touch($this->directory . '/real/inside.png');
-		symlink('/etc', $this->directory . '/elsewhere');
+	public function testFilesUnderALinkedDirectoryAreFoundAndRefused() {
+		touch($this->directory . '/inside.png');
+		symlink(dirname($this->outsideFile('secret.png')), $this->directory . '/pics');
+
+		$sources = ImageImport::sources($this->directory, self::EXTENSIONS);
+
+		$this->assertSame(['inside.png', 'secret.png'], $this->basenames($sources));
+		$this->assertSame(
+			[$this->directory . '/pics/secret.png'],
+			ImageImport::outside($this->directory, $sources)
+		);
+	}
+
+	/** A link with nothing on the other side cannot be shown to be in the tree, so it is refused. */
+	public function testALinkToNothingIsRefused() {
+		symlink($this->outside . '/gone.png', $this->directory . '/broken.png');
 
 		$this->assertSame(
-			['inside.png'],
-			$this->basenames(ImageImport::sources($this->directory, self::EXTENSIONS))
+			[$this->directory . '/broken.png'],
+			ImageImport::outside($this->directory, [$this->directory . '/broken.png'])
+		);
+	}
+
+	/**
+	 * A title collapses runs of space and underscore to one underscore, so these three are one
+	 * File: page; comparing the names as written would have called them three and imported one.
+	 */
+	public function testNamesThatDifferOnlyInWhitespaceAreOnePage() {
+		mkdir($this->directory . '/Guide');
+		mkdir($this->directory . '/Setup');
+		touch($this->directory . '/Bakery oven.png');
+		touch($this->directory . '/Guide/Bakery_oven.png');
+		touch($this->directory . '/Setup/Bakery  oven.png');
+
+		$collisions = ImageImport::collisions(ImageImport::sources($this->directory, self::EXTENSIONS));
+
+		$this->assertSame(['Bakery_oven.png'], array_keys($collisions));
+		$this->assertCount(3, $collisions['Bakery_oven.png']);
+	}
+
+	/** A non-breaking space is one of the characters core collapses, and it is not a plain space. */
+	public function testANonBreakingSpaceCollapsesLikeASpace() {
+		mkdir($this->directory . '/Guide');
+		touch($this->directory . "/Bakery\u{00A0}oven.png");
+		touch($this->directory . '/Guide/Bakery oven.png');
+
+		$this->assertSame(
+			['Bakery_oven.png'],
+			array_keys(ImageImport::collisions(ImageImport::sources($this->directory, self::EXTENSIONS)))
 		);
 	}
 


### PR DESCRIPTION
## The defect

`ImageImport::sources()` refused to descend a symlinked directory. Core's `importImages.php` does descend one — `findFiles()` tests `is_dir()`, which a link to a directory satisfies — and `build.php` passes `--search-recursively`. So the two walks disagreed, and everything the build knows about its images came from the shorter one.

Reproduced with `src/pics -> /somewhere/private`:

| walk | result |
| --- | --- |
| `ImageImport::sources()` | `["<src>/ok.png"]` |
| core's `findFiles()` | `["<src>/ok.png", "<src>/pics/id_rsa.png"]` |

`id_rsa.png` was imported and published. `links()` returned `[]` — the file itself is not a link, only the directory above it is — so the symlink refusal passed. `collisions()` never saw the name. The failure count was off by every file under the link. The build exited 0.

## The fix

**The walk goes where core's goes.** The `!is_link()` guard is gone from the recursion. Where a walk stops is not where to answer a symlink.

**`links()` becomes `outside()`.** It resolves each source and refuses whatever does not come back inside the source directory. One rule covers all three shapes: a linked file, a real file under a linked directory, and a link pointing at nothing (containment cannot be shown for it, so it is refused too). The build's error is now `'<path>' is not a file in <dir>`.

**`collisions()` compares titles, not strings.** `TitleParser` collapses runs of space, underscore, NBSP and the other whitespace it knows to a single underscore and trims those off the ends, so `Bakery oven.png` and `Bakery_oven.png` are one `File:` page. Comparing the names on disk called them two, and `--skip-dupes` would have dropped the second with a line among thousands while some page showed the other one's picture. Case is still left alone: `default.yml` sets `CapitalLinks: false`, so `diagram.png` and `Diagram.png` really are two pages here.

Also corrects `build.php:952`'s comment, which claimed `sources()` counted the same files `--search-recursively` would — the sentence this PR makes true.

## Tests

15 pass. New:

- `testFilesUnderALinkedDirectoryAreFoundAndRefused` — the defect itself; fails on the old walk, which returned only `inside.png`.
- `testALinkToNothingIsRefused`
- `testFilesThatAreFilesAreNotOutside`
- `testNamesThatDifferOnlyInWhitespaceAreOnePage` — three spellings, one page.
- `testANonBreakingSpaceCollapsesLikeASpace`

`testTheWalkDoesNotFollowALinkedDirectory` is gone: it asserted the behaviour that caused this.

The fixture tree moved under a stem directory with a sibling `elsewhere/`, so a test that needs a link out of the source tree points at that rather than at `/etc`, and teardown deletes the tree without descending through a link.

`phpcs`, `mago fmt --check`, `mago lint`, `typos` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_