### PR TITLE
docs: say what the all-clear comment body is for

### DIFF
--- a/actions/check-translations/action.yml
+++ b/actions/check-translations/action.yml
@@ -189,8 +189,8 @@ runs:
               # A fork's token is read-only, and a job without pull-requests: write has no rights
               # either. Neither is a reason to fail a check that has already reported everything it
               # found as annotations.
-              echo "::warning::wikven: could not post the translations comment (needs" \
-                   "pull-requests: write, which a pull request from a fork does not get)."
+              echo "::warning::wikven: could not leave the translations comment as it should be" \
+                   "(needs pull-requests: write, which a pull request from a fork does not get)."
             fi
           fi
         fi

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -35,7 +35,7 @@
 	"wikven-translations-can-fail": "Closing line used when a source page is broken, which is the one kind of finding that can fail the check.",
 	"wikven-translations-documentation": "Sentence sending the reader to the Translating page, appended to whichever closing line was used. $1 is {{msg-mw|wikven-translations-documentation-url}}. Markdown link syntax, not wikitext.",
 	"wikven-translations-documentation-url": "URL of the Translating page linked from the comment. Translate this to the address of that page in your language where the wikven documentation has one, and leave it as is otherwise.",
-	"wikven-translations-all-clear": "The whole comment for a run that found nothing, which replaces an earlier complaint once it has been answered.",
+	"wikven-translations-all-clear": "The whole comment for a run that found nothing, shown where an earlier complaint stood by a consumer that keeps its comment. wikven's own GitHub action deletes the comment instead of showing this.",
 	"wikven-translations-all-clear-scoped": "Body of the comment when the check found nothing about the files the change touches, used in place of {{msg-wikven|wikven-translations-all-clear}}. It says nothing about pages the change did not touch, which may still be waiting for a translation.",
 	"wikven-licenses-intro": "Opening paragraph of the generated licenses page, above the tables of what the site publishes.",
 	"wikven-licenses-software": "Lead-in under the software heading of the generated licenses page, saying why only MediaWiki's license is filled in there and the other rows leave that column empty.",

--- a/includes/PageTranslation/TranslationAdvice.php
+++ b/includes/PageTranslation/TranslationAdvice.php
@@ -126,10 +126,13 @@ class TranslationAdvice {
 	}
 
 	/**
-	 * The comment a run leaves once everything it complained about is fixed.
+	 * The body of a run that found nothing, which is how a consumer tells that from a finding.
 	 *
-	 * Edited over the old body rather than deleted, so the thread keeps its place in the
-	 * conversation and a reader who followed a notification finds the answer rather than a gap.
+	 * CLEAR_MARKER on its own line is what says so; what to do about it is the consumer's to
+	 * decide. wikven's own action deletes the comment it left before, because a comment saying
+	 * there is nothing wrong is one nobody needs and the run's annotations hold the record either
+	 * way. The prose below is for a consumer that keeps its comment and wants something to put
+	 * where the complaint stood.
 	 *
 	 * @param list<string> $languages
 	 */

--- a/maintenance/checkTranslations.php
+++ b/maintenance/checkTranslations.php
@@ -168,8 +168,9 @@ class CheckTranslations extends Maintenance {
 	/**
 	 * Write the comment body for --comment-file, or nothing when the option is not given.
 	 *
-	 * A clean run still writes one, saying so: the action edits its own earlier comment with it, so
-	 * a complaint that has been answered stops standing on the change.
+	 * A clean run still writes one, carrying TranslationAdvice::CLEAR_MARKER: a consumer that only
+	 * ever heard from a run with findings could not tell a complaint that has been answered from a
+	 * run that never happened, and would leave the answered one standing on the change.
 	 */
 	private function writeComment(): void {
 		$path = (string)$this->getOption('comment-file', '');


### PR DESCRIPTION
Follow-up to #595, which changed the action from editing an all-clear over its own comment to deleting the comment. Three places still describe what it used to do:

- `TranslationAdvice::allClear()` — "Edited over the old body rather than deleted, so the thread keeps its place in the conversation"
- `CheckTranslations::writeComment()` — "the action edits its own earlier comment with it"
- `i18n/qqq.json`, `wikven-translations-all-clear` — "which replaces an earlier complaint once it has been answered"

Corrected to what the body actually is: `CLEAR_MARKER` is the signal, and what to do about it is the consumer's to decide. wikven's own action deletes; a consumer that keeps its comment shows the prose under the marker where the complaint stood. That is also why `allClear()` still renders it — `--comment-file` is a general option, not the action's private channel.

`writeComment()`'s docblock now says why a clean run writes a body at all: a consumer that only ever heard from a run with findings could not tell an answered complaint from a run that never happened, and would leave the answered one standing on the change.

Also: the action's fallback warning said `could not post the translations comment`, which after #595 is one of three things it could have been doing. Now `could not leave the translations comment as it should be`.

No behaviour change. `TranslationAdviceTest` 16 pass; `phpcs`, `mago fmt --check`, `mago lint`, `typos` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_