### PR TITLE
fix: stop three things going quiet

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -57,10 +57,13 @@ if [ "$command" = "translate" ]; then
     check) script=checkTranslations.php ;;
     stamp) script=stampTranslations.php ;;
   esac
+  code=0
+  # The status is kept rather than allowed to end the script, because set -e would take the chown
+  # below with it: a scaffold that wrote half a language and then stopped leaves those files in the
+  # caller's own src/, owned by root and not theirs to edit or delete.
   php maintenance/run.php \
     "/var/www/html/extensions/Wikven/maintenance/$script" \
-    --source "$WIKVEN_WORKDIR/src" "$@"
-  code=$?
+    --source "$WIKVEN_WORKDIR/src" "$@" || code=$?
   # These run as root; hand any files they created/edited in src back to the mount owner so the
   # translator can edit them without sudo. A no-op on a read-only mount (check).
   chown -R "$(stat -c '%u:%g' "$WIKVEN_WORKDIR/src")" "$WIKVEN_WORKDIR/src" 2>/dev/null || true
@@ -71,10 +74,14 @@ fi
 # does not create; a no-op when no bundled extension adds tables.
 php maintenance/run.php update --quick
 
-php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/build.php
+# Kept for the same reason as above: a build that aborts has still written some of dist/, and
+# leaving that root-owned in the caller's mount is a worse answer than the failure itself.
+code=0
+php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/build.php || code=$?
 rm -rf "$WIKVEN_WORKDIR/dist/history/"
 
 # The build runs as root; hand dist/ back to the mount owner so they can edit it without sudo.
 if [ -d "$WIKVEN_WORKDIR/dist" ]; then
   chown -R "$(stat -c '%u:%g' "$WIKVEN_WORKDIR/dist")" "$WIKVEN_WORKDIR/dist"
 fi
+exit "$code"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,6 +2,7 @@
 	"@metadata": {
 		"authors": []
 	},
+	"wikven-desc": "Builds a static site from a directory of wiki source files.",
 	"wikven-footer-source": "View project on $1",
 	"wikven-footer-source-plain": "View project source",
 	"wikven-skins": "Skins",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -2,6 +2,7 @@
 	"@metadata": {
 		"authors": []
 	},
+	"wikven-desc": "위키 원본 파일 디렉터리로 정적 사이트를 빌드합니다.",
 	"wikven-footer-source": "$1에서 프로젝트 보기",
 	"wikven-footer-source-plain": "프로젝트 소스 보기",
 	"wikven-skins": "스킨",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -2,6 +2,7 @@
 	"@metadata": {
 		"authors": []
 	},
+	"wikven-desc": "{{desc|name=Wikven|url=https://github.com/chaotic-ground/wikven}}",
 	"wikven-footer-source": "Footer link to the project's source repository. $1 is the repository host name (e.g. GitHub, GitLab) or a bare domain.",
 	"wikven-footer-source-plain": "Footer link to the project's source repository, used when no host can be derived from the URL.",
 	"wikven-skins": "Heading of the sidebar section holding the export's other skins, used by skins that render their own sections in the page-tools menu. The section key is the message key.",

--- a/includes/TarballChecksum.php
+++ b/includes/TarballChecksum.php
@@ -21,11 +21,19 @@ class TarballChecksum {
 	 * Says nothing about whether the value is a checksum; that is isValid()'s question, asked
 	 * separately so a spec that pins nonsense is told apart from one that pins nothing.
 	 *
+	 * Null is a pin, not the absence of one. "sha256:" with nothing after it is how YAML spells a
+	 * key whose value the author has not filled in yet, and reading that as "pins nothing" fetched
+	 * the tarball unverified without a word -- the one outcome the key exists to prevent. Only a
+	 * spec with no sha256 key at all pins nothing.
+	 *
 	 * @param array $spec One WikvenRepositories entry.
 	 */
 	public static function wanted(array $spec): ?string {
-		if (!isset($spec['sha256'])) {
+		if (!array_key_exists('sha256', $spec)) {
 			return null;
+		}
+		if ($spec['sha256'] === null) {
+			return '';
 		}
 		if (is_array($spec['sha256']) || is_object($spec['sha256'])) {
 			return '';

--- a/tests/phpunit/unit/TarballChecksumTest.php
+++ b/tests/phpunit/unit/TarballChecksumTest.php
@@ -40,6 +40,18 @@ class TarballChecksumTest extends MediaWikiUnitTestCase {
 		$this->assertFalse(TarballChecksum::isValid(''));
 	}
 
+	/**
+	 * "sha256:" with nothing after it is how YAML spells a key whose value has not been filled in
+	 * yet. Reading that as "pins nothing" fetched the tarball unverified without a word -- the one
+	 * outcome the key exists to prevent -- so it is a pin that fails validation instead.
+	 */
+	public function testASpecWhoseChecksumIsEmptyHasPinnedSomethingUnreadable() {
+		$this->assertSame('', TarballChecksum::wanted(['sha256' => null]));
+		$this->assertSame('', TarballChecksum::wanted(['sha256' => '']));
+		$this->assertSame('', TarballChecksum::wanted(['sha256' => "  \n"]));
+		$this->assertFalse(TarballChecksum::isValid(''));
+	}
+
 	public function testACheckSumIsTakenAsWrittenOnceLowercasedAndTrimmed() {
 		$upper = strtoupper(self::WIKVEN);
 


### PR DESCRIPTION
Three small ones, each a case of something failing without saying so.

### An unfilled pin fetched the tarball unverified

```yaml
- name: SomeExtension
  tarball: https://example.test/some.tar.gz
  sha256:
```

That is how YAML spells a key whose value has not been written yet: the value parses to `null`. `TarballChecksum::wanted()` tested `isset()`, so `null` read as *pins nothing*, `validatedSha256()` returned null, and `fetchTarball()` skipped the comparison entirely. The tarball was downloaded and unpacked with no check — the exact outcome `sha256:` exists to prevent, for the one fetch method whose source can change under a site without its configuration changing.

Now only a spec with no `sha256` key at all pins nothing. An empty one is a pin, and lands where an unreadable one already landed: `isValid('')` is false, and the build stops with `has an invalid sha256 (expected 64 hex characters)`.

New test `testASpecWhoseChecksumIsEmptyHasPinnedSomethingUnreadable` covers `null`, `''` and whitespace. 10 pass.

### A failed run left root-owned files in your mount

`bin/entrypoint` runs as root and chowns what it wrote back to the mount's owner afterwards — but `set -e` is on, so a non-zero exit from the script or the build ended the entrypoint before that line. A `translate scaffold` that wrote half a language and then stopped, or a build that aborted partway through `dist/`, left those files in the caller's own directory owned by root: not theirs to edit, not theirs to delete without sudo.

Both call sites now keep the status (`|| code=$?`) and chown either way, then `exit "$code"`. Same pattern the action already uses around `docker run` for the same reason.

### `Special:Version` showed a missing message

`extension.json` names `descriptionmsg: wikven-desc`, and no i18n file had the key, so it rendered as `⧼wikven-desc⧽`. Added to `en`, `ko` and `qqq`.

---

`sh -n bin/entrypoint`, `phpcs`, `mago fmt --check`, `mago lint`, `typos`, `biome` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_