### PR TITLE
fix: stop shipping a Caddy module wikven cannot use

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -99,6 +99,24 @@ jobs:
             printf '| PHP | `%s` |\n' "$php"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # Vulcain, which binary.Dockerfile leaves out of the xcaddy module list. Asserted on the built
+      # artefact rather than on that list, because the list is a request and this is the answer: a
+      # module reachable through another module's imports is linked whatever the flags said, which
+      # is exactly the case of Mercure, and why Mercure is not asserted here.
+      #
+      # Grepped rather than read with `go version -m`, which would need a toolchain agreeing with
+      # the one that built this. A Go binary carries its module paths as plain strings, so their
+      # absence from the bytes is the whole claim.
+      - name: Vulcain is not linked in
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          if grep -aqF github.com/dunglas/vulcain "wikven-linux-$ARCH"; then
+            echo "::error::vulcain is linked in; see the module list in binary.Dockerfile"
+            exit 1
+          fi
+
       # Handed to the bake job below, which is a separate job because it needs a runner without a
       # Docker build on it -- the point is to exercise the binary the way somebody who downloaded it
       # would, on a machine that has nothing of wikven's installed.

--- a/binary.Dockerfile
+++ b/binary.Dockerfile
@@ -33,10 +33,22 @@ WORKDIR /go/src/app
 COPY --from=app /var/www/html ./dist/app
 # A small Caddy module registers the `build`, `serve` and `translate` subcommands,
 # so the binary can be run as `./wikven build` instead of `./wikven php-cli
-# build.php`. It is linked into the FrankenPHP binary alongside FrankenPHP's own
-# default Caddy modules.
+# build.php`.
+#
+# Setting this replaces FrankenPHP's default module list rather than adding to it, so the line is
+# also the list of what the binary does not carry. Vulcain, a REST push gateway, is left out of it:
+# nothing in a bake or in `wikven serve` reaches one, and it is AGPL-3.0, so linking it meant
+# redistributing AGPL code for a capability nobody using this binary can call. binary.yml asserts
+# it is gone from the build, because a list like this is easy to restore by copying FrankenPHP's
+# defaults back over it.
+#
+# Mercure, the other AGPL-3.0 default, is not attempted and cannot be dropped this way: frankenphp's
+# own Caddy package imports it (`go mod why` gives frankenphp/caddy -> mercure), so it is linked
+# whatever this list says and every FrankenPHP binary carries it. The licenses page names it.
+#
+# cbrotli stays: it is what `wikven serve` compresses with.
 COPY caddy /go/wikven-caddy
-ENV SPC_CMD_VAR_FRANKENPHP_XCADDY_MODULES="--with github.com/dunglas/mercure/caddy --with github.com/dunglas/vulcain/caddy --with github.com/dunglas/caddy-cbrotli --with github.com/chaotic-ground/wikven/caddy=/go/wikven-caddy"
+ENV SPC_CMD_VAR_FRANKENPHP_XCADDY_MODULES="--with github.com/dunglas/caddy-cbrotli --with github.com/chaotic-ground/wikven/caddy=/go/wikven-caddy"
 ENV PHP_VERSION=8.3
 ENV PHP_EXTENSIONS="gd,intl,pdo_sqlite,sqlite3,mbstring,dom,xml,simplexml,xmlreader,xmlwriter,fileinfo,iconv,ctype,filter,tokenizer,phar,session,calendar,opcache,openssl,sodium,zlib,bcmath,exif"
 ENV PHP_EXTENSION_LIBS="libpng,libjpeg,freetype,libwebp"


### PR DESCRIPTION
`binary.Dockerfile`'s xcaddy module list restated FrankenPHP's defaults and appended wikven's own, so **Vulcain** came along: a REST push gateway, in a program that renders wikitext to files and then serves them off disk. Nothing in a bake or in `wikven serve` reaches it.

It is **AGPL-3.0**. Carrying it meant redistributing AGPL code inside a GPL-3.0-or-later binary for a capability its users cannot call.

This was real rather than nominal — `go version -m` on the released 1.0.0 binary lists it:

```
dep  github.com/dunglas/vulcain        v1.4.3
dep  github.com/dunglas/vulcain/caddy  v1.4.3
```

## Why the check is on the artefact

The module list is a request; the build is the answer. A module reachable through another module's imports is linked whatever the flags said.

That is not hypothetical here. An earlier revision of this change dropped **both** AGPL defaults from the list and asserted both were gone. The assertion caught Vulcain leaving and Mercure staying, and `go mod why` explained it:

```
why -> github.com/dunglas/frankenphp/caddy -> github.com/dunglas/mercure
```

`frankenphp`'s own Caddy package imports Mercure, so no xcaddy list can decline it and every FrankenPHP binary carries it. So this change asserts only what the repository controls, and the comment in `binary.Dockerfile` says why Mercure is not attempted rather than leaving the next person to rediscover it.

Mercure is not left unsaid, though: #617 put it on the generated licenses page with its license, alongside FrankenPHP, Caddy and Vulcain. Once this merges, the Vulcain row stops appearing on its own — `runtimeEnv()` reports the modules the build actually linked, so nothing there needs editing.

## How the check was tested

Grepped rather than read with `go version -m`, which would need a toolchain agreeing with the one that built the binary; a Go binary carries its module paths as plain strings, so their absence from the bytes is the whole claim.

Run against the released 1.0.0 binary — which does contain the module — it exits 1 and names it. An assertion that cannot fail is not one.

## Size

A side effect, not the reason, and measured on the two builds of the previous branch that differed only in this:

| | artifact |
| --- | --- |
| Vulcain linked | 201,045,680 B |
| Vulcain gone | 200,235,279 B |

−810,401 B, about 0.40%. That is the compressed artifact CI stores; the raw binary's shrink is larger and was not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_