### PR TITLE
docs: let the action examples read the version like the prose does

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -248,26 +248,21 @@ jobs:
           done
           exit "$status"
 
-      # The prose names the current version with {{WIKVENVERSION}}, which cannot go stale. A
-      # <syntaxhighlight> block cannot use it: a template or a variable is not expanded inside one,
-      # so the two action examples pin a literal instead, and a release that bumped extension.json
-      # without them would publish a page telling readers to pin the version before the one it
-      # announces. There is nothing else in docs/ naming a version by hand.
-      - name: Check the action examples pin the version being released
+      # No page under docs/ spells out which version to pin. The prose reads it from
+      # {{WIKVENVERSION}}, and the action examples reach it too: a variable is not expanded inside
+      # a plain <syntaxhighlight>, but a parser function's arguments are expanded before the tag
+      # ever sees them, so the examples are written as {{#tag:syntaxhighlight|...|lang=yaml}}.
+      # A literal written back in would be right on the day and wrong at the next release.
+      - name: Check no page pins a wikven action to a literal version
         run: |
           set -euo pipefail
-          version=$(jq -r '.version' extension.json)
-          status=0
-          while IFS= read -r hit; do
-            case "$hit" in *"@v$version"*) continue ;; esac
-            echo "::error::$hit"
-            status=1
-          done < <(grep -rn -oE 'chaotic-ground/wikven/actions/[a-z-]+@[^ ]+' docs/ || true)
-          if [ "$status" -ne 0 ]; then
-            echo "::error::the lines above pin an action version other than $version, which is what" \
-                 "extension.json declares. Bump them with the release."
+          stray=$(grep -rn -oE 'chaotic-ground/wikven/actions/[a-z-]+@v[0-9]' docs/ || true)
+          if [ -n "$stray" ]; then
+            echo "$stray"
+            echo "::error::the lines above name a version by hand. Write @v{{WIKVENVERSION}}" \
+                 "instead, in a {{#tag:syntaxhighlight|...|lang=yaml}} block so it is expanded."
+            exit 1
           fi
-          exit "$status"
 
   # "composer test" is minus-x, which checks file modes and shebangs and needs no wiki around it.
   # It ran as a quibble stage, which spent 100 seconds booting MediaWiki to reach a check that

--- a/docs/Commands.wikitext
+++ b/docs/Commands.wikitext
@@ -157,12 +157,12 @@ Bakes a source tree with the Docker image, on a GitHub Actions runner. See [[<tv
 {{note|Both actions are pinned by tag, and <code>@v<tvar name="3">{{WIKVENVERSION}}</tvar></code> is the current release. Naming no <code>image</code> is enough on its own: the action then runs the image of the release it was cut from, the matching <code>:<tvar name="4">{{WIKVENVERSION}}</tvar></code> — the git tag carries the <code>v</code> and the image tag does not — so the two cannot fall out of step. To try a change before it is released, name a dated <code>nightly-YYYY-MM-DD</code> pre-release from the [<tvar name="2">https://github.com/chaotic-ground/wikven/releases</tvar> releases page], and name the image from the same nightly while you are there.}}
 </translate>
 
-<syntaxhighlight lang="yaml" copy>
-- uses: chaotic-ground/wikven/actions/bake@v1.0.0
+{{#tag:syntaxhighlight|
+- uses: chaotic-ground/wikven/actions/bake@v{{WIKVENVERSION}}
   with:
     source: src
     output: dist
-</syntaxhighlight>
+|lang=yaml|copy=}}
 
 <translate>
 <!--T:24-->
@@ -199,11 +199,11 @@ Runs <code>translate check</code> over a source tree and reports each finding as
 {{note|Annotations are for whoever is reading the diff. A contributor sending their first translation is better served by being told what to run, which <code>comment: true</code> does: one comment on the pull request, the findings grouped by what went wrong, each group naming the command that answers it. It is edited on each run rather than added to, and taken down once nothing is left to report -- a comment saying nothing is wrong is one nobody needs, and the annotations hold the record either way. That contributor is by definition working in another language, so the comment can speak it: <code>comment-languages: auto</code> writes it in English and in the language of the translation it is about, from wikven's own interface messages. The job needs <code>pull-requests: write</code>; a pull request from a fork carries a read-only token, and the comment is then skipped with a line in the log.}}
 </translate>
 
-<syntaxhighlight lang="yaml" copy>
-- uses: chaotic-ground/wikven/actions/check-translations@v1.0.0
+{{#tag:syntaxhighlight|
+- uses: chaotic-ground/wikven/actions/check-translations@v{{WIKVENVERSION}}
   with:
     source: src
-</syntaxhighlight>
+|lang=yaml|copy=}}
 
 <translate>
 <!--T:28-->

--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -42,7 +42,7 @@ Two things about that layout are worth knowing before you point a host at it. Li
 This workflow rebuilds and publishes the site on every push. It bakes the source with the {{SITENAME}} [<tvar name="1">https://github.com/chaotic-ground/wikven/tree/main/actions/bake</tvar> composite action], then uploads <code>dist/</code> to Pages.
 </translate>
 
-<syntaxhighlight lang="yaml" copy>
+{{#tag:syntaxhighlight|
 name: Deploy
 on:
   push:
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+      url: $<nowiki>{{</nowiki> steps.deploy.outputs.page_url <nowiki>}}</nowiki>
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -64,7 +64,7 @@ jobs:
           # its source file. A shallow checkout knows only the latest commit.
           fetch-depth: 0
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
-      - uses: chaotic-ground/wikven/actions/bake@v1.0.0
+      - uses: chaotic-ground/wikven/actions/bake@v{{WIKVENVERSION}}
         with:
           source: src
           output: dist
@@ -73,7 +73,7 @@ jobs:
           path: dist
       - id: deploy
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
-</syntaxhighlight>
+|lang=yaml|copy=}}
 
 <translate>
 <!--T:26-->


### PR DESCRIPTION
The prose names the current version with `{{WIKVENVERSION}}` and so cannot go stale. The three action examples could not: the parser strips a tag hook's content out *before* it expands anything, so nothing is expanded inside `<syntaxhighlight>`. They pinned a literal, and 1.0.0 added a lint check to hold that literal to `extension.json`.

A parser function's arguments are expanded before the function runs, and `{{#tag:}}` hands its expanded argument to the tag hook. Measured against a real MediaWiki 1.46 with SyntaxHighlight_GeSHi loaded:

| what was parsed | what came out |
| --- | --- |
| `<syntaxhighlight lang="yaml" copy>…@v{{WIKVENVERSION}}…</syntaxhighlight>` | `…@v{{WIKVENVERSION}}` — unexpanded |
| `{{#tag:syntaxhighlight\|…@v{{WIKVENVERSION}}…\|lang=yaml\|copy=}}` | `…@v1.0.0`, and `mw-highlight-copy` still on the wrapper |

`copy=` is enough for the button because SyntaxHighlight asks only `isset( $args['copy'] )`.

## The one line that pays for it

A parser function's argument ends at the next `|`, and `{{` inside it opens a transclusion. The deploy workflow contains a GitHub expression:

```yaml
      url: ${{ steps.deploy.outputs.page_url }}
```

which came out as `$[[:Template:Steps.deploy.outputs.page url]]`. Of the escapes tried, only one survives:

| escape | result |
| --- | --- |
| `${<nowiki/>{ … }}` | the `}}` closes `#tag:` early; `\|lang=yaml}}` leaks into the page |
| `$<nowiki>{{</nowiki> … <nowiki>}}</nowiki>` | **`url: ${{ steps.deploy.outputs.page_url }}`** |
| `$&#123;&#123; … &#125;&#125;` | entities are not decoded; shown as written |
| `{{!}}` for a literal pipe | works, though no example needs one |

So that one line carries `<nowiki>` around its braces and everything else in the block is unchanged.

## The lint check turns around

1.0.0's check read `extension.json` and required every example to pin exactly that version. With no literal left it would fail on `@v{{WIKVENVERSION}}`, and it has nothing to guard anyway. It now asserts the opposite — that no page pins a version by hand — which is the property the examples now have:

```
grep -rn -oE 'chaotic-ground/wikven/actions/[a-z-]+@v[0-9]' docs/
```

Verified empty on this tree, and verified non-empty (exit 1) with a literal written back into a decoy page.

## Rendering

Both real pages parsed against MediaWiki 1.46 with Wikven loaded, so `{{WIKVENVERSION}}` resolves from `extension.json`:

```
=== Deploying ===
  url: ${{ steps.deploy.outputs.page_url }}
  - uses: chaotic-ground/wikven/actions/bake@v1.0.0
  copy wrappers: 4
=== Commands ===
  - uses: chaotic-ground/wikven/actions/bake@v1.0.0
  - uses: chaotic-ground/wikven/actions/check-translations@v1.0.0
  copy wrappers: 8
```

The copy-wrapper counts match the `copy` blocks each page has, so no block lost its button. Nothing leaked: no unexpanded `{{WIKVENVERSION}}`, no `Template:Steps…`, no stray `lang=yaml` text, no strip markers.

All three blocks sit outside `<translate>`, so no translation unit moves and no stamp changes. `tests/e2e/copy-button.spec.js` reads `Configuration.html`, which is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_