### PR TITLE
fix: send a Special:MyLanguage link to the file it means

### DIFF
--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -263,7 +263,9 @@ class Adder implements
 		}
 		// Built as the title it stands for, rather than spelt out, so this marker and the one
 		// GetLocalURL writes for a real Special:MyLanguage link are the same string in either
-		// spelling of the file names -- which is what resolveMyLanguage() below matches on.
+		// spelling of the file names -- which is what resolveMyLanguage() matches on. "Special" is
+		// the canonical namespace name, the one Hooks\Main::nameFor() writes whatever this wiki
+		// calls that namespace itself, so the two markers agree in the content language too.
 		$page = Title::makeName($licenses->getNamespace(), $licenses->getDBkey());
 		return './' . OutputName::href(OutputName::of('Special', "MyLanguage/$page"));
 	}

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -87,7 +87,7 @@ class Main implements
 
 		// The file this title is written to, url-encoded so a static server asking for it finds it;
 		// see OutputName, which rename.php asks the same question of from the file's side.
-		$href = OutputName::href(OutputName::of((string)$title->getNsText(), $title->getDBkey()));
+		$href = OutputName::href(OutputName::of(...$this->nameFor($title)));
 		// Parse query to name=>value; substring-matching "action=" would also match "veaction=edit".
 		$params = wfCgiToArray($query);
 		$action = $params['action'] ?? null;
@@ -107,6 +107,38 @@ class Main implements
 	}
 
 	/**
+	 * The namespace and title a link is written from.
+	 *
+	 * A page is named as this wiki names it, which is the answer rename.php gets from the content
+	 * language when it names the file, so link and file agree. A special page is named canonically
+	 * instead, because it has no file: no export contains one, so where such a link survives it is
+	 * a marker for a later pass -- Special:MyLanguage, which resolveTranslationLinks.php rewrites
+	 * to the reader's own copy of the target, and which Hooks\Adder writes by that spelling too.
+	 *
+	 * A marker has to be one string, and this wiki's own spelling is several: the namespace is
+	 * that language's word for it ("특수" on a Korean wiki), the special page answers to aliases of
+	 * its own ("내언어"), and an alias is matched however it was capitalised, so even an English wiki
+	 * writes "Special:Mylanguage/X" for a link typed that way. Written canonically, all of those
+	 * arrive as the marker that pass matches on; the special pages that are not markers name a file
+	 * no export has in either spelling, and stay the dead links they already were.
+	 *
+	 * @return array{string,string} Namespace text and dbkey, as OutputName::of() takes them.
+	 */
+	private function nameFor(Title $title): array {
+		if ($title->getNamespace() !== NS_SPECIAL) {
+			return [(string)$title->getNsText(), $title->getDBkey()];
+		}
+		$services = MediaWikiServices::getInstance();
+		$canonical = (string)$services->getNamespaceInfo()->getCanonicalName(NS_SPECIAL);
+		[$name, $subpage] = $services->getSpecialPageFactory()->resolveAlias($title->getDBkey());
+		// A name no special page answers to has no canonical form to be written in; leave it as typed.
+		if ($name === null) {
+			return [$canonical, $title->getDBkey()];
+		}
+		return [$canonical, $subpage === null ? $name : "$name/$subpage"];
+	}
+
+	/**
 	 * Where a search goes in the export: the results page, carrying the term the link asks for
 	 * (SifterSearch's widget reads it from "?search="), or nowhere.
 	 *
@@ -120,7 +152,7 @@ class Main implements
 		if (!$results) {
 			return '#';
 		}
-		$url = './' . OutputName::href(OutputName::of((string)$results->getNsText(), $results->getDBkey()));
+		$url = './' . OutputName::href(OutputName::of(...$this->nameFor($results)));
 		$term = wfCgiToArray($query)['search'] ?? '';
 		return $term === '' ? $url : $url . '?' . wfArrayToCgi(['search' => $term]);
 	}
@@ -331,7 +363,7 @@ class Main implements
 			&& $title
 			&& $out->getSkin()->getSkinName() !== $mainSkin
 		) {
-			$href = OutputName::href(OutputName::of((string)$title->getNsText(), $title->getDBkey()));
+			$href = OutputName::href(OutputName::of(...$this->nameFor($title)));
 			$tags['link-canonical'] = Html::element('link', [
 				'rel' => 'canonical',
 				'href' => "../$href"

--- a/includes/OutputName.php
+++ b/includes/OutputName.php
@@ -145,18 +145,33 @@ class OutputName {
 	/**
 	 * A namespace and an already-escaped body, in the site's spelling.
 	 *
+	 * The namespace is escaped here rather than handed in escaped, because it arrives as the
+	 * content language spells it and the body arrives as the file cache left it. Both then go
+	 * through one spelling, which is what keeps a name in a namespace whose own text is not plain
+	 * letters -- "도움말", "MediaWiki・トーク" -- from coming out half escaped and half not under
+	 * ENCODED, where the body's own bytes are escaped and the namespace's were not.
+	 */
+	private static function assemble(string $namespaceText, string $body, string $scheme): string {
+		$body = self::spell($body, $scheme);
+		if ($namespaceText === '') {
+			return $body;
+		}
+		$separator = $scheme === self::ENCODED ? '%3A' : ':';
+		return self::spell(urlencode($namespaceText), $scheme) . $separator . $body;
+	}
+
+	/**
+	 * One escaped string, written as the site spells it.
+	 *
 	 * Two escapes are undone in both spellings. "%2E" is the file cache's own doing -- it escapes
 	 * every dot to keep an extension from being mistaken for the file's -- and a name with no dot in
 	 * it cannot end in ".html". "%2F" is the subpage separator, and a subpage is exported into a
-	 * real directory, so it has to be a real slash before anything counts the depth.
+	 * real directory, so it has to be a real slash before anything counts the depth. A readable name
+	 * then gives up the rest of its escaping too, but for KEPT.
 	 */
-	private static function assemble(string $namespaceText, string $body, string $scheme): string {
-		$body = str_replace(['%2E', '%2F'], ['.', '/'], $body);
-		if ($scheme !== self::ENCODED) {
-			$body = self::readable($body);
-		}
-		$separator = $scheme === self::ENCODED ? '%3A' : ':';
-		return $namespaceText === '' ? $body : $namespaceText . $separator . $body;
+	private static function spell(string $escaped, string $scheme): string {
+		$escaped = str_replace(['%2E', '%2F'], ['.', '/'], $escaped);
+		return $scheme === self::ENCODED ? $escaped : self::readable($escaped);
 	}
 
 	/** Every escape undone but the ones a Windows path could not hold; see KEPT. */

--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -273,10 +273,14 @@ class RelativeUrl {
 	 * source "Target.html". The link's existing relative prefix (already depth-correct after reparent)
 	 * and any "#fragment" are kept, so the target stays reachable from any page depth.
 	 *
-	 * The colon after "Special" is matched in both spellings OutputName writes, because the marker
-	 * is built as a link like any other: under encoded file names it arrives as "Special%253A". What
-	 * follows it is the target's own link, so appending "/<lang>.html" to it names the translation's
-	 * link, and $hasTranslation is handed that link to turn back into a file name.
+	 * "Special:MyLanguage" is matched as the canonical spelling alone, which is the only one that
+	 * reaches here: both sides that write this marker -- Hooks\Main::nameFor() for a link on a page,
+	 * Hooks\Adder::licensesHref() for the footer's -- write it canonically however this wiki spells
+	 * that namespace and that special page itself. The colon is matched in both spellings OutputName
+	 * writes, because the marker is built as a link like any other: under encoded file names it
+	 * arrives as "Special%253A". What follows it is the target's own link, so appending
+	 * "/<lang>.html" to it names the translation's link, and $hasTranslation is handed that link to
+	 * turn back into a file name.
 	 *
 	 * @param string $html
 	 * @param string|null $lang The page's language, or null for a source page (always the source target).

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -130,6 +130,49 @@ class MainTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
+	 * A Special:MyLanguage link is written canonically, not in this wiki's own words for it.
+	 *
+	 * The link is not a link to a file -- no export holds that special page -- but the marker
+	 * resolveTranslationLinks.php reads to send a reader to their own copy of the target, and a
+	 * marker matched by one spelling has to be written in one. On a wiki whose content language is
+	 * not English the namespace is that language's word for it, so the marker written from the
+	 * wiki's own naming would be "특수:MyLanguage/..." and that pass would walk past it, leaving
+	 * every translated page pointing at a file the site does not have.
+	 */
+	public function testSpecialMyLanguageIsMarkedCanonicallyInAnotherContentLanguage() {
+		$this->setContentLang('ko');
+		$url = '/x';
+		$this->main()->onGetLocalURL(Title::newFromText('Special:MyLanguage/Getting Started'), $url, '');
+		$this->assertSame('./Special:MyLanguage/Getting_Started.html', $url);
+	}
+
+	/** That language's own name for the special page resolves to the same marker. */
+	public function testSpecialMyLanguageIsMarkedCanonicallyFromALocalisedAlias() {
+		$this->setContentLang('ko');
+		$url = '/x';
+		$this->main()->onGetLocalURL(Title::newFromText('특수:내언어/Getting Started'), $url, '');
+		$this->assertSame('./Special:MyLanguage/Getting_Started.html', $url);
+	}
+
+	/**
+	 * So does one capitalised differently, which is the same fault on an English wiki: MediaWiki
+	 * matches a special page's name however it was typed, so "Special:Mylanguage/X" is that page as
+	 * surely as "Special:MyLanguage/X" and has to reach the pass as the same marker.
+	 */
+	public function testSpecialMyLanguageIsMarkedCanonicallyFromAnotherCapitalisation() {
+		$url = '/x';
+		$this->main()->onGetLocalURL(Title::newFromText('Special:Mylanguage/Getting Started'), $url, '');
+		$this->assertSame('./Special:MyLanguage/Getting_Started.html', $url);
+	}
+
+	/** A name no special page answers to has no canonical form; it keeps the one it was given. */
+	public function testAnUnknownSpecialPageKeepsItsName() {
+		$url = '/x';
+		$this->main()->onGetLocalURL(Title::newFromText('Special:NoSuchPage'), $url, '');
+		$this->assertSame('./Special:NoSuchPage.html', $url);
+	}
+
+	/**
 	 * The "View source" tab points at the page's source file in the repository, and in Citizen it
 	 * brings an icon: the skin renders the page actions as icon buttons and stops rendering their
 	 * labels below desktop width, so a tab it has no icon for is a blank box there. It maps icons

--- a/tests/phpunit/unit/OutputNameTest.php
+++ b/tests/phpunit/unit/OutputNameTest.php
@@ -10,7 +10,7 @@ use MediaWikiUnitTestCase;
  */
 class OutputNameTest extends MediaWikiUnitTestCase {
 	/** Namespace numbers as the wiki this file describes has them. */
-	private const NAMESPACES = ['' => 0, 'File' => 6, 'Help' => 12];
+	private const NAMESPACES = ['' => 0, 'File' => 6, 'Help' => 12, '도움말' => 12];
 
 	protected function tearDown(): void {
 		unset($GLOBALS['wgWikvenFileNames']);
@@ -38,6 +38,7 @@ class OutputNameTest extends MediaWikiUnitTestCase {
 			'a plus stands' => ['', 'C++', 'C++.html'],
 			'a percent stands' => ['', '50%_done', '50%_done.html'],
 			'a Korean title stands' => ['', '설치', '설치.html'],
+			'a Korean namespace stands too' => ['도움말', '설치', '도움말:설치.html'],
 			// The four a Windows path cannot hold, other than the colon and the slash.
 			'a question mark stays escaped' => ['', 'What?', 'What%3F.html'],
 			'a quote stays escaped' => ['', 'A"B', 'A%22B.html'],
@@ -64,7 +65,14 @@ class OutputNameTest extends MediaWikiUnitTestCase {
 			// A subpage is a real directory under both, or nothing could count a page's depth.
 			'a subpage is still a directory' => ['', 'Manual/Config', 'Manual/Config.html'],
 			// As is the extension: the cache escapes every dot, and a name with none cannot end .html.
-			'the dot in a name comes back' => ['', 'File.svg', 'File.svg.html']
+			'the dot in a name comes back' => ['', 'File.svg', 'File.svg.html'],
+			// The namespace is escaped as the body is, or the name comes out half one and half the
+			// other -- and the two directions below stop agreeing on what the file is called.
+			'a Korean namespace is escaped too' => [
+				'도움말',
+				'설치',
+				'%EB%8F%84%EC%9B%80%EB%A7%90%3A%EC%84%A4%EC%B9%98.html'
+			]
 		];
 	}
 
@@ -116,6 +124,28 @@ class OutputNameTest extends MediaWikiUnitTestCase {
 
 	public static function provideBothSchemes(): array {
 		return ['readable' => [OutputName::READABLE], 'encoded' => [OutputName::ENCODED]];
+	}
+
+	/**
+	 * A prefixed name handed in whole names the file its namespace and dbkey name apart.
+	 *
+	 * The Special:MyLanguage marker is built that way: the target's prefixed name rides inside the
+	 * marker's own dbkey (Hooks\Adder::licensesHref, and any link through GetLocalURL), and
+	 * resolveTranslationLinks.php then looks for the file that name spells. So the two ways of
+	 * spelling one title have to land on one file, which is only true while the namespace is
+	 * escaped exactly as the rest of the name is.
+	 *
+	 * @dataProvider provideBothSchemes
+	 */
+	public function testAPrefixedNameSpellsTheFileItsPartsDo(string $scheme) {
+		foreach ([['File', 'Logo.png'], ['Help', '설치'], ['도움말', '설치'], ['도움말', 'Licenses']] as $title) {
+			[$namespace, $dbkey] = $title;
+			$this->assertSame(
+				OutputName::of($namespace, $dbkey, $scheme),
+				OutputName::of('', "$namespace:$dbkey", $scheme),
+				"$namespace:$dbkey, $scheme"
+			);
+		}
 	}
 
 	/** Nothing the file cache wrote, so nothing to rename: left exactly as it is. */


### PR DESCRIPTION
A `Special:MyLanguage` link is not a link to a file — no export holds that special page. It is the marker `resolveTranslationLinks.php` reads to send a reader to their own copy of the target, and on a translated site it is how a reader reaches their own language at all. The footer's licenses link rides on it too (`Adder::licensesHref`).

Two things had to hold for that to work, and neither did outside an English-language, plain-letters wiki.

## 1. The marker has to be written in one spelling

`RelativeUrl::resolveMyLanguage()` matches it by one. `Hooks\Main::onGetLocalURL()` wrote it from the wiki's own naming, which is several:

| what the author writes | what was written into the href | resolved? |
| --- | --- | --- |
| `[[Special:MyLanguage/X]]` on an English wiki | `Special:MyLanguage/X.html` | yes |
| `[[Special:MyLanguage/X]]`, content language `ko` | `특수:MyLanguage/X.html` | **no** |
| `[[특수:내언어/X]]`, content language `ko` | `특수:내언어/X.html` | **no** |
| `[[Special:Mylanguage/X]]` on an English wiki | `Special:Mylanguage/X.html` | **no** |

`getNsText()` answers `특수`, `Spezial`, `特別`; the special page answers to aliases of its own (`내언어` is core's Korean alias for `MyLanguage`); and MediaWiki matches an alias however it was capitalised, so the last row is reachable on a plain English wiki with no language configuration at all.

`Hooks\Main` now names a special page canonically — `NamespaceInfo::getCanonicalName(NS_SPECIAL)` for the namespace, `SpecialPageFactory::resolveAlias()` for the page — so all four rows arrive as the one marker the pass knows. Anything that is not a special page is still named as the wiki names it, which is the answer `rename.php` gets from the content language when it names the file, so link and file go on agreeing. A name no special page answers to keeps the one it was given. Special pages that are not markers named a file no export has before this change and name one after it; they stay the dead links they already were.

`Adder::licensesHref()` already wrote the canonical spelling, and its comment claiming the two markers are the same string is now true rather than aspirational. The three link sites in `Hooks\Main` now ask one private helper the same question.

## 2. The marker's target has to spell the file the target does

`OutputName::assemble()` escaped the body of a name and left the namespace text alone. Where a namespace is plain letters the two are the same thing and nothing showed. Where it is not, an `encoded` name came out half escaped and half not:

| | file on disk | target inside the marker |
| --- | --- | --- |
| `File:Logo.png` | `File%3ALogo.png.html` | `File%3ALogo.png` ✓ |
| `도움말:문서` | `도움말%3A%EB%AC%B8%EC%84%9C.html` | `%EB%8F%84%EC%9B%80%EB%A7%90%3A%EB%AC%B8%EC%84%9C` ✗ |

The marker carries its target's *prefixed* name inside its own dbkey, so the target went through the escaping whole while the file's namespace bypassed it. `resolveTranslationLinks.php` then found no translation and fell back to the source name, which was not there either.

The namespace now goes through the same spelling as the body. A name in a namespace reads the same whether its parts are handed in apart or the prefixed name is handed in whole — the invariant the marker rides on — and an `encoded` name is escaped throughout, as `WikvenFileNames`' documentation already says it is ("leaves every escape the page cache made in place"). `readable` names are unchanged in every case, since that spelling undoes the escaping again.

## Tests

Four added to `MainTest`, three of which fail on `main`:

- content language `ko`, canonical input → `./Special:MyLanguage/Getting_Started.html`
- content language `ko`, `특수:내언어/...` → the same marker
- English wiki, `Special:Mylanguage/...` → the same marker
- `Special:NoSuchPage` keeps its name (the guard; passes either way)

Two added to `OutputNameTest`, both of which fail on `main`:

- an `encoded` name in a Korean namespace is escaped throughout
- `of($ns, $dbkey)` and `of('', "$ns:$dbkey")` name one file, under both spellings

The existing both-directions test picks up the new Korean-namespace cases, so `of()` and `fromCache()` are still checked to agree on every one of them.

Each fix was verified by reverting it and watching its own tests fail, then restoring it. Full suite: 613 tests, 1045 assertions, OK, against MediaWiki 1.46 + SQLite. `phpcs`, `mago lint`, `mago format --check` and `typos` clean.