### PR TITLE
chore: keep the image to what it runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,15 @@
+# What COPY ./ must not put in the image -- and, through binary.Dockerfile's COPY --from=app, in
+# the standalone binary either. Everything here is a thing that builds or checks wikven rather than
+# a thing wikven runs, and a site built with the image reads none of it.
 .git
+.github
+.claude
+.tf
+.venv
+.rumdl_cache
+docs
+examples
+tests
 node_modules
 vendor
 dist

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
 	"name": "chaotic-ground/wikven",
+	"description": "Builds a static site from a directory of wiki source files.",
 	"type": "mediawiki-extension",
+	"homepage": "https://github.com/chaotic-ground/wikven",
 	"license": "GPL-3.0-or-later",
 	"scripts": {
 		"test": "minus-x check .",


### PR DESCRIPTION
`Dockerfile:94` is `COPY ./ /var/www/html/extensions/Wikven`, and `binary.Dockerfile:33` is `COPY --from=app /var/www/html ./dist/app`. So whatever `.dockerignore` does not name is shipped in the image *and* embedded in the standalone binary. It named five things.

What was going along:

| | |
| --- | --- |
| `.venv` | 4.3M |
| `docs` | 1.1M |
| `tests` | 456K |
| `.github` | 128K |
| `examples` | 56K |
| `.tf` | 32K |
| `.claude`, `.rumdl_cache` | small |

None of it is read by a site built with the image: the smoke run mounts `docs/` from the runner's checkout, and PHPUnit runs against a plain checkout in `test.yml`, not inside the container. `binary.Dockerfile:18` already did `find /var/www/html -type d -name tests -prune -exec rm -rf {} +` — the intent was there, one layer too late and only for one of them.

Also gives `composer.json` the `description` and `homepage` it never had, so `composer show` says what the package is. No `require` block: what wikven needs to run is MediaWiki, which `extension.json` states, and a second constraint here would only be a copy to keep in step.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_