### PR TITLE
docs: give the documentation site a logo its structured data can use

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -37,6 +37,12 @@ config:
   WikvenViewSourceUrl: https://github.com/chaotic-ground/wikven/blob/main/docs/$1
   WikvenLogos:
     icon: logo.svg
+    # The same mark as a raster, and only the schema.org block reads it. WikiSEO names the site's
+    # logo by walking these values for the first jpg/jpeg/png/gif/webp, and takes an SVG as no logo
+    # at all; with the icon alone every page carried "logo": [], which asserts the site has no logo
+    # rather than saying nothing about one. No skin is affected: a skin with an icon renders that,
+    # and 1x is the fallback for one without.
+    1x: logo.png
   # Translated pages may be in a script the reader's system has no font for.
   WikvenBundleWebfonts: true
   # Search results have no thumbnails, so drop the empty thumbnail column from


### PR DESCRIPTION
Every page of the site published `"logo": []` in its schema.org block, for both `author` and `publisher`:

```json
"author":    {"@type":"Organization","name":"Wikven","url":"…","logo":[]},
"publisher": {"@type":"Organization","name":"Wikven","url":"…","logo":[]}
```

An empty array is not silence. It asserts the site has no logo, which is worse than the field being absent.

WikiSEO names the site's logo by walking `$wgLogos` for the first `jpg`/`jpeg`/`png`/`gif`/`webp`, and takes an SVG as no logo at all. `WikvenLogos` named `logo.svg` alone, so the lookup never found one and both callers turned that into `[]`.

The same mark already lives in the tree as a 160×160 PNG — `docs/logo.png`, which the README shows — so the site now names it beside the SVG:

```json
"logo":{"@type":"ImageObject","url":"https://chaotic-ground.github.io/wikven/assets/img-5d163c4d9d29.png","caption":"Wikven"}
```

## What it costs

Measured against a bake of the same source without the line:

- All 222 pages differ, and on each of them the only line that differs is the JSON-LD one. No skin renders the raster: a skin with an `icon` renders that, and `1x` is the fallback for one without.
- The published asset set is unchanged — `logo.png` is a source image and was already being published.
- Two script bundles differ, by a ResourceLoader version hash over byte-identical content: the skin style modules hash `$wgLogos` into their version.

## Not fixed here

WikiSEO's raster-only filter is still where the bug lives, and every wikven site with an SVG logo hits it. Left on #632 as an upstream report to make; this is what the site itself can do about it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_