### PR TITLE
docs: name everything the image ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,21 @@ compatible, so this is attribution rather than a conflict.
 | Component | License | Bundled in |
 | --- | --- | --- |
 | [MediaWiki](https://www.mediawiki.org/), with its bundled skins and extensions | GPL-2.0-or-later | image, binary |
-| [PHP](https://www.php.net/) | PHP License 3.01 | binary |
+| [SifterSearch](https://github.com/chaotic-ground/SifterSearch) | GPL-3.0-or-later | image, binary |
+| [Pagefind](https://pagefind.app/), the search index and widget SifterSearch ships | MIT | image, binary |
+| [Translate](https://www.mediawiki.org/wiki/Extension:Translate) | GPL-2.0-or-later | image, binary |
+| [UniversalLanguageSelector](https://www.mediawiki.org/wiki/Extension:UniversalLanguageSelector) | GPL-2.0-or-later OR MIT | image, binary |
+| [Spyc](https://github.com/mustangostang/spyc) and [composer/installers](https://github.com/composer/installers), which Translate requires | MIT | image, binary |
+| [PHP](https://www.php.net/) | PHP License 3.01 | image, binary |
 | [FrankenPHP](https://frankenphp.dev/) | MIT | binary |
 | [Caddy](https://caddyserver.com/) | Apache-2.0 | binary |
 | [Composer](https://getcomposer.org/) | MIT | image |
 
-The binary is compiled with FrankenPHP, which also links several Caddy modules; see the FrankenPHP
-project for their licenses. The image keeps MediaWiki's own `COPYING`, and each component's full
-license text is available from its project.
+The rows from SifterSearch down to Spyc are what the image adds to MediaWiki's own tree, so the
+binary — which is built from that tree — carries them too. The binary is compiled with FrankenPHP,
+which also links several Caddy modules; see the FrankenPHP project for their licenses. The image
+keeps MediaWiki's own `COPYING`, and each component's full license text is available from its
+project.
 
 That is what wikven ships. What a site built with it publishes is its own set, and every build
 writes it out: see the Licenses page of any wikven site, [this documentation's


### PR DESCRIPTION
The README says the image and binary "redistribute third-party software under that software's own licenses, acknowledged here" — and then the table stopped at MediaWiki, PHP, FrankenPHP, Caddy and Composer.

What `Dockerfile` also bakes in, and the table did not name:

| From | Component | License |
| --- | --- | --- |
| `Dockerfile:44-51` | SifterSearch | GPL-3.0-or-later |
| the same tarball | Pagefind (the per-arch binary a clone omits) | MIT |
| `Dockerfile:78-86` | Translate | GPL-2.0-or-later |
| `Dockerfile:76-85` | UniversalLanguageSelector | GPL-2.0-or-later OR MIT |
| `Dockerfile:89-92` | Spyc, composer/installers | MIT |

Licenses read from each project's own `extension.json` / `composer.json` / `LICENSE`, not from memory.

`binary.Dockerfile:33` is `COPY --from=app /var/www/html ./dist/app`, so the binary is built from that tree and carries every one of them — hence `image, binary` on each row, and a sentence saying why.

**One row changed rather than added:** PHP was marked `binary` only. The image is `FROM mediawiki:1.46.0-fpm-alpine`, which is a PHP-FPM image, so PHP has always been in it. Now `image, binary`. Say the word if that was deliberate and I'll put it back.

Not added: Alpine and the base image's own system packages. That is a line worth drawing somewhere and I've drawn it at "what wikven's Dockerfile puts there"; happy to go further if you'd rather.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_