### PR TITLE
docs: install WikiSEO and claim the documentation site

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -139,6 +139,24 @@ jobs:
           print(f'sitemap.xml: {len(locs)} absolute URLs')
           PY
 
+          # og:url has to be a whole URL: it is read off the page by something that never saw the
+          # page's address. Title::getFullURL() answers the GetFullURL hook, so this is the tag that
+          # proves that hook fired -- before it existed WikiSEO published "http:index.html" here,
+          # green across every other check.
+          python3 - <<'PY'
+          import glob, re, sys
+          from urllib.parse import urlparse
+          bad = []
+          for path in glob.glob('dist/**/*.html', recursive=True):
+              with open(path, encoding='utf-8') as handle:
+                  found = re.search(r'<meta property="og:url" content="([^"]*)"', handle.read())
+              if found and urlparse(found.group(1)).scheme not in ('http', 'https'):
+                  bad.append((path, found.group(1)))
+          if bad:
+              sys.exit(f'og:url is not an absolute URL on {len(bad)} page(s): {bad[:3]}')
+          print('og:url is absolute on every page that carries one')
+          PY
+
           # Two bakes of one source must agree on the sitemap too; the walk behind it is a directory
           # iterator, whose order is the filesystem's rather than anything reproducible (#411).
           diff dist/sitemap.xml dist-again/sitemap.xml

--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -10,6 +10,7 @@ extensions:
   - TabberNeue
   - TemplateStyles
   - Translate
+  - WikiSEO
   - UniversalLanguageSelector
 # With Vector from default.yml, this is the whole supported set.
 skins:
@@ -21,6 +22,10 @@ config:
   # any directory and any host. Anything that has to name a page from outside the site is built
   # from this.
   WikvenSiteUrl: https://chaotic-ground.github.io/wikven/
+  # Proves to Google that whoever registered this site in Search Console controls it. WikiSEO turns
+  # it into a meta tag on every page; the value is a public token, not a credential -- it grants
+  # nothing but the claim, and Google publishes it back to anyone who asks for the site's tag.
+  GoogleSiteVerificationKey: 2rzhjoB0M6oJLKFCyvqcW6_SGAkxpf7o4RIWOGfpfPY
   WikvenFooterUrl: https://github.com/chaotic-ground/wikven
   WikvenEditUrl: https://github.com/chaotic-ground/wikven/edit/main/docs/$1
   WikvenHistoryUrl: https://github.com/chaotic-ground/wikven/commits/main/docs/$1
@@ -71,3 +76,13 @@ config:
     MobileFrontend:
       repository: https://github.com/wikimedia/mediawiki-extensions-MobileFrontend.git
       commit: f0212f7fc0dc3403b8da334250af2188b07143ec
+    # WikiSEO writes the head tags a static export cannot get any other way: the site
+    # verification token above, and later the canonical and hreflang links. Not bundled in the
+    # image, so it is fetched here.
+    #
+    # Pinned to REL1_46's head, like MobileFrontend and for the same reason, rather than to the
+    # v2.7.0 tag: that tag carries a manifest reading 2.6.6 and MediaWiki >= 1.39, while the branch
+    # reads 2.7.0 and >= 1.42. The tag is mis-stamped, so its name promises code it does not hold.
+    WikiSEO:
+      repository: https://github.com/wikimedia/mediawiki-extensions-WikiSEO.git
+      commit: 3f8aeb66f322d6687a3623e377cd8f0488f39f71

--- a/updatecli/updatecli.d/mediawiki-extensions.yaml
+++ b/updatecli/updatecli.d/mediawiki-extensions.yaml
@@ -46,6 +46,13 @@ sources:
       url: https://github.com/wikimedia/mediawiki-extensions-MobileFrontend
       branch: REL1_46
       depth: 1
+  wikiseo:
+    name: Head of WikiSEO's REL1_46
+    kind: gitcommit
+    spec:
+      url: https://github.com/wikimedia/mediawiki-extensions-WikiSEO
+      branch: REL1_46
+      depth: 1
 
 targets:
   translate:
@@ -76,3 +83,11 @@ targets:
     spec:
       file: docs/.wikven.yaml
       key: $.config.WikvenRepositories.MobileFrontend.commit
+  wikiseo:
+    name: 'build(deps): bump WikiSEO to {{ source "wikiseo" }}'
+    kind: yaml
+    scmid: default
+    sourceid: wikiseo
+    spec:
+      file: docs/.wikven.yaml
+      key: $.config.WikvenRepositories.WikiSEO.commit


### PR DESCRIPTION
Follows #621, #624, #623 and #630. Three files, no code.

## What it does

A static export has no way to put a head tag that is about the site rather than a page, and proving control of a site to a search engine is exactly that. WikiSEO is the widely used extension for it. The key is a public token — it grants nothing but the claim, and the search engine publishes it back to anyone who asks for the site&#39;s tag.

**The pin is REL1_46&#39;s head, not the `v2.7.0` tag.** The tag is mis-stamped:

| ref | manifest version | requires |
| --- | --- | --- |
| `v2.7.0` tag | **2.6.6** | MediaWiki &gt;= 1.39 |
| `REL1_46` branch | 2.7.0 | MediaWiki &gt;= 1.42 |
| `master` | 2.7.0 | MediaWiki &gt;= 1.42 |

The tag&#39;s name promises code it does not hold. `REL1_46` carries the same code as master and follows the release branch of the image&#39;s MediaWiki, which is how Translate, UniversalLanguageSelector and MobileFrontend are already pinned. `updatecli/updatecli.d/mediawiki-extensions.yaml` gains a source and target so the pin does not go stale.

## Why it needed #630 first

WikiSEO does not only emit the verification tag. Diffing the head against the same fixture without it:

```
+    <meta property="og:title" content="…">
+    <meta property="og:url" content="…">
+    <meta property="og:type" content="website">
+    <meta property="article:modified_time" content="…">
+    <meta property="article:published_time" content="…">
```

`article:modified_time` and `article:published_time` come out as the frozen `page_touched`, so they are stable across bakes — a fixed value rather than a drifting one, same as the sitemap&#39;s omitted modification time.

`og:url` was the blocker, and it was ours, not WikiSEO&#39;s:

```php
$url = $this->outputPage->getTitle()->getFullURL();   // this build answered "./index.html"
$url = WikiSEO::protocolizeUrl( $url, ... );          // -> "http:index.html"
```

There is no switch that turns the OpenGraph output off — `MetadataGenerators` **replaces** the built-in list when non-empty, but `Twitter extends OpenGraph`, so the only list that drops `og:url` is `[SchemaOrg]`, which throws away the useful tags with it. #630 fixed the cause instead.

## Verification

Built with the released binary against a fixture that fetches the extension for real:

- the verification tag lands on every page;
- **`og:url` is an absolute URL on all 219 pages that carry one**, and a skin preview copy names the page it duplicates rather than itself;
- WikiSEO appears on the generated Licenses page by itself (GPL-2.0-or-later), with no extra work;
- two bakes of one source are byte-identical, so nothing here breaks #411.

The smoke bake now fails on a non-absolute `og:url`. Every check was green while the preview shipped the broken one, which is the same gap that let a fataling setting through in #621 — and this assertion is the end-to-end proof of #630, which could not carry it: without WikiSEO installed no page has an `og:url` to assert on.

## After this merges

Register the site in Google Search Console and submit `sitemap.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn