### PR TITLE
refactor: keep the name a stored picture gets in one place

### DIFF
--- a/includes/AssetFile.php
+++ b/includes/AssetFile.php
@@ -31,6 +31,29 @@ class AssetFile {
 	}
 
 	/**
+	 * What a picture the build made local is called, from the reference pages had for it.
+	 *
+	 * Content-addressed so one picture referenced twice is stored once, and so a rebuild of an
+	 * unchanged site writes the same name (#411). Kept here rather than in the step that stores
+	 * them because two things now have to agree on it: storeImages names the file, and a site's
+	 * social image has to be named in a head tag before that step has run. A rule kept twice is a
+	 * rule that drifts, and the drift here is a head tag pointing at a file nobody wrote.
+	 *
+	 * @param string $key What identifies the picture: the storage path for a local file, the whole
+	 *   URL for a remote one. Two references to one picture must give the same key.
+	 * @param string|null $from Where to read the extension from, when that is not the key itself.
+	 */
+	public static function imageName(string $key, ?string $from = null): string {
+		return 'img-' . substr(md5($key), 0, 12) . '.' . self::extension($from ?? $key);
+	}
+
+	/** A safe lowercase file extension, defaulting to "img". */
+	public static function extension(string $url): string {
+		$ext = strtolower((string)pathinfo((string)parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION));
+		return preg_match('/^[a-z0-9]+$/', $ext) ? $ext : 'img';
+	}
+
+	/**
 	 * The directory the assets live in, as a path under the output root, or "" for the root itself.
 	 *
 	 * Both spellings of the output directory itself -- "" and "." -- name the root, and neither is a

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -110,7 +110,7 @@ class StoreImages extends Maintenance {
 		string $assetDirectory
 	): ?string {
 		$url = str_starts_with($ref, '//') ? "https:$ref" : $ref;
-		$name = 'img-' . substr(md5($ref), 0, 12) . '.' . $this->extension($url);
+		$name = AssetFile::imageName($ref, $url);
 		// The file and the link to it are worked out together; a page linking one directory while
 		// the file was written to another has no picture and nothing anywhere to say so.
 		$located = AssetFile::locate($htmlDir, $assetDirectory, $name);
@@ -169,7 +169,7 @@ class StoreImages extends Maintenance {
 			$this->output("  missing: $path\n");
 			return null;
 		}
-		$name = 'img-' . substr(md5($path), 0, 12) . '.' . $this->extension($path);
+		$name = AssetFile::imageName($path);
 		$located = AssetFile::locate($htmlDir, $assetDirectory, $name);
 		if (!file_exists($located['path'])) {
 			$this->copyWithoutTimestamps($src, $located['path']);
@@ -186,14 +186,6 @@ class StoreImages extends Maintenance {
 			return;
 		}
 		file_put_contents($dest, $stripped, LOCK_EX);
-	}
-
-	/**
-	 * @return string A safe lowercase file extension, defaulting to "img".
-	 */
-	private function extension(string $url): string {
-		$ext = strtolower((string)pathinfo((string)parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION));
-		return preg_match('/^[a-z0-9]+$/', $ext) ? $ext : 'img';
 	}
 }
 

--- a/tests/phpunit/unit/AssetFileTest.php
+++ b/tests/phpunit/unit/AssetFileTest.php
@@ -87,4 +87,62 @@ class AssetFileTest extends MediaWikiUnitTestCase {
 		$this->assertSame(1, AssetFile::depth('assets'));
 		$this->assertSame(2, AssetFile::depth('static/css'));
 	}
+
+	/**
+	 * Two references to one picture must name one file, and a rebuild of an unchanged site must
+	 * name the same one -- the whole point of hashing the reference rather than counting (#411).
+	 */
+	public function testOnePictureIsOneNameHoweverOftenItIsAsked() {
+		$this->assertSame(
+			AssetFile::imageName('/logo.png'),
+			AssetFile::imageName('/logo.png')
+		);
+		$this->assertNotSame(
+			AssetFile::imageName('/logo.png'),
+			AssetFile::imageName('/card.png')
+		);
+	}
+
+	/**
+	 * The name a head tag has to be able to predict before storeImages has run: this is the rule
+	 * both sides read, and the picture the documentation site publishes is the case that proves it.
+	 */
+	public function testTheNameIsTheOneStoreImagesWrites() {
+		$this->assertSame('img-5d163c4d9d29.png', AssetFile::imageName('/logo.png'));
+	}
+
+	/** A remote picture is keyed by its whole URL, and takes its extension from the same string. */
+	public function testARemotePictureKeepsItsExtension() {
+		$url = 'https://upload.wikimedia.org/wikipedia/commons/e/ee/Diagram.png?width=250';
+		$this->assertStringEndsWith('.png', AssetFile::imageName($url, $url));
+	}
+
+	/** Where the key is not what carries the extension, the second argument is. */
+	public function testTheExtensionCanComeFromSomewhereElseThanTheKey() {
+		$this->assertStringEndsWith(
+			'.jpg',
+			AssetFile::imageName('//example.org/photo?size=large', 'https://example.org/photo.jpg')
+		);
+	}
+
+	/**
+	 * A reference with nothing extension-shaped on the end still names a file. "img" rather than
+	 * nothing, because a name ending in a bare dot is not one a static host serves.
+	 *
+	 * @dataProvider provideOddExtensions
+	 */
+	public function testAnExtensionIsAlwaysASafeOne(string $url, string $expected) {
+		$this->assertSame($expected, AssetFile::extension($url));
+	}
+
+	public static function provideOddExtensions() {
+		return [
+			'a plain name' => ['/logo.png', 'png'],
+			'shouted' => ['/LOGO.PNG', 'png'],
+			'a query after it' => ['https://example.org/a/b.svg?version=9', 'svg'],
+			'no extension at all' => ['/logo', 'img'],
+			'not alphanumeric' => ['/logo.tar.gz~', 'img'],
+			'nothing to read' => ['', 'img']
+		];
+	}
 }


### PR DESCRIPTION
First of three, splitting what was one change for #632. Nothing changes in the output.

`storeImages` names a picture it makes local by hashing the reference pages had for it:

```php
$name = 'img-' . substr( md5( $path ), 0, 12 ) . '.' . $this->extension( $path );
```

Nothing else needed to know that, so the rule lived where it was used. #644 needs it somewhere else: a head tag naming the site's own picture has to give that picture's address **before `storeImages` has run**, so it has to reach the same name by the same rule.

A rule kept twice is a rule that drifts, and the drift here is a head tag pointing at a file nobody wrote — the same shape `LicensesPage`'s own docblock warns about, for the same reason.

So it moves to `AssetFile`, beside the other question about where something the build generated ends up, as `AssetFile::imageName()`. Both call sites pass what they passed before; `extension()` comes along because it is half the name.

## Verification

The test pins the rule to a name that already exists in the wild: `docs/logo.png` is published at

```
https://chaotic-ground.github.io/wikven/assets/img-5d163c4d9d29.png
```

and `AssetFile::imageName( '/logo.png' )` has to keep saying `img-5d163c4d9d29.png`. If the two sides ever part, that assertion is what says so.

The extension cases are covered where they decide whether a static host serves the file at all — a shouted `.PNG`, a `?version=` query after it, and the three ways there is nothing to read, which fall back to `img` rather than leaving a name ending in a bare dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_