### PR TITLE
docs: say what each host does with a page's address

### DIFF
--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -91,6 +91,24 @@ Enable Pages for the repository under '''Settings → Pages → Build and deploy
 <!--T:7-->
 Because <code>dist/</code> is just files, you can serve it from any static host ([<tvar name="1">https://www.netlify.com/</tvar> Netlify], [<tvar name="2">https://pages.cloudflare.com/</tvar> Cloudflare Pages], an object store like [<tvar name="3">https://aws.amazon.com/s3/</tvar> S3], or a plain web server). Build the site in your CI or locally, then point the host at the <code>dist/</code> directory, or upload its contents to the server's document root.
 
+<!--T:27-->
+=== What each host does with the addresses ===
+
+<!--T:28-->
+A page is a file. {{SITENAME}} writes <code>Getting_Started.html</code> rather than <code>Getting_Started/index.html</code>, and every link a page carries is relative to where that file sits. So any host that serves files serves the site, with nothing to configure.
+
+<!--T:29-->
+Some hosts also answer the address without the extension, so that <code>/Getting_Started</code> reaches the same page as <code>/Getting_Started.html</code>. GitHub Pages, [<tvar name="1">https://docs.gitlab.com/user/project/pages/</tvar> GitLab Pages] and Cloudflare Pages do; [<tvar name="2">https://codeberg.page/</tvar> Codeberg Pages], an object store and a plain web server do not. The site works either way, because the links {{SITENAME}} writes carry the extension; it matters only for an address somebody types or shares by hand.
+
+<!--T:30-->
+'''Netlify''' is the one to turn something off on. Its [<tvar name="3">https://docs.netlify.com/manage/routing/redirects/redirect-options/</tvar> Pretty URLs], on by default, forward <code>/Getting_Started</code> to <code>/Getting_Started/</code> and rewrite <code>/Getting_Started.html</code> to the same address. {{SITENAME}} writes no <code>Getting_Started/</code> directory, so a page served there sits one directory deeper than its own links expect, and its stylesheets and pictures resolve to nothing. It is under Project configuration → Build & deploy → Post processing.
+
+<!--T:31-->
+'''Cloudflare Pages''' hides a broken link. Where a site has no <code>404.html</code>, it answers an address the site does not have by serving the front page with a 200, taking the site for a single-page application. A stale or mistyped link then looks like a working one.
+
+<!--T:32-->
+Whether you need an error page depends on the host, then: some show their own, and Cloudflare Pages shows yours or your front page. Name a page <code>404</code> in the source tree and the build writes <code>dist/404.html</code>, which GitHub Pages, GitLab Pages and Codeberg Pages serve for an address that is not there. Put <code><nowiki>__NOINDEX__</nowiki></code> on it — a sitemap is an invitation to index, and an error page is not a page to invite anyone to.
+
 <!--T:8-->
 <span id="preview-locally"></span>
 == Preview locally ==

--- a/docs/Deploying/ko.wikitext
+++ b/docs/Deploying/ko.wikitext
@@ -31,6 +31,24 @@
 <!--T:7 @4b653cc4-->
 <code>dist/</code>는 그저 파일 모음이므로, 어떤 정적 호스트([$1 Netlify], [$2 Cloudflare Pages], [$3 S3] 같은 객체 저장소, 또는 평범한 웹 서버)에서도 제공할 수 있습니다. CI나 로컬에서 사이트를 빌드한 뒤, 호스트가 <code>dist/</code> 디렉터리를 가리키게 하거나 그 내용을 서버의 문서 루트에 업로드하세요.
 
+<!--T:27 @cf7f4a52-->
+=== 호스트마다 주소를 어떻게 다루는가 ===
+
+<!--T:28 @f5ae4cac-->
+문서는 곧 파일입니다. {{SITENAME}}은 <code>Getting_Started/index.html</code>이 아니라 <code>Getting_Started.html</code>을 쓰고, 문서가 지니는 링크는 모두 그 파일이 놓인 자리를 기준으로 한 상대 주소입니다. 그래서 파일을 제공하는 호스트라면 어디서든 설정할 것 없이 사이트가 동작합니다.
+
+<!--T:29 @10e9c4db-->
+어떤 호스트는 확장자 없는 주소에도 답해서, <code>/Getting_Started</code>가 <code>/Getting_Started.html</code>과 같은 문서에 닿습니다. GitHub Pages, [$1 GitLab Pages], Cloudflare Pages는 그렇게 하고, [$2 Codeberg Pages]와 객체 저장소, 평범한 웹 서버는 그렇게 하지 않습니다. {{SITENAME}}이 쓰는 링크에는 확장자가 붙어 있으므로 어느 쪽이든 사이트는 동작합니다. 이 차이는 누군가 손으로 적거나 공유한 주소에서만 드러납니다.
+
+<!--T:30 @810e8299-->
+'''Netlify'''는 무언가를 꺼야 하는 유일한 곳입니다. 기본으로 켜져 있는 [$3 Pretty URLs]가 <code>/Getting_Started</code>를 <code>/Getting_Started/</code>로 넘기고, <code>/Getting_Started.html</code>도 같은 주소로 다시 씁니다. {{SITENAME}}은 <code>Getting_Started/</code> 디렉터리를 만들지 않으므로, 그 주소에서 제공되는 문서는 자기 링크가 기대하는 것보다 한 단계 깊은 곳에 놓이고 스타일시트와 그림이 아무 데도 닿지 않습니다. Project configuration → Build & deploy → Post processing에 있습니다.
+
+<!--T:31 @e79851d9-->
+'''Cloudflare Pages'''는 끊어진 링크를 감춥니다. 사이트에 <code>404.html</code>이 없으면, 사이트에 없는 주소에 대해 그 사이트를 단일 페이지 애플리케이션으로 보고 대문을 200으로 돌려줍니다. 그러면 낡았거나 잘못 적힌 링크가 멀쩡한 링크처럼 보입니다.
+
+<!--T:32 @5019cd96-->
+그러니 오류 문서가 필요한지는 호스트에 달렸습니다. 자기 오류 문서를 보여 주는 곳도 있고, Cloudflare Pages는 당신의 오류 문서 아니면 당신의 대문을 보여 줍니다. 소스 트리에 <code>404</code>라는 이름의 문서를 두면 빌드가 <code>dist/404.html</code>을 쓰고, GitHub Pages와 GitLab Pages, Codeberg Pages가 없는 주소에 대해 그 파일을 제공합니다. 그 문서에는 <code><nowiki>__NOINDEX__</nowiki></code>를 넣으십시오. 사이트맵은 색인해 달라는 초대이고, 오류 문서는 누구도 초대할 문서가 아닙니다.
+
 <!--T:8 @4a3c7f11-->
 <span id="preview-locally"></span>
 == 로컬에서 미리 보기 ==


### PR DESCRIPTION
Closes #651.

The Deploying page names Netlify, Cloudflare Pages, S3 and "a plain web server" in one breath, as though pointing any of them at `dist/` were the same act. It is not, and two of them want something from the reader before the site is right.

## Written by behaviour, not by brand

A brand list dates, and the brands this page would have listed miss the end of the field wikven's own readers are most likely at. So the new section is one rule and two exceptions:

**The rule.** A page is a file. wikven writes `Getting_Started.html`, not `Getting_Started/index.html`, and every link is relative to where that file sits — so any host that serves files serves the site untouched. That covers Codeberg Pages, an object store, and a self-hosted nginx or Caddy, none of which do anything clever with an address.

**The bonus.** Some hosts also answer `/Getting_Started`. GitHub Pages, GitLab Pages and Cloudflare Pages do. Nothing to configure either way, because wikven's own links carry the extension; it matters only for an address somebody types or shares by hand.

**Netlify** needs something turned off. [Pretty URLs](https://docs.netlify.com/manage/routing/redirects/redirect-options/), on by default, forward `/Getting_Started` to `/Getting_Started/` and rewrite `/Getting_Started.html` to the same address. wikven writes no `Getting_Started/` directory, so a page served there is one directory below where its own relative links expect to be, and its stylesheets and pictures resolve to nothing.

**Cloudflare Pages** hides a broken link: absent a `404.html` it answers an address the site does not have by [serving the front page with a 200](https://developers.cloudflare.com/pages/configuration/serving-pages/), taking the site for a single-page app.

**The error page**, where those two meet: whether a site needs one depends on the host, and a page named `404` in the source tree is how to have one. Verified on a bake — `src/404.wikitext` → `dist/404.html`.

Only the GitHub Pages behaviour is measured here; GitLab, Netlify, Cloudflare and Codeberg are from their own documentation, and the section says what it says on that basis.

This is also the answer to #651, which asked whether the build should mark an error page `noindex` or the documentation should say so. The documentation says so: a rule that read meaning into the title `404` would silently noindex a wiki's page *about* the status code, and wikven reads meaning into a title nowhere else.

## One thing a render caught

The first draft wrote `<code>__NOINDEX__</code>`. That is a behaviour switch, so writing it **takes effect** rather than showing:

| | before | after |
| --- | --- | --- |
| the word, in the sentence telling you to use it | *(deleted)* | `__NOINDEX__` |
| `Deploying.html` robots | `noindex,follow,…` | `max-image-preview:standard` |
| `Deploying/ko.html` robots | `noindex,follow,…` | `max-image-preview:standard` |
| `Deploying*` in `sitemap.xml` | **0 entries** | 3 |

The documentation had noindexed itself, in both languages, and dropped out of the sitemap. Every page still built and still read correctly, so nothing short of rendering the site would have shown it. It is written through `<nowiki>` now, which is how a magic word is shown anywhere.

## Checking it

Both languages rendered from a real bake of `docs/`: the three external links resolve, the tvars substituted, the word appears, the robots meta is back to normal and the page is back in the sitemap. `translate check --gate` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn