### PR TITLE
chore: write extension.json the way release-please leaves it

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -14,27 +14,46 @@
 	},
 	"ResourceModules": {
 		"ext.Wikven.styles": {
-			"styles": ["ext.Wikven.styles.less"]
+			"styles": [
+				"ext.Wikven.styles.less"
+			]
 		},
 		"ext.Wikven.emptyToolbox": {
-			"styles": ["empty-toolbox.less"]
+			"styles": [
+				"empty-toolbox.less"
+			]
 		},
 		"ext.Wikven.pinnableState": {
-			"scripts": ["pinnable-state.js"],
-			"dependencies": ["mediawiki.storage"]
+			"scripts": [
+				"pinnable-state.js"
+			],
+			"dependencies": [
+				"mediawiki.storage"
+			]
 		},
 		"ext.Wikven.citizenSkins": {
-			"scripts": ["citizen-skins.js"],
-			"messages": ["wikven-skin", "wikven-skin-description"]
+			"scripts": [
+				"citizen-skins.js"
+			],
+			"messages": [
+				"wikven-skin",
+				"wikven-skin-description"
+			]
 		},
 		"ext.Wikven.citizenSearchShortcuts": {
-			"scripts": ["citizen-search-shortcuts.js"]
+			"scripts": [
+				"citizen-search-shortcuts.js"
+			]
 		},
 		"ext.Wikven.vectorSkins": {
-			"scripts": ["vector-skins.js"]
+			"scripts": [
+				"vector-skins.js"
+			]
 		},
 		"ext.Wikven.appearance": {
-			"scripts": ["appearance.js"]
+			"scripts": [
+				"appearance.js"
+			]
 		}
 	},
 	"ResourceModuleSkinStyles": {
@@ -48,13 +67,22 @@
 	},
 	"Hooks": {
 		"ParserOutputPostCacheTransform": "hider",
-		"SkinTemplateNavigation::Universal": ["hider", "main"],
-		"SidebarBeforeOutput": ["hider", "adder"],
+		"SkinTemplateNavigation::Universal": [
+			"hider",
+			"main"
+		],
+		"SidebarBeforeOutput": [
+			"hider",
+			"adder"
+		],
 		"SkinAddFooterLinks": "adder",
 		"BeforePageDisplay": "adder",
 		"GetLocalURL": "main",
 		"OutputPageAfterGetHeadLinksArray": "main",
-		"SetupAfterCache": ["retrier", "main"],
+		"SetupAfterCache": [
+			"retrier",
+			"main"
+		],
 		"SifterSearchIndexPage": "indexer",
 		"PageContentLanguage": "declarer",
 		"GetMagicVariableIDs": "versioner",
@@ -63,7 +91,9 @@
 	"HookHandlers": {
 		"main": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Main",
-			"services": ["MainConfig"]
+			"services": [
+				"MainConfig"
+			]
 		},
 		"adder": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Adder"
@@ -79,7 +109,10 @@
 		},
 		"declarer": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Declarer",
-			"services": ["LanguageFactory", "LanguageNameUtils"]
+			"services": [
+				"LanguageFactory",
+				"LanguageNameUtils"
+			]
 		},
 		"versioner": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Versioner"
@@ -152,7 +185,9 @@
 		}
 	},
 	"MessagesDirs": {
-		"Wikven": ["i18n"]
+		"Wikven": [
+			"i18n"
+		]
 	},
 	"ExtensionMessagesFiles": {
 		"WikvenMagic": "Wikven.i18n.magic.php"


### PR DESCRIPTION
Groundwork for the 1.0.0 release, kept out of the release commit.

release-please bumps `$.version` in `extension.json` with its `json` updater, which re-serialises the whole object and expands every single-line array on the way out. #30 currently carries that as 128 lines of reformatting inside a commit that means to say one thing:

```
-			"styles": ["ext.Wikven.styles.less"]
+			"styles": [
+				"ext.Wikven.styles.less"
+			]
```

Reverting it in the release PR buys nothing — the next release PR opens with the same diff, and whoever handles it has to know to revert again. So write the file as the tool leaves it, once, and every release from here touches the version line alone.

Nothing else changes. That is checked rather than asserted:

```
$ php -r '$a = json_decode(shell_exec("git show origin/main:extension.json"), true);
          $b = json_decode(file_get_contents("extension.json"), true);
          echo $a === $b ? "identical\n" : "DIFFERS\n";'
identical
```

`biome.json` already lists `extension.json` under `files.includes` as an exclusion, so no formatter has an opinion to lose here.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_