### PR TITLE
fix: give a picture named in a page's metadata an address that resolves

### DIFF
--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -14,8 +14,8 @@ class RelativeUrl {
 	 * non-main-skin canonical does). A subpage title such as "Manual/Config" caches to a flat file but
 	 * is exported into a real "Manual/" directory; its references then need a "../" per level so links
 	 * and files agree on a static host. Absolute, protocol-relative and data: URLs carry no leading
-	 * "./" and are left alone. Covers href/src/srcset attributes, CSS url(), and the page's own
-	 * JavaScript config (see reparentConfigVars()).
+	 * "./" and are left alone. Covers href/src/srcset attributes, CSS url(), the page's own
+	 * JavaScript config (see reparentConfigVars()) and its schema.org block (reparentJsonLd()).
 	 *
 	 * Each candidate is required to sit inside a real "<tag ...>" span (or, for url(), inside a
 	 * <style> block too): MediaWiki escapes preformatted text with htmlspecialchars(..., ENT_NOQUOTES),
@@ -92,6 +92,7 @@ class RelativeUrl {
 		);
 
 		$html = self::reparentConfigVars($html, $rebase);
+		$html = self::reparentJsonLd($html, $rebase);
 
 		return self::rebasePrintFooter($html, $up);
 	}
@@ -141,6 +142,40 @@ class RelativeUrl {
 			$offset = $open + strlen($rebased);
 		}
 		return $html;
+	}
+
+	/**
+	 * Rebase the root-relative URLs a page carries in its schema.org block.
+	 *
+	 * The claim reparentConfigVars() answers, one escaping further along. Where a site has said
+	 * where it is published, a picture named in machine-read metadata gets a whole URL and no depth
+	 * can apply to it. Where it has not, storeImages can only name the file from the output root,
+	 * and a "./assets/..." written into a JSON document is spelled ".\/assets\/...": json_encode()
+	 * escapes a slash unless told not to. The passes above look for an attribute value or a bare
+	 * "./", so none of them sees that, and a subpage's schema.org image resolves inside the
+	 * subpage's own directory.
+	 *
+	 * Scoped to the block for the reason reparentConfigVars() is scoped to RLCONF: a bare string
+	 * carries no marker telling a URL of ours from a path a page merely shows. A ld+json script is
+	 * a span an extension wrote, and everything in it is data about the page rather than prose.
+	 *
+	 * @param string $html A rendered page.
+	 * @param callable(string):string $rebase Takes the matched "." or "..", returns its replacement.
+	 */
+	private static function reparentJsonLd(string $html, callable $rebase): string {
+		return preg_replace_callback(
+			'~<script type="application/ld\+json">.*?</script>~s',
+			static function (array $block) use ($rebase): string {
+				return preg_replace_callback(
+					'~"(\.\.?)\\\\/~',
+					static function (array $m) use ($rebase): string {
+						return '"' . str_replace('/', '\\/', $rebase($m[1]));
+					},
+					$block[0]
+				);
+			},
+			$html
+		);
 	}
 
 	/**

--- a/includes/UploadReference.php
+++ b/includes/UploadReference.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * What a rendered page says about a picture MediaWiki stored, and what the export should say instead.
+ *
+ * Every local picture reaches a page as a URL under $wgUploadPath, a directory the export does not
+ * publish: the build copies each file into the asset directory under a content-addressed name, and
+ * every reference to it has to be moved with it. That much is one rewrite. What makes it two is
+ * that a page says the same URL in more than one way, and the ways are not interchangeable.
+ *
+ * A page's body gets its pictures from File::getUrl(), a path from the site root. Machine-read
+ * metadata -- an og:image, a schema.org image -- gets File::getFullUrl(), which is that same URL
+ * expanded against $wgServer and so carries a scheme and a host. MediaWiki has already decided
+ * which question was asked, and the answer is in the text: a reference that arrived whole is one
+ * something will read away from the page, where a path beside the page means nothing. So a whole
+ * URL is answered with a whole URL, and a root-relative one with the file beside the page. There is
+ * no hook to ask instead -- File::getUrl() is memoised and FileRepo::getZoneUrl() is a configured
+ * string -- but there is no need for one, because nothing has thrown the distinction away yet.
+ *
+ * The second spelling is the escaping. json_encode() writes a slash as "\/" unless told otherwise,
+ * and an extension writing a JSON-LD block calls it plainly, so the same URL reads "\/images\/x.png"
+ * there. A pattern that knows only the first spelling walks straight past it and leaves a URL
+ * naming a directory the export does not serve -- which is how one page could carry a rewritten
+ * og:image and a dead schema.org image for the same file.
+ */
+final class UploadReference {
+	/** A slash as a page can spell it: bare in an attribute, backslash-escaped inside JSON. */
+	private const SLASH = '(?:\\\\)?/';
+
+	/** Matches an upload-path reference; group 1 the scheme and host, group 2 the storage path. */
+	private readonly string $pattern;
+
+	private readonly SiteUrl $siteUrl;
+
+	/**
+	 * @param string $uploadPath $wgUploadPath, the path a stored picture's URL hangs off.
+	 * @param SiteUrl $siteUrl Where the export is published, if the site has said.
+	 */
+	public function __construct(string $uploadPath, SiteUrl $siteUrl) {
+		// Neither the host nor the path may hold "<" or ">". {{filepath:}} writes its URL into an
+		// autolink's text as well as into the href, and nothing quotes the text, so a path that
+		// admits them eats the "</a>" after it and the build aborts over a file nobody can find.
+		$slash = self::SLASH;
+		$host = '((?:https?:)?' . $slash . $slash . '[^/\s"\\\\<>]+)?';
+		$upload = str_replace('/', $slash, preg_quote($uploadPath, '~'));
+		$path = '((?:' . $slash . '[^\s"?<>\\\\]+)+)';
+		$query = '(?:\?[^\s"<>]*)?';
+
+		$this->pattern = "~$host$upload$path$query~";
+		$this->siteUrl = $siteUrl;
+	}
+
+	/**
+	 * Point every upload-path reference in $html at the file the build published instead.
+	 *
+	 * @param string $html A rendered page.
+	 * @param callable(string):(string|null) $publish Given what a reference names after the upload
+	 *   path ("/Card.png", "/thumb/Card.png/100px-Card.png"), the reference the build publishes
+	 *   that file under ("./assets/img-*.ext"), or null if it could not be published. Asked once
+	 *   per reference rather than per file, so the caller that reads and copies is the one that
+	 *   remembers; a reference it cannot answer is left as the page wrote it, for it to report.
+	 */
+	public function rewrite(string $html, callable $publish): string {
+		return preg_replace_callback(
+			$this->pattern,
+			function (array $m) use ($publish): string {
+				// One name per file, whatever the reference looked like: the trailing ?query is left
+				// out, so a page's several sizes and cache stamps of one picture are one question,
+				// and the escaping is undone, so a file written both ways is one path and not two.
+				$href = $publish(str_replace('\\/', '/', $m[2]));
+				if ($href === null) {
+					return $m[0];
+				}
+				$whole = $m[1] !== '' && $this->siteUrl->isKnown();
+				$out = $whole ? $this->siteUrl->forFile(ltrim($href, './')) : $href;
+				return str_contains($m[0], '\\/') ? str_replace('/', '\\/', $out) : $out;
+			},
+			$html
+		);
+	}
+}

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -42,8 +42,13 @@ class StoreImages extends Maintenance {
 		// HTML reference => local "./img-*.ext" (or null on failure), deduping each reference.
 		$map = [];
 
-		// Match $wgUploadPath URLs; group 1 is the storage path, trailing ?query stripped from it.
-		$localPattern = '~(?:(?:https?:)?//[^/\s"]+)?' . preg_quote($wgUploadPath, '~') . '(/[^\s"?]+)(?:\?[^\s"]*)?~';
+		// Where the site is published, read through the config service: this step runs with
+		// MediaWiki fully up, so the settings file's excuse for reaching into globals is not one
+		// here. It decides nothing about which files are copied, only how a page names them.
+		$references = new UploadReference(
+			$wgUploadPath,
+			SiteUrl::fromWritten((string)$this->getConfig()->get('WikvenSiteUrl'))
+		);
 
 		foreach (glob("$htmlDir/*.html") as $file) {
 			$html = file_get_contents($file);
@@ -61,11 +66,9 @@ class StoreImages extends Maintenance {
 				$html
 			);
 
-			$html = preg_replace_callback(
-				$localPattern,
-				function ($m) use (&$map, $uploadDir, $htmlDir, $assetDirectory) {
-					// Key by storage path (no ?query) so sizes/timestamps of one file dedupe.
-					$path = $m[1];
+			$html = $references->rewrite(
+				$html,
+				function (string $path) use (&$map, $uploadDir, $htmlDir, $assetDirectory): ?string {
 					if (!array_key_exists($path, $map)) {
 						// The path came out of a page's rendered HTML, so it is whatever someone
 						// wrote there rather than something MediaWiki stored. Bound it to the
@@ -78,9 +81,8 @@ class StoreImages extends Maintenance {
 							? null
 							: $this->storeLocal($src, $path, $htmlDir, $assetDirectory);
 					}
-					return $map[$path] ?? $m[0];
-				},
-				$html
+					return $map[$path];
+				}
 			);
 
 			file_put_contents($file, $html, LOCK_EX);

--- a/tests/phpunit/unit/RelativeUrlTest.php
+++ b/tests/phpunit/unit/RelativeUrlTest.php
@@ -202,6 +202,46 @@ class RelativeUrlTest extends MediaWikiUnitTestCase {
 		);
 	}
 
+	/**
+	 * A schema.org block names a picture with the URL storeImages left there. Where the site has
+	 * said where it is published that is a whole URL and no depth applies to it; where it has not,
+	 * it is a path from the output root spelled the way json_encode() spells one, which the
+	 * attribute and bare "./" passes both walk straight past.
+	 */
+	public function testAJsonLdUrlFromTheOutputRootIsRebased() {
+		$this->assertSame(
+			'<script type="application/ld+json">{"url":"..\\/assets\\/img-abc.png"}</script>',
+			RelativeUrl::reparent(
+				'<script type="application/ld+json">{"url":".\\/assets\\/img-abc.png"}</script>',
+				1
+			)
+		);
+	}
+
+	public function testAJsonLdUrlGainsOneLevelPerDepth() {
+		$this->assertSame(
+			'<script type="application/ld+json">{"url":"..\\/..\\/assets\\/img-abc.png"}</script>',
+			RelativeUrl::reparent(
+				'<script type="application/ld+json">{"url":".\\/assets\\/img-abc.png"}</script>',
+				2
+			)
+		);
+	}
+
+	public function testAWholeJsonLdUrlIsLeftAlone() {
+		$html = '<script type="application/ld+json">{"url":"https:\\/\\/example.org\\/a.png"}</script>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
+	/**
+	 * The reason reparentConfigVars() is scoped to RLCONF, one escaping along: a bare string
+	 * carries no marker telling a URL of ours from a path a page merely shows.
+	 */
+	public function testAnEscapedPathOutsideAJsonLdBlockIsLeftAlone() {
+		$html = '<code>{"url":".\\/assets\\/img-abc.png"}</code>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
 	/** A page documenting the export's link shape writes the same string as prose. */
 	public function testAQuotedRootRelativePathInTheBodyIsLeftAlone() {
 		$html = '<pre>Title::getLocalURL() answers "./Page.html"</pre>';

--- a/tests/phpunit/unit/UploadReferenceTest.php
+++ b/tests/phpunit/unit/UploadReferenceTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\SiteUrl;
+use MediaWiki\Extension\Wikven\UploadReference;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\UploadReference
+ */
+class UploadReferenceTest extends MediaWikiUnitTestCase {
+	/** Publishes every path as one asset, so a test can read what was written rather than which. */
+	private static function published(): callable {
+		return static function (string $path): ?string {
+			return './assets/img-abc123def456.png';
+		};
+	}
+
+	private static function references(string $siteUrl = 'https://example.org/wikven/'): UploadReference {
+		return new UploadReference('/images', SiteUrl::fromWritten($siteUrl));
+	}
+
+	public function testAReferenceFromTheSiteRootIsAnsweredBesideThePage() {
+		$this->assertSame(
+			'<img src="./assets/img-abc123def456.png">',
+			self::references()->rewrite('<img src="/images/Card.png">', self::published())
+		);
+	}
+
+	/**
+	 * The defect this class exists for. MediaWiki hands a head tag File::getFullUrl(), which is the
+	 * body's URL expanded against $wgServer, so a scheme and host arriving here is MediaWiki saying
+	 * this will be read away from the page. Answered with a path beside the page it means nothing:
+	 * a crawler that never saw the page has nothing to resolve it against.
+	 */
+	public function testAWholeReferenceIsAnsweredWhole() {
+		$this->assertSame(
+			'<meta property="og:image" content="https://example.org/wikven/assets/img-abc123def456.png">',
+			self::references()
+				->rewrite(
+					'<meta property="og:image" content="https://example.org/images/Card.png">',
+					self::published()
+				)
+		);
+	}
+
+	public function testAProtocolRelativeReferenceIsWholeToo() {
+		$this->assertSame(
+			'https://example.org/wikven/assets/img-abc123def456.png',
+			self::references()->rewrite('//example.org/images/Card.png', self::published())
+		);
+	}
+
+	/**
+	 * A site that has not said where it is published has no whole URL to be given, and the host in
+	 * the reference is the machine that ran the build. Naming that is worse than naming nothing.
+	 */
+	public function testWithNoPublishedBaseAWholeReferenceFallsBackToThePathBesideThePage() {
+		$this->assertSame(
+			'./assets/img-abc123def456.png',
+			self::references('')->rewrite('http://localhost:4000/images/Card.png', self::published())
+		);
+	}
+
+	/**
+	 * json_encode() escapes a slash unless told not to, and an extension writing a schema.org block
+	 * calls it plainly. Matching only the bare spelling is how one page could carry a rewritten
+	 * og:image and, for the same file, a JSON-LD image still naming the upload path.
+	 */
+	public function testAJsonEscapedReferenceIsMatchedAndAnsweredEscaped() {
+		$this->assertSame(
+			'"url":"https:\/\/example.org\/wikven\/assets\/img-abc123def456.png"',
+			self::references()
+				->rewrite(
+					'"url":"https:\/\/example.org\/images\/Card.png"',
+					self::published()
+				)
+		);
+	}
+
+	public function testAJsonEscapedReferenceFromTheSiteRootStaysRelativeAndEscaped() {
+		$this->assertSame(
+			'"url":".\/assets\/img-abc123def456.png"',
+			self::references('')->rewrite('"url":"\/images\/Card.png"', self::published())
+		);
+	}
+
+	public function testBothSpellingsAskAboutTheSamePath() {
+		$asked = [];
+		self::references()
+			->rewrite(
+				'<img src="/images/Card.png"> "url":"https:\/\/example.org\/images\/Card.png"',
+				static function (string $path) use (&$asked): ?string {
+					$asked[] = $path;
+					return './assets/img-abc123def456.png';
+				}
+			);
+		$this->assertSame(['/Card.png', '/Card.png'], $asked);
+	}
+
+	/** A page carries one picture at several sizes and cache-busting stamps; all are one file. */
+	public function testTheQueryIsLeftOutOfThePathAndOutOfTheAnswer() {
+		$asked = null;
+		$out = self::references()
+			->rewrite(
+				'<meta content="https://example.org/images/Card.png?version=9f8e7d">',
+				static function (string $path) use (&$asked): ?string {
+					$asked = $path;
+					return './assets/img-abc123def456.png';
+				}
+			);
+		$this->assertSame('/Card.png', $asked);
+		$this->assertSame(
+			'<meta content="https://example.org/wikven/assets/img-abc123def456.png">',
+			$out
+		);
+	}
+
+	public function testAPathOfSeveralSegmentsIsOnePath() {
+		$asked = null;
+		self::references()
+			->rewrite(
+				'<img src="/images/thumb/Card.png/100px-Card.png">',
+				static function (string $path) use (&$asked): ?string {
+					$asked = $path;
+					return './assets/img-abc123def456.png';
+				}
+			);
+		$this->assertSame('/thumb/Card.png/100px-Card.png', $asked);
+	}
+
+	/**
+	 * {{filepath:}} writes its URL into the autolink's text as well as into the href, and nothing
+	 * quotes the text. A path that admits "<" runs on into the tag after it, and the build aborts
+	 * over "/Card.png</a>", a file that was never referenced.
+	 */
+	public function testAnAutolinkedUrlDoesNotSwallowTheTagAfterIt() {
+		$asked = null;
+		$out = self::references()
+			->rewrite(
+				'<a href="https://example.org/images/Card.png" class="external free">'
+				. 'https://example.org/images/Card.png</a>',
+				static function (string $path) use (&$asked): ?string {
+					$asked = $path;
+					return './assets/img-abc123def456.png';
+				}
+			);
+		$this->assertSame('/Card.png', $asked);
+		$this->assertStringEndsWith('</a>', $out);
+	}
+
+	public function testAReferenceThatCouldNotBePublishedIsLeftAsThePageWroteIt() {
+		$html = '<img src="/images/Missing.png">';
+		$this->assertSame(
+			$html,
+			self::references()
+				->rewrite($html, static function (string $path): ?string {
+					return null;
+				})
+		);
+	}
+
+	public function testAUrlOutsideTheUploadPathIsNotOurs() {
+		$html = '<img src="https://example.com/elsewhere/Card.png">';
+		$this->assertSame($html, self::references()->rewrite($html, self::published()));
+	}
+}


### PR DESCRIPTION
Closes #642.

A local picture reaches a page as a URL under `$wgUploadPath`, a directory the export does not publish, so `storeImages` copies the file into the asset directory and rewrites every reference to it. It rewrote them all the same way, and they are not the same thing.

MediaWiki gives a page's body `File::getUrl()`, a path from the site root, and gives machine-read metadata `File::getFullUrl()` — the same URL expanded against `$wgServer`. The text already says which question was asked. Answering a whole URL with a path beside the page hands a crawler that never saw the page something it cannot resolve.

So: answer in the shape the reference asked in. A reference carrying a scheme and host gets the address the export publishes the file at; a root-relative one gets the file beside the page, as before. Where the site has not said where it is published there is no whole address to give, so both fall back to relative and the build host still reaches nothing.

Two references were being missed outright:

- `json_encode()` escapes a slash unless told otherwise, so a schema.org block spells the same URL `\/images\/x.png`. Nothing matched that, and one page could carry a rewritten `og:image` beside a dead upload path for the same file.
- The path admitted `<` and `>`. `{{filepath:}}` writes its URL into the autolink's text as well as the href, where nothing quotes it, so the match ran on into `/Card.png</a>` and the build aborted over a file that was never referenced.

Matching the escaped spelling means the fallback can put a root-relative URL into a JSON document, which `reparent()` could not see either — a subpage's schema.org image kept `.\/` where the body had `../`. It now rebases those the way it already rebases the page's JavaScript config.

## Measured

A throwaway site — a root page, a subpage `Deep/Page`, one uploaded `Card.png`, WikiSEO, `WikvenSiteUrl: https://example.org/wikven/` — with the picture named four ways: a thumbnail, `[{{filepath:Card.png}} …]`, `WikiSeoDefaultImage: Card.png` written plainly under `config:`, and an unrelated external URL as a control.

In `dist/Deep/Page.html`, one level down, the head and the whole-URL links keep their address:

```html
<meta property="og:image" content="https://example.org/wikven/assets/img-63f33e1cb9fd.png">
<a href="https://example.org/wikven/assets/img-63f33e1cb9fd.png">whole url on a subpage</a>
<a href="https://example.com/elsewhere.png">an unrelated absolute url</a>
```
```json
"image":{"@type":"ImageObject","url":"https:\/\/example.org\/wikven\/assets\/img-63f33e1cb9fd.png","width":160,"height":160}
```

while in the same file the picture's own `src` and `srcset` picked up the `../` the subpage needs — `../assets/img-9d46035bd020.png` and `../assets/img-63f33e1cb9fd.png 2x`.

Both files exist in `dist/assets/`; no `/images/` path and no build host survives anywhere in the output. Before this change the same page failed the build outright, on `missing: /Card.png</a>`.

The same source without `WikvenSiteUrl` keeps everything relative, and the subpage's schema.org URL now reads `..\/assets\/img-63f33e1cb9fd.png` rather than `.\/`.

## Checking it

`UploadReferenceTest` covers each spelling and each fallback, `RelativeUrlTest` the schema.org rebasing. The `{{filepath:}}` case is the autolink that used to abort the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn