### PR TITLE
ci: link each bumped extension to what changed

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -30,3 +30,94 @@ jobs:
       - run: updatecli pipeline apply --config updatecli/updatecli.d
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The bundled extensions are pinned to commits, and a gitcommit source carries no changelog,
+      # so the pull request updatecli writes for them names the new commit and stops there: what
+      # moved is a click away only for a reader willing to build the compare url by hand. The range
+      # needs the pin being replaced, which no upstream source can know and only this repository
+      # holds, so it is worked out here -- the pins on main against the pins updatecli pushed --
+      # and appended to the body updatecli wrote.
+      #
+      # No mirror url is written down below. The Dockerfile fetches each tarball from codeload, and
+      # the site's config names the repository on the line above the commit, so every link is read
+      # off the same line as the pin it describes and cannot come to name a repository the build
+      # does not fetch from. The other manifests need none of this: their sources are GitHub
+      # releases, which bring their own notes and their own compare link.
+      - name: Link each bumped extension to what changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          # updatecli names the branch after the manifest's pipelineid.
+          BRANCH: updatecli_main_mediawiki-extensions
+          # The block is written between these, and a later run strips what they hold before
+          # writing again, so a pull request updatecli keeps open collects one block and not one
+          # per week.
+          OPEN: "<!-- wikven: what changed upstream -->"
+          CLOSE: "<!-- /wikven -->"
+        run: |
+          set -euo pipefail
+
+          if ! gh api "repos/$REPOSITORY/branches/$BRANCH" >/dev/null 2>&1; then
+            echo "wikven: updatecli pushed no extension bump; nothing to link."
+            exit 0
+          fi
+
+          # "<name> <owner/repo> <commit>", one per extension pinned by a commit.
+          pins() {
+            tree=$1
+            sed -n 's/^ARG \([A-Z_]*_VERSION\)=\([0-9a-f]\{40\}\)$/\1=\2/p' "$tree/Dockerfile" |
+              while IFS='=' read -r var sha; do
+                slug=$(sed -n \
+                  "s#.*codeload\.github\.com/\([^/]*/[^/]*\)/tar\.gz/\$$var\b.*#\1#p" \
+                  "$tree/Dockerfile" | head -n1)
+                [ -n "$slug" ] || continue
+                printf '%s %s %s\n' "${slug##*-}" "$slug" "$sha"
+              done
+            awk '
+              /^    [A-Za-z]/ { name = $1; sub(/:$/, "", name); repo = "" }
+              /^      repository:/ { repo = $2 }
+              /^      commit:/ && repo != "" {
+                slug = repo
+                sub(/^https:\/\/github\.com\//, "", slug)
+                sub(/\.git$/, "", slug)
+                print name, slug, $2
+              }
+            ' "$tree/docs/.wikven.yaml"
+          }
+
+          work=$(mktemp -d)
+          after=$work/after
+          mkdir -p "$after/docs"
+          for file in Dockerfile docs/.wikven.yaml; do
+            gh api "repos/$REPOSITORY/contents/$file?ref=$BRANCH" \
+              -H "Accept: application/vnd.github.raw" > "$after/$file"
+          done
+
+          pins . | sort > "$work/before.pins"
+          pins "$after" | sort > "$work/after.pins"
+          links=$(join -j 1 -o 0,1.2,1.3,2.3 "$work/before.pins" "$work/after.pins" |
+            while read -r name slug old new; do
+              [ "$old" != "$new" ] || continue
+              printf '* [%s](https://github.com/%s/compare/%s...%s)\n' "$name" "$slug" "$old" "$new"
+            done)
+
+          if [ -z "$links" ]; then
+            echo "wikven: the branch pins what main pins; nothing to link."
+            exit 0
+          fi
+
+          number=$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$number" ]; then
+            echo "wikven: no open pull request for $BRANCH; leaving the links unwritten."
+            exit 0
+          fi
+
+          gh pr view "$number" --repo "$REPOSITORY" --json body --jq .body \
+            | awk -v opening="$OPEN" -v closing="$CLOSE" '
+                $0 == opening { skip = 1 } !skip { print } $0 == closing { skip = 0 }
+              ' > "$work/body"
+          { printf '%s\n' "$OPEN"; echo; echo "What changed upstream:"; echo
+            printf '%s\n' "$links"; echo; printf '%s\n' "$CLOSE"; } >> "$work/body"
+          gh pr edit "$number" --repo "$REPOSITORY" --body-file "$work/body"
+          echo "wikven: linked $(printf '%s\n' "$links" | wc -l) bumped extension(s) on #$number."


### PR DESCRIPTION
#610 says this and nothing more:

```
build(deps): bump MobileFrontend to f0212f7fc0dc3403b8da334250af2188b07143ec
build(deps): bump Translate to 9712a29d4501c1e71abdb807754cdb6ff80a1ee2
build(deps): bump UniversalLanguageSelector to d33a5434bd80c3f7acb02541b9394665c84ea585
```

The three bundled extensions are pinned to commits, and updatecli's `gitcommit` source carries no changelog, so its pull request names the new commit and leaves the reader to build the compare URL by hand. Every other manifest reads a GitHub release, which brings its own notes and its own compare link — only this one is bare.

No upstream source can close that gap: a compare range needs the pin being *replaced*, and only this repository holds it. So the links are worked out where the two meet — after updatecli has pushed, the pins on `main` are read against the pins on its branch — and appended to the body updatecli wrote.

With #610's real values the step produces:

```
* [MobileFrontend](``https://github.com/wikimedia/mediawiki-extensions-MobileFrontend/compare/fe7cb1a753c901d5a9b84bae7f727037e8820bec...f0212f7fc0dc3403b8da334250af2188b07143ec``)
* [Translate](``https://github.com/wikimedia/mediawiki-extensions-Translate/compare/aa26d27de23b513ccad3d760cacca45d363441d2...9712a29d4501c1e71abdb807754cdb6ff80a1ee2``)
* [UniversalLanguageSelector](``https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector/compare/2abc262e45f5cda98bdcdcd1a0c32d9bb8ef7130...d33a5434bd80c3f7acb02541b9394665c84ea585)``
```

The first of those was opened to check the shape: a real comparison, one commit, "Localisation updates from translatewiki.net".

## No mirror URL is written down

The Dockerfile fetches each tarball from `codeload.github.com/<owner>/<repo>/tar.gz/$<ARG>`, and the site's config names `repository:` on the line above `commit:`. The step reads each link off the same line as the pin it describes, so it cannot come to name a repository the build does not fetch from — there is no second copy of the mapping to drift.

The target name was the other candidate and is unusable: updatecli commits once per target with the name as the message, and those are already being truncated —

```
chore: build(deps): bump Translate to 9712a29d4501c1e71abdb807754cdb6...
    ... ff80a1ee2
```

— so a URL there would land in a commit subject that release-please and `semantic-pull-request` both read.

## Testing

The script was extracted from the YAML with a parser and run as the runner would run it, with `gh` stubbed:

| case | result |
| --- | --- |
| three pins moved | the three links above, appended under the markers |
| run again on the body it just wrote | byte-identical — the block is replaced, not repeated |
| branch pins == main pins | `the branch pins what main pins; nothing to link.`, exit 0 |
| no branch pushed | `updatecli pushed no extension bump; nothing to link.`, exit 0 |

Two bugs were caught that way and fixed: `$work/after` collided with the directory of the same name, and `open`/`close` cannot be `awk -v` names because both are builtins.

`yamllint --strict` and `typos` are clean. Temporary files go to `mktemp -d` rather than the checkout. Every `${{ }}` is bound through `env:` rather than interpolated into the script, and the job already carries the `contents` and `pull-requests` permissions the step needs.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cnWPQfAU8XuUYwBgtGUAN)_