### PR TITLE
fix: answer a caller that asked for a whole URL with one

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -78,6 +78,8 @@
 		"SkinAddFooterLinks": "adder",
 		"BeforePageDisplay": "adder",
 		"GetLocalURL": "main",
+		"GetFullURL": "main",
+		"GetCanonicalURL": "main",
 		"OutputPageAfterGetHeadLinksArray": "main",
 		"SetupAfterCache": [
 			"retrier",

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -7,6 +7,7 @@ use MediaWiki\Extension\Wikven\AssetFile;
 use MediaWiki\Extension\Wikven\BuildFor;
 use MediaWiki\Extension\Wikven\OutputName;
 use MediaWiki\Extension\Wikven\Search;
+use MediaWiki\Extension\Wikven\SiteUrl;
 use MediaWiki\Extension\Wikven\SourceFile;
 use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
@@ -17,6 +18,8 @@ use MediaWiki\ResourceLoader\ResourceLoader;
 use MediaWiki\Title\Title;
 
 class Main implements
+	\MediaWiki\Hook\GetCanonicalURLHook,
+	\MediaWiki\Hook\GetFullURLHook,
 	\MediaWiki\Hook\GetLocalURLHook,
 	\MediaWiki\Hook\OutputPageAfterGetHeadLinksArrayHook,
 	\MediaWiki\Hook\SetupAfterCacheHook,
@@ -31,27 +34,120 @@ class Main implements
 	/** The directory everything the build generates is written to, relative to the HTML one. */
 	private string $assetDirectory;
 
+	/** Where the site says it will be published, unknown where it has not said. */
+	private SiteUrl $siteUrl;
+
 	public function __construct(Config $config) {
 		$this->config = $config;
 		$this->htmlDirectory = $config->get('WikvenHtmlDirectory');
 		$this->assetDirectory = $config->get('WikvenAssetDirectory');
+		// Read once: onGetLocalURL answers every link on every page, and parsing a URL per link
+		// would be paid thousands of times a render for a value that cannot change mid-build.
+		$this->siteUrl = SiteUrl::fromWritten((string)$config->get('WikvenSiteUrl'));
 	}
 
 	/** @inheritDoc */
 	public function onGetLocalURL($title, &$url, $query) {
+		$target = $this->exportTarget($title, (string)$query);
+		if ($target !== null) {
+			$url = $target['local'];
+		}
+	}
+
+	/**
+	 * The whole URL of the page, for a caller that asked for one.
+	 *
+	 * getFullURL() and getCanonicalURL() each run their own hook after calling getLocalURL() and
+	 * expanding the result, and each is handed the same Title this build already knows how to name.
+	 * So the answer is recomputed from that title rather than recovered from the string: which of
+	 * the three hooks ran is the only honest signal that a caller wanted an absolute URL, and core
+	 * delivers it.
+	 *
+	 * Without it they get what expand() makes of a relative link, which is not a URL at all --
+	 * "./index.html" comes back as "index.html", and a caller that prepends a scheme publishes
+	 * "http:index.html". That is what WikiSEO put in og:url on every page.
+	 *
+	 * Where the site has not said where it is published there is no address to give, so the value
+	 * is left as it was: a wrong absolute URL would be worse than an obviously relative one.
+	 *
+	 * @inheritDoc
+	 */
+	public function onGetFullURL($title, &$url, $query) {
+		$target = $this->exportTarget($title, (string)$query);
+		if ($target !== null && $target['whole'] !== null) {
+			$url = $target['whole'];
+		}
+	}
+
+	/**
+	 * As onGetFullURL, plus the fragment getCanonicalURL() carries and getFullURL() does not.
+	 *
+	 * @inheritDoc
+	 */
+	public function onGetCanonicalURL($title, &$url, $query) {
+		$target = $this->exportTarget($title, (string)$query);
+		if ($target !== null && $target['whole'] !== null) {
+			$url = $target['whole'] . $title->getFragmentForURL();
+		}
+	}
+
+	/**
+	 * A target outside the export: one whole URL, and the same URL whichever hook asked.
+	 *
+	 * @return array{local:string,whole:string}
+	 */
+	private static function leavingTheExport(string $url): array {
+		return ['local' => $url, 'whole' => $url];
+	}
+
+	/**
+	 * A file this build wrote, named relative to the output root.
+	 *
+	 * A page links to it from beside itself, which is what makes an export work from any
+	 * directory. Its whole URL needs the address the site is published at, and where the site
+	 * has not said there is none to give: a wrong absolute URL is worse than an obviously
+	 * relative one, so a caller that asked for one is left with what it had.
+	 *
+	 * @return array{local:string,whole:?string}
+	 */
+	private function inTheExport(string $href): array {
+		return [
+			'local' => './' . $href,
+			'whole' => $this->siteUrl->isKnown() ? $this->siteUrl->forFile($href) : null
+		];
+	}
+
+	/**
+	 * Where a title points in this export, or null where the build leaves the URL alone.
+	 *
+	 * One decision for all three URL hooks, so a Commons file, a Special:Translate link and an
+	 * edit link are answered the same whether the caller wanted a relative URL or a whole one.
+	 * Both answers are worked out here rather than one derived from the other: 'local' is what a
+	 * page links to, and 'whole' the address the export is served at, null where the site has not
+	 * said where that is.
+	 *
+	 * @param Title $title
+	 * @param string $query
+	 * @return array{local:string,whole:?string}|null
+	 */
+	private function exportTarget($title, string $query): ?array {
 		if (MW_ENTRY_POINT !== 'cli') {
-			return;
+			return null;
 		}
 		if ($title->getInterwiki()) {
-			return;
+			return null;
 		}
 
 		// Foreign-repo files (Commons via InstantCommons) have no local File: page; link to Commons.
+		// A repo that names no description page answers false, and there is nothing to link to
+		// then: say nothing rather than write an empty href, which is what came out before.
 		if ($title->getNamespace() === NS_FILE) {
 			$file = MediaWikiServices::getInstance()->getRepoGroup()->findFile($title);
 			if ($file && !$file->isLocal()) {
-				$url = $file->getDescriptionUrl();
-				return;
+				$description = $file->getDescriptionUrl();
+				return is_string($description) && $description !== ''
+					? self::leavingTheExport($description)
+					: null;
 			}
 		}
 
@@ -65,12 +161,11 @@ class Main implements
 			if (isset($params['language']) && str_starts_with($params['group'] ?? '', 'page-')) {
 				$translation = Title::newFromText(substr($params['group'], 5) . '/' . $params['language']);
 				if ($translation) {
-					$url = str_replace(
+					return self::leavingTheExport(str_replace(
 						'$1',
 						SourceFile::titleToParam($translation->getPrefixedText()),
 						$wgWikvenEditUrl
-					);
-					return;
+					));
 				}
 			}
 		}
@@ -81,8 +176,10 @@ class Main implements
 		// it there instead of at a 404. SifterSearch retargets the link itself once its script
 		// runs; writing the link out right is what makes the exported page correct on its own.
 		if ($title->isSpecial('Search')) {
-			$url = $this->searchUrl($query);
-			return;
+			$search = $this->searchHref($query);
+			// Nowhere to land: the toggle stays the button its own script treats it as, and there
+			// is no page for a caller wanting a whole URL to be told about.
+			return $search === null ? ['local' => '#', 'whole' => null] : $this->inTheExport($search);
 		}
 
 		// The file this title is written to, url-encoded so a static server asking for it finds it;
@@ -98,12 +195,20 @@ class Main implements
 		$wantsHistory = $action === 'history' || array_key_exists('diff', $params);
 		// For edit/history, $1 is the source filename so the link targets the editable file.
 		if ($action === 'edit' && $wgWikvenEditUrl) {
-			$url = str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $wgWikvenEditUrl);
-		} elseif ($wantsHistory && $wgWikvenHistoryUrl) {
-			$url = str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $wgWikvenHistoryUrl);
-		} else {
-			$url = "./$href";
+			return self::leavingTheExport(str_replace(
+				'$1',
+				SourceFile::titleToParam($title->getPrefixedText()),
+				$wgWikvenEditUrl
+			));
 		}
+		if ($wantsHistory && $wgWikvenHistoryUrl) {
+			return self::leavingTheExport(str_replace(
+				'$1',
+				SourceFile::titleToParam($title->getPrefixedText()),
+				$wgWikvenHistoryUrl
+			));
+		}
+		return $this->inTheExport($href);
 	}
 
 	/**
@@ -147,12 +252,12 @@ class Main implements
 	 * is the whole of what it is for, and a reader without scripts has no search here either way --
 	 * Pagefind answers in the browser. That beats a link to a page that answers 404.
 	 */
-	private function searchUrl(string $query): string {
+	private function searchHref(string $query): ?string {
 		$results = Search::resultsPage();
 		if (!$results) {
-			return '#';
+			return null;
 		}
-		$url = './' . OutputName::href(OutputName::of(...$this->nameFor($results)));
+		$url = OutputName::href(OutputName::of(...$this->nameFor($results)));
 		$term = wfCgiToArray($query)['search'] ?? '';
 		return $term === '' ? $url : $url . '?' . wfArrayToCgi(['search' => $term]);
 	}

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -40,6 +40,52 @@ class MainTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
+	 * A caller that asked for a whole URL gets one. getFullURL() runs its own hook after
+	 * expanding what getLocalURL() returned, so the answer is recomputed from the same title
+	 * rather than recovered from "./Getting_Started.html", which expand() reads as a bare path
+	 * and hands back without a host.
+	 */
+	public function testAWholeUrlIsWhole() {
+		$this->overrideConfigValue('WikvenSiteUrl', 'https://example.org/docs');
+		$title = Title::newFromText('Getting Started');
+		$url = 'http:Getting_Started.html';
+		$this->main()->onGetFullURL($title, $url, '');
+		$this->assertSame('https://example.org/docs/Getting_Started.html', $url);
+	}
+
+	/** getCanonicalURL() carries the fragment getFullURL() drops, so the canonical hook adds it. */
+	public function testACanonicalUrlCarriesTheFragment() {
+		$this->overrideConfigValue('WikvenSiteUrl', 'https://example.org/docs');
+		$title = Title::newFromText('Getting Started#Oven');
+		$url = 'http:Getting_Started.html';
+		$this->main()->onGetCanonicalURL($title, $url, '');
+		$this->assertSame('https://example.org/docs/Getting_Started.html#Oven', $url);
+	}
+
+	/**
+	 * Where the site has not said where it is published there is no address to write, so the
+	 * value is left as it was: a wrong absolute URL is worse than an obviously relative one.
+	 */
+	public function testAWholeUrlIsLeftAloneWithoutASiteUrl() {
+		$title = Title::newFromText('Getting Started');
+		$url = 'http:Getting_Started.html';
+		$this->main()->onGetFullURL($title, $url, '');
+		$this->assertSame('http:Getting_Started.html', $url);
+	}
+
+	/**
+	 * A target that is already a whole URL is one whichever hook asked: an edit link goes to the
+	 * repository whether the caller wanted a relative URL or an absolute one.
+	 */
+	public function testAWholeUrlToAnExternalTargetNeedsNoSiteUrl() {
+		$this->overrideConfigValue('WikvenEditUrl', 'https://repo/edit/$1');
+		$title = Title::newFromText('Getting Started');
+		$url = '/x';
+		$this->main()->onGetFullURL($title, $url, 'action=edit');
+		$this->assertSame('https://repo/edit/Getting%20Started.wikitext', $url);
+	}
+
+	/**
 	 * The edit and history actions are rewritten to the configured repository
 	 * URLs, with $1 replaced by the page's percent-encoded source file name, so a
 	 * reader can jump from the rendered page to its source.


### PR DESCRIPTION
Closes #628.

`Hooks\Main` answers `GetLocalURL` with `./Name.html`, a file beside the one asking. `Title::getFullURL()` and `getCanonicalURL()` are both built on `getLocalURL()`, so **every MediaWiki method for obtaining an absolute URL has been returning a relative string**, and no caller could tell.

```php
$title->getFullURL();                     // "./index.html"
UrlUtils::expand( './index.html' );       // "index.html" -- removeDotSegments() eats the "./"
'http:' . 'index.html';                   // "http:index.html"
```

Two callers already hit it:

| caller | what it published |
| --- | --- |
| core's `generateSitemap.php` | relative `<loc>` values, which the sitemap protocol forbids |
| WikiSEO's `og:url` (#627) | `http:index.html` on every page |

## The fix

`getFullURL()` and `getCanonicalURL()` each run **their own hook** after calling `getLocalURL()` and expanding the result, and each hands it the same `Title`:

```php
// includes/Title/Title.php
( new HookRunner( ... ) )->onGetFullURL( $this, $url, $query );
( new HookRunner( ... ) )->onGetCanonicalURL( $this, $url, $query );
```

So the answer is recomputed from that title through the same `OutputName`, not recovered from the string. Which of the three hooks ran is the only honest signal that a caller wanted an absolute URL, and core delivers it — no re-entrancy flag, no reverse-engineering `"http:index.html"` back into a `Title`.

One decision now serves all three hooks, in `exportTarget()`, and it works out both answers at once rather than deriving one from the other: what a page links to, and the address the export is served at. A Commons file, a `Special:Translate` link and an edit link are answered the same whether the caller wanted a relative URL or a whole one. Previously only `onGetLocalURL` knew about any of them.

Where the site has not said where it is published (`WikvenSiteUrl` empty) there is no address to give, so the value is left alone. A wrong absolute URL is worse than an obviously relative one.

**One bug found on the way.** A foreign repo that names no description page answers `false` from `getDescriptionUrl()`, and that went straight into the link as an empty `href`. There is nothing to link to in that case, so the build now says nothing about the title rather than writing a broken link.

## What this does not change

Page links stay relative — that is the whole point of the export, and `getLocalURL()` is what renders them. Verified on a real bake of `docs/`:

- body links are still `./Installation.html`, and `../assets/…` from a subpage;
- edit and history links still go to the repository;
- `dist/sitemap.xml` is unchanged.

The one visible change beyond correctness: a skin preview copy under `dist/<skin>/` now names **the page it duplicates** rather than itself, which is what a canonical URL is for.

`SiteUrl` is read once in the constructor: `onGetLocalURL` answers every link on every page, and parsing a URL per link would be paid thousands of times a render for a value that cannot change mid-build.

## Verification

Four cases added to `MainTest`: a whole URL is whole, the canonical hook carries the fragment `getFullURL()` drops, an unset `WikvenSiteUrl` leaves the value alone, and an external target needs no site URL.

End-to-end coverage arrives with #627: without WikiSEO installed no page carries an `og:url` for the smoke bake to assert on. That is why the two are separate — the fix is general and belongs in the release notes on its own, the extension install is documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn