### PR TITLE
chore: repair the settings load order WikvenSiteUrl needs

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -16,6 +16,11 @@ skins:
   - Citizen
   - MinervaNeue
 config:
+  # Where this site is served from. Nothing in a build can work this out for itself: it renders
+  # against a local server and links every page relatively, which is what lets an export run from
+  # any directory and any host. Anything that has to name a page from outside the site is built
+  # from this.
+  WikvenSiteUrl: https://chaotic-ground.github.io/wikven/
   WikvenFooterUrl: https://github.com/chaotic-ground/wikven
   WikvenEditUrl: https://github.com/chaotic-ground/wikven/edit/main/docs/$1
   WikvenHistoryUrl: https://github.com/chaotic-ground/wikven/commits/main/docs/$1

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -155,8 +155,11 @@ if ($wikvenConvert === null || $wikvenRsvg === null) {
 // Load config: default.yml then the site file via $wgSettings; ext/skin lists loaded leniently.
 global $wgSettings;
 
-// Autoloader not active yet at LocalSettings time; load the helper directly.
+// Autoloader not active yet at LocalSettings time; load the helpers directly. SiteUrl belongs here
+// rather than beside its other use below: lint() reads a site's WikvenSiteUrl through it, and that
+// runs a few lines down from here.
 require_once "$IP/extensions/Wikven/includes/SiteConfig.php";
+require_once "$IP/extensions/Wikven/includes/SiteUrl.php";
 
 // Pick the highest-precedence config name present; warn about any others.
 $wikvenLocated = MediaWiki\Extension\Wikven\SiteConfig::locate($wikvenSrc);
@@ -197,9 +200,6 @@ foreach ([$wikvenYamlData, $wikvenSiteData] as $wikvenData) {
 
 // Push merged config into globals so the logo handling below reads final values.
 $wgSettings->apply();
-
-// Autoloader not active yet at LocalSettings time; load the helper directly.
-require_once "$IP/extensions/Wikven/includes/SiteUrl.php";
 
 // Core keeps a site's address in two halves -- $wgCanonicalServer is scheme and host, a path lives
 // elsewhere -- and a site should not have to write it twice. It writes WikvenSiteUrl once and this


### PR DESCRIPTION
Split out of #623, which now stacks on this.

## The defect

`SiteConfig::lint()` reads a site's `WikvenSiteUrl` through `SiteUrl`, and ran twenty lines above the `require_once` that loads it. Any site that actually set the value fataled at `LocalSettings` time:

    Fatal error: Uncaught Error: Class "MediaWiki\Extension\Wikven\SiteUrl" not found
      in /var/www/html/WikvenSettings.php

CI never saw it. The path is behind `$siteUrl !== ''` and no test site set one, so the only setting #621 added was broken on its only non-default path with all 26 checks green.

`docs/.wikven.yaml` now names the documentation site's own URL. That is what stops this recurring: the path is in every bake CI runs, and it fills `$wgCanonicalServer` besides, so an absolute URL MediaWiki or an extension builds names the right host instead of `localhost`.

## Why this is a chore and not a fix

The defect was introduced by #621, and #621 has not been released — it is sitting in the pending 1.1.0 (#618). Nobody running 1.0.0 ever had this bug.

`.release-please-config.json` shows `fix` under a visible "Bugfixes" section, so typing this as a fix would put a line in 1.1.0's notes describing a defect no released version carried. `chore` is hidden, which is the right answer for repairing unreleased work. The commit message says the same, so the reasoning survives the squash.

## Checked locally

Built with the released binary over this working tree:

- A site setting `WikvenSiteUrl` — reproduced the fatal, then confirmed the build completes and writes its pages.
- `$wgCanonicalServer` comes out as `https://chaotic-ground.github.io` where `WikvenSiteUrl` is `https://chaotic-ground.github.io/wikven/` — the host half, path left to wikven.
- `phpcs` (60 files), `mago format --check`, `mago lint`, `yamllint` all clean.

`phpcs` now runs here, which it did not for the three lint failures earlier in this stack: `phpcsstandards/phpcsextra` was installed but its sniff path was not registered, so every `Universal.*` reference errored out. Registering `installed_paths` fixed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_