### PR TITLE
fix: give every source image its own File: page

### DIFF
--- a/includes/ImageImport.php
+++ b/includes/ImageImport.php
@@ -59,10 +59,10 @@ class ImageImport {
 	 * Files that would import as the same page, keyed by the name they would share.
 	 *
 	 * A File: title is the file's name and nothing else -- core takes wfBaseName($file) and makes
-	 * the title from that -- so two images with one name in two directories are one page. The build
-	 * passes --skip-dupes, so the second is skipped with a line among thousands and whichever page
-	 * embedded it shows the other one's picture. Reading subdirectories is what makes this
-	 * reachable, so it is answered where it becomes reachable.
+	 * the title from that -- so two images with one name in two directories are one page. The
+	 * importer takes the first and skips the second, the name being taken, with a line among
+	 * thousands; whichever page embedded the second then shows the other one's picture. Reading
+	 * subdirectories is what makes this reachable, so it is answered where it becomes reachable.
 	 *
 	 * The name a file claims is the name after core normalises it, not the name on disk: a title
 	 * collapses every run of space, underscore and the other whitespace it knows to one underscore

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -17,6 +17,7 @@ use MediaWiki\Title\TitleValue;
 use MediaWiki\User\User;
 use RebuildFileCache;
 use RunJobs;
+use UtfNormal\Validator;
 use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
@@ -933,7 +934,7 @@ class Build extends Maintenance {
 		}
 
 		// A File: title is the file's name alone, so two images sharing a name in two directories
-		// are one page, and --skip-dupes below would take the first and drop the second with a line
+		// are one page, and the importer below would take the first and skip the second with a line
 		// nobody reads. Said here, with both paths, before anything is imported.
 		$collisions = ImageImport::collisions($sources);
 		if ($collisions !== []) {
@@ -949,7 +950,13 @@ class Build extends Maintenance {
 		$child = $this->createChild(ImportImages::class, $file);
 		$child->setArg(0, $directory);
 		$child->setOption('extensions', implode(',', $extensions));
-		$child->setOption('skip-dupes', true);
+		// No --skip-dupes. It skips a file whose *content* matches one already imported, whatever
+		// the two are called, so a logo shipped twice under two names left the second name with no
+		// File: page and every page embedding it red-linking, reported as one skipped line and a
+		// successful build. Nothing is lost by dropping it: a name already taken is skipped by the
+		// importer with or without it, and two source files cannot share a name here anyway --
+		// collisions() above has already stopped the build if they do.
+		//
 		// Subdirectories, because pages are read from them; sources() above walked the same way.
 		$child->setOption('search-recursively', true);
 		// An image the wiki rejected leaves every page embedding it with a red File: link, so this
@@ -961,6 +968,42 @@ class Build extends Maintenance {
 			$count = count($sources);
 			$this->fatalError("Wikven: not all $count image(s) in $directory imported; aborting the build.");
 		}
+		$this->assertEveryImageGotItsPage($sources);
+	}
+
+	/**
+	 * Every source image now has a File: page, or the build stops naming the ones that do not.
+	 *
+	 * The importer answers "I skipped that one" with the same success it answers "I imported them
+	 * all" with, and it has more than one reason to skip: a duplicate under another name, a title
+	 * core would not make from the file's own name, a name already taken. Whichever it was, the
+	 * page embedding the image is left with a red link and the build says nothing, so the check is
+	 * on the outcome rather than on the reasons -- the pages that were supposed to be here.
+	 *
+	 * @param string[] $sources Absolute paths, as ImageImport::sources() returns them.
+	 */
+	private function assertEveryImageGotItsPage(array $sources): void {
+		$missing = [];
+		foreach ($sources as $path) {
+			// The importer's own two lines, so this asks about the page it would have made rather
+			// than about one this file names differently.
+			$title = Title::makeTitleSafe(NS_FILE, Validator::cleanUp(basename($path)));
+			if ($title === null || !$title->exists()) {
+				$missing[] = $path;
+			}
+		}
+		if ($missing === []) {
+			return;
+		}
+		foreach ($missing as $path) {
+			$this->error("Wikven: '$path' did not become a File: page");
+		}
+		$this->fatalError(
+			'Wikven: '
+			. count($missing)
+			. ' image(s) were offered to the importer and are not here,'
+			. ' so every page embedding one would publish a red link; aborting the build.'
+		);
 	}
 
 	/** Point the wiki's main page at $wgWikvenMainPage (imported later; see assertMainPageExists). */

--- a/tests/phpunit/unit/ImageImportTest.php
+++ b/tests/phpunit/unit/ImageImportTest.php
@@ -113,8 +113,8 @@ class ImageImportTest extends MediaWikiUnitTestCase {
 
 	/**
 	 * What reading subdirectories makes reachable: core names a File: page after the file alone
-	 * (wfBaseName), so two directories holding one name are one page, and --skip-dupes would take
-	 * the first and drop the second with a line among thousands.
+	 * (wfBaseName), so two directories holding one name are one page, and the importer would take
+	 * the first and skip the second with a line among thousands.
 	 */
 	public function testTwoDirectoriesCannotShareAnImageName() {
 		mkdir($this->directory . '/Guide');


### PR DESCRIPTION
The last one in the image-import family, after #590 and #596.

## `--skip-dupes` skips by content, not by name

`importImages.php` REL1_46, lines 253-264 — reached only when the title is *not* already taken:

```php
if ( $this->hasOption( 'skip-dupes' ) ) {
    $sha1 = FSFile::getSha1Base36FromPath( $file );
    $dupes = $repo->findBySha1( $sha1 );
    if ( $dupes ) {
        $this->output( "{$base} already exists as {$dupes[0]->getName()}, skipping\n" );
        $statistics['skipped']++;
        continue;
    }
}
```

So a logo shipped twice under two names — one for the header, one a page embeds by its own name — imports once. The second name never becomes a `File:` page, every page embedding it publishes a red link, and the build reports one line among thousands and exits 0.

**Nothing is lost by dropping the flag.** The name-already-taken case is handled by the `$image->exists()` branch above it, with or without `--skip-dupes`; and since #596 two source files cannot share a name here at all — `collisions()` stops the build before the importer runs. The flag's only remaining effect was the harmful one.

Cost: two identical images under two names now occupy two asset files in `dist/`. `storeImages.php` names assets `img-<md5 of the path>.ext`, so that was already true for two references to one file. Correctness over bytes.

## The check is on the outcome

Dropping the flag fixes the cause; this catches the class. The importer answers *I skipped that one* with the same success it answers *I imported them all* with, and it has more than one reason to skip — a title core would not make from the file's own name, a name already taken. So `assertEveryImageGotItsPage()` asks the only question that matters after the fact: is each source image a `File:` page? It builds the title from `Validator::cleanUp(basename($path))`, the importer's own two lines, so it asks about the page the importer would have made rather than one this file names differently.

Verified there are no duplicate-content images in `docs/` or `examples/`, so the smoke bake sees the same set either way.

`ImageImportTest` 15 pass. `phpcs`, `mago fmt --check`, `mago lint`, `typos` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_