### PR TITLE
fix: stop handing a reader the address of the machine that built the site

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -157,6 +157,59 @@ jobs:
           print('og:url is absolute on every page that carries one')
           PY
 
+          # Nothing a reader is handed may name the machine that built it. The build installs
+          # against http://localhost:4000 and every step is a maintenance script, so any address
+          # that reaches the output through $wgServer is the container's, not the site's. Two
+          # places had one, green across every other check: WikiSEO named it as the site's author
+          # and publisher in the JSON-LD of every page, and mw.config shipped it as wgServer in
+          # the module bundle, disagreeing with the wgServerName beside it.
+          #
+          # Scoped to the head, because "http://localhost:8080" is also a correct sentence:
+          # docs/Deploying.wikitext tells a reader to open the preview there, and wikitext
+          # autolinks it, so the body legitimately holds an anchor to a local address. The head is
+          # machine-read metadata about the site and can hold no such sentence. The generated
+          # bundles are searched whole; they hold no prose either.
+          python3 - <<'PY'
+          import glob, json, re, sys
+          from urllib.parse import urlparse
+          LOCAL = {'localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'}
+          def html_urls(text):
+              yield from re.findall(r'(?:href|src|content)="([^"]*)"', text)
+              for block in re.findall(r'<script type="application/ld\+json">(.*?)</script>', text, re.S):
+                  try:
+                      parsed = json.loads(block)
+                  except ValueError:
+                      continue
+                  stack = [parsed]
+                  while stack:
+                      node = stack.pop()
+                      if isinstance(node, dict):
+                          stack.extend(node.values())
+                      elif isinstance(node, list):
+                          stack.extend(node)
+                      elif isinstance(node, str):
+                          yield node
+          bad = []
+          for path in glob.glob('dist/**/*', recursive=True):
+              if not path.endswith(('.html', '.js', '.css', '.json', '.xml')):
+                  continue
+              with open(path, encoding='utf-8', errors='replace') as handle:
+                  text = handle.read()
+              if path.endswith('.html'):
+                  text = text.split('</head>', 1)[0]
+              if not any(host in text for host in LOCAL):
+                  continue
+              if path.endswith('.html'):
+                  found = [v for v in html_urls(text) if urlparse(v).hostname in LOCAL]
+              else:
+                  found = [m for m in re.findall(r'https?://[^\s"\'<>,)]+', text)
+                           if urlparse(m).hostname in LOCAL]
+              bad.extend((path, v) for v in found)
+          if bad:
+              sys.exit(f'the build host reached the output in {len(bad)} place(s): {bad[:3]}')
+          print('no exported URL names the build host')
+          PY
+
           # Two bakes of one source must agree on the sitemap too; the walk behind it is a directory
           # iterator, whose order is the filesystem's rather than anything reproducible (#411).
           diff dist/sitemap.xml dist-again/sitemap.xml

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -206,8 +206,15 @@ $wgSettings->apply();
 // hands core the half core understands, so an absolute URL core or any extension builds names the
 // right host. The path half is wikven's to add; see SiteUrl.
 //
-// Only where the site said. Left alone, $wgCanonicalServer keeps the install's localhost, which is
-// wrong but is what everything downstream already expects of a build that has not been told.
+// $wgServer gets it too. Core means it as the address requests arrive on, and for a live wiki the
+// two are the same; a build is the case where they are not, and the entrypoint installs against
+// http://localhost:4000 because the installer demands a value, not because anything is served
+// there. Nothing in a build fetches from it -- every step is a maintenance script -- so what it
+// reaches is what is written into pages, and a reader was being handed the build container's
+// address. WikiSEO named it as the site's publisher on every page.
+//
+// Only where the site said. Left alone, both keep the install's localhost, which is wrong but is
+// what everything downstream already expects of a build that has not been told.
 //
 // This is where the setting is read. SiteUrl is handed the written value rather than fetching it,
 // so the same class serves this file, a maintenance script holding configuration, and a test
@@ -215,6 +222,7 @@ $wgSettings->apply();
 $wikvenSiteUrl = MediaWiki\Extension\Wikven\SiteUrl::fromWritten((string)( $wgWikvenSiteUrl ?? '' ));
 if ($wikvenSiteUrl->isKnown()) {
 	$wgCanonicalServer = $wikvenSiteUrl->canonicalServer();
+	$wgServer = $wgCanonicalServer;
 }
 
 // And take back the three the build works out for itself, which apply() has just handed to


### PR DESCRIPTION
Closes #631.

`bin/entrypoint` installs with `--server=http://localhost:4000`. `WikvenSettings.php` hands `WikvenSiteUrl` to `$wgCanonicalServer` and leaves `$wgServer` holding that, so anything reading `$wgServer` writes the build container into the published site.

**Two places did, on every page.** A bake of `docs/` names the build host in **441** URLs:

```json
// every page's JSON-LD, live on the documentation site right now
"author":    { "name": "Wikven", "url": "http://localhost:4000", ... },
"publisher": { "name": "Wikven", "url": "http://localhost:4000", ... }
```

```js
// assets/modules-static.js -- mw.config, shipped to every reader
"wgServer":"http://localhost","wgServerName":"chaotic-ground.github.io"
```

The second one I did not know about when filing #631, and it is the more interesting of the two: `wgServerName` was already correct, so the config a reader received **contradicted itself**, and any client script asking `mw.config.get('wgServer')` got the container.

## The change

```php
if ($wikvenSiteUrl->isKnown()) {
    $wgCanonicalServer = $wikvenSiteUrl->canonicalServer();
    $wgServer = $wgCanonicalServer;
}
```

Core means `$wgServer` as the address requests arrive on, and for a live wiki the two are the same. A build is the case where they are not — and there, nothing arrives at all: every step is a maintenance script, and `--server` is passed because the installer demands a value, not because anything listens. So what `$wgServer` reaches is only what gets written into pages.

Only where the site said. Left alone, both keep the install's localhost, which is wrong but is what everything downstream already expects of a build that has not been told.

**What this still cannot fix.** `$wgServer` is scheme and host; WikiSEO builds the publisher URL from it alone and drops the path. So a site served from a subdirectory is named by its origin (`https://chaotic-ground.github.io`) rather than by itself (`.../wikven/`). That is as far as core's own two halves reach, and it is at least a host a reader can resolve. Dropping the path is WikiSEO's doing, not ours.

## Verification

Two bakes of one source with the released binary, one on `main` and one with this change, diffed byte for byte. **225 files differ and every difference is this defect:**

| where | before | after |
| --- | --- | --- |
| JSON-LD `author.url`, `publisher.url` | `http://localhost` | `https://chaotic-ground.github.io` |
| `mw.config` `wgServer` in the module bundle | `http://localhost` | `https://chaotic-ground.github.io` |

Nothing else moved. The remaining diff noise in `startup-static.js` is ResourceLoader module version hashes, which change because the module content did.

## The assertion

The smoke bake now fails on a local address in the head of any page, or anywhere in a generated bundle. Run verbatim:

- against the `main` bake — **fails, 441 places**;
- against this bake — **passes**.

It is scoped that way because a local address is also a correct sentence. `docs/Deploying.wikitext` tells a reader to open the preview at `http://localhost:8080` and wikitext autolinks it, so the body of a page holds one on purpose; a grep over the whole file, or over every `href`, flags the documentation for documenting. The head is machine-read metadata about the site and can hold no such sentence, and the generated bundles hold no prose either.

Every other check was green while all 441 of these shipped — the same gap as #621 and #627.

Baking `docs/` locally is blocked on an unrelated flake: the Commons image the page about file naming embeds answers 429 under repeated fetches, which fails the bake regardless of this change (it does so on an untouched release binary too). Both bakes above were run with that one image `<nowiki>`-escaped in a scratch copy of the source, so the two are comparable; the repository is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_