### PR TITLE
fix: wait for the page before filling in the skins section

### DIFF
--- a/resources/appearance.js
+++ b/resources/appearance.js
@@ -7,12 +7,24 @@
 // skins carry theirs in the chrome, so it is taken from there rather than worked out again here.
 //
 // The static bundle runs every module on every page, so this leaves where there is no list to fill.
-const container = document.querySelector("#wikven-appearance-skins");
+(() => {
+	// Both queries below need body content. The bundle is a plain <script src> in <head> -- on the
+	// generated settings page it is around 3300 bytes in, where the head ends past 6000 and the
+	// entries this reads are past 21000 -- so a module running as it is implemented can be looking
+	// at a document whose body has not been parsed. Running once with no wait meant that when it
+	// lost, container was null, the fill was skipped, and nothing ever tried again: a reader got a
+	// heading, a description and nothing under them, with no console error to say so.
+	const fill = () => {
+		const container = document.querySelector("#wikven-appearance-skins");
+		if (!container || container.children.length) {
+			return;
+		}
 
-if (container && !container.children.length) {
-	const entries = document.querySelectorAll('[id^="t-wikven-skin-"]');
+		const entries = document.querySelectorAll('[id^="t-wikven-skin-"]');
+		if (!entries.length) {
+			return;
+		}
 
-	if (entries.length) {
 		const list = document.createElement("ul");
 		list.className = "wikven-skin-list";
 
@@ -34,5 +46,14 @@ if (container && !container.children.length) {
 		}
 
 		container.append(list);
+	};
+
+	// The same wait the other modules in this bundle make, and for the same reason. It also keeps
+	// this ahead of citizen-skins.js, which reads the same entries and then removes the toolbox they
+	// live in: both defer the same way, so the bundle's order still decides, as it does today.
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", fill);
+	} else {
+		fill();
 	}
-}
+})();

--- a/resources/citizen-skins.js
+++ b/resources/citizen-skins.js
@@ -104,7 +104,13 @@
 			}
 		});
 
-		removeToolbox();
+		// The generated settings page reads these same entries for its own copy of the list
+		// (appearance.js), so they cannot go while anything still has a turn at them. Which module
+		// the bundle runs first is not ours to decide: appearance.js used to read the page as it was
+		// implemented, ahead of everything here, and now waits for the document as the rest of the
+		// bundle does. A task of its own puts this after every DOMContentLoaded listener, in
+		// whatever order the bundle registered them, and the wait is imperceptible.
+		setTimeout(removeToolbox, 0);
 	};
 
 	if (document.readyState === "loading") {


### PR DESCRIPTION
Closes #646.

The generated settings page ships its skins section empty, and every skin but Minerva fills it in the browser. `appearance.js` did that once, at module execution, with no wait and no retry — but the bundle is a plain `<script src>` in `<head>`, and on `Settings.html` the numbers are:

| | offset |
| --- | --- |
| the bundle | 3304 |
| end of `<head>` | 6401 |
| first `t-wikven-skin-*` entry | 21834 |
| `#wikven-appearance-skins` | 24375 |

Whatever ordering held was incidental. When it lost, `querySelector` answered `null`, the fill was skipped, and nothing tried again: a reader got a heading, a description and nothing under them, with no console error to say so.

## Reproduced

Served through a proxy that hands out the page in two pieces with a second's pause after `</head>` — the race, made deterministic. Chromium, counting `#wikven-appearance-skins .wikven-skin-item`:

| | before | after |
| --- | --- | --- |
| Vector, pause after `</head>` | **0** | 3 |
| Citizen, pause after `</head>` | **0** | 3 |
| Vector, body arrives at once | 3 | 3 |
| Citizen, body arrives at once | 3 | 3 |
| Minerva (list written by the build) | 3 | 3 |

No console errors in any run, before or after — which is the point: nothing was ever going to report this.

## Two halves

**The wait.** The other three scripts in this bundle — `pinnable-state.js`, `citizen-skins.js`, `vector-skins.js` — each check `document.readyState` before reading anything. This was the only one without it.

**The order.** Waiting alone breaks Citizen, and the browser says why. Before:

```
skin list filled @ readyState=loading
DOMContentLoaded
#p-tb removed
```

`citizen-skins.js` reads the same entries and then removes the toolbox holding them, and the bundle runs it first — so reading the page early was the only reason the settings page ever won those entries. Make `appearance.js` wait and the fill disappears entirely:

```
DOMContentLoaded
#p-tb removed
(no fill: the entries were already gone)
```

So `citizen-skins.js` now removes the toolbox in a task of its own, which puts it after every `DOMContentLoaded` listener whatever order the bundle registered them in. Both files say so. Afterwards, in both timing conditions:

```
DOMContentLoaded
skin list filled
#p-tb removed
```

The toolbox still goes on an ordinary Citizen page, and the wait is imperceptible.

## Checking it

All 64 e2e tests pass against a bake of `docs/` carrying both changes, including `tests/e2e/skin-switcher.spec.js:235` — the test that failed once on #644 and started this — and the Citizen and Vector suites that own the toolbox behaviour.

No test is added: the existing one already covers it, and the reason it only caught this once is timing rather than coverage. Making it wait longer would hide a defect readers can hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_