### PR TITLE
fix: stop a build that died halfway from reporting success

### DIFF
--- a/includes/SkinPass.php
+++ b/includes/SkinPass.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * What a skin pass says when it has finished, and how the build reads that back.
+ *
+ * The build renders each skin in a process of its own and asks it the usual question -- what did
+ * you exit with. That answer cannot be trusted here. An uncaught PHP Error goes past
+ * MaintenanceRunner's catch, which takes Exception rather than Throwable, and reaches MediaWiki's
+ * handler; its guard against claiming success on the way out is a shutdown function calling
+ * exit(255), and the standalone binary drops an exit code set from a shutdown function. So a pass
+ * that died halfway through rendering returned 0, and a build reported success over an export
+ * holding 15 of its 222 pages -- every page in it perfectly good, which is why nothing downstream
+ * had anything to say.
+ *
+ * A line a pass can only write by reaching the end of its own work does not have that problem,
+ * whatever killed the pass and whatever it managed to return. Both sides of it are here, so the
+ * sentence a pass writes and the sentence the build looks for cannot drift apart.
+ */
+class SkinPass {
+	private const WROTE = 'Wikven: this pass wrote';
+
+	/** A pass's last line: it finished, and this is how much of the site it produced. */
+	public static function wrote(int $pages): string {
+		return self::WROTE . " $pages page(s)";
+	}
+
+	/** What a pass said it wrote, or null where it never reached the end to say. */
+	public static function pagesWritten(string $output): ?int {
+		$pattern = '/^' . preg_quote(self::WROTE, '/') . ' (\d+) page\(s\)$/m';
+		return preg_match($pattern, $output, $matched) === 1 ? (int)$matched[1] : null;
+	}
+}

--- a/includes/SkinPass.php
+++ b/includes/SkinPass.php
@@ -31,4 +31,42 @@ class SkinPass {
 		$pattern = '/^' . preg_quote(self::WROTE, '/') . ' (\d+) page\(s\)$/m';
 		return preg_match($pattern, $output, $matched) === 1 ? (int)$matched[1] : null;
 	}
+
+	/**
+	 * What is wrong with a set of finished passes, said in the words a build stops on.
+	 *
+	 * Three questions, and the second is the one this class exists for: did the pass return
+	 * success, did it say it finished, and do the passes agree on how much of the site there is.
+	 * The third is nearly free -- every pass renders the same wiki, which nothing has written to
+	 * since it was frozen, so passes that report different numbers have not all rendered it.
+	 *
+	 * @param array<string,array{exit:int,output:string}> $passes Skin name to what it returned and said.
+	 * @return string[] Empty where every pass finished and they agree.
+	 */
+	public static function failures(array $passes): array {
+		$failed = [];
+		$written = [];
+		foreach ($passes as $skin => $pass) {
+			$wrote = self::pagesWritten($pass['output']);
+			if ($pass['exit'] !== 0) {
+				$failed[] = "$skin (exit {$pass['exit']})";
+			} elseif ($wrote === null) {
+				// It returned success and did not finish; the class comment says how both.
+				$failed[] = "$skin (stopped before the end of its work)";
+			} else {
+				$written[$skin] = $wrote;
+			}
+		}
+		if ($failed) {
+			return ['Wikven: build failed for skin ' . implode(', ', $failed)];
+		}
+		if (count(array_unique($written)) < 2) {
+			return [];
+		}
+		$parts = [];
+		foreach ($written as $skin => $count) {
+			$parts[] = "$skin wrote $count";
+		}
+		return ['Wikven: the skin passes disagree on how much of the site there is: ' . implode(', ', $parts)];
+	}
 }

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -472,6 +472,7 @@ class Build extends Maintenance {
 		$queued = $skins;
 		$running = [];
 		$failed = [];
+		$written = [];
 		while ($queued || $running) {
 			while ($queued && count($running) < $limit) {
 				$skin = array_shift($queued);
@@ -489,8 +490,14 @@ class Build extends Maintenance {
 				// process's own stdout as they go would interleave into something no one could
 				// attribute a failure from, and the log is how a bake is debugged.
 				$this->reportPass($skin, $running[$skin], $exit);
+				$wrote = SkinPass::pagesWritten($running[$skin]['output'][1]);
 				if ($exit !== 0) {
 					$failed[] = "$skin (exit $exit)";
+				} elseif ($wrote === null) {
+					// It returned success and did not finish; SkinPass says how both.
+					$failed[] = "$skin (stopped before the end of its work)";
+				} else {
+					$written[$skin] = $wrote;
 				}
 				unset($running[$skin]);
 			}
@@ -499,6 +506,18 @@ class Build extends Maintenance {
 		$this->removeDatabaseCopies($databases);
 		if ($failed) {
 			$this->fatalError('Wikven: build failed for skin ' . implode(', ', $failed));
+		}
+		// Every pass renders the same wiki, which nothing has written to since it was frozen, so a
+		// pass that produced a different number of pages from its siblings did not render all of
+		// it -- and it said so only because it was asked.
+		if (count(array_unique($written)) > 1) {
+			$parts = [];
+			foreach ($written as $skin => $count) {
+				$parts[] = "$skin wrote $count";
+			}
+			$this->fatalError(
+				'Wikven: the skin passes disagree on how much of the site there is: ' . implode(', ', $parts)
+			);
 		}
 	}
 
@@ -740,7 +759,7 @@ class Build extends Maintenance {
 		// Minerva takes no navigation from the sidebar, so its menu is filled in the rendered pages.
 		$this->step(FillMinervaMenu::class, "$own/fillMinervaMenu.php");
 		$this->step(StoreImages::class, "$own/storeImages.php");
-		$this->step(Rename::class, "$own/rename.php");
+		$named = $this->nameCachedPages("$own/rename.php");
 		// Rename has expanded translation pages into "<Page>/<lang>.html"; resolve MyLanguage links now.
 		$this->step(ResolveTranslationLinks::class, "$own/resolveTranslationLinks.php");
 		// After the pages have their final names and links, so what the sitemap names is what the
@@ -763,6 +782,9 @@ class Build extends Maintenance {
 		if ($searchBundle !== null) {
 			$this->copySearchBundle($searchBundle);
 		}
+
+		// After everything, because that is the whole of what it says; see SkinPass.
+		$this->output(SkinPass::wrote($named) . "\n");
 	}
 
 	/**
@@ -905,8 +927,25 @@ class Build extends Maintenance {
 		rmdir($dir);
 	}
 
-	/** Run one build step as a child maintenance script, applying $options first. */
-	private function step(string $class, string $file, array $options = []): void {
+	/**
+	 * Name the cached pages, and say how many there were.
+	 *
+	 * The number is this pass's own account of what it produced, and the pass above has no other
+	 * way to come by it; see SkinPass.
+	 */
+	private function nameCachedPages(string $file): int {
+		$rename = $this->step(Rename::class, $file);
+		// createChild() is typed to Maintenance, and this is the one step whose answer is read.
+		return $rename instanceof Rename ? $rename->named : 0;
+	}
+
+	/**
+	 * Run one build step as a child maintenance script, applying $options first.
+	 *
+	 * The child is handed back for the one caller that wants a number out of it; every other one
+	 * runs the step for its effect and drops it.
+	 */
+	private function step(string $class, string $file, array $options = []): Maintenance {
 		$child = $this->createChild($class, $file);
 		foreach ($options as $name => $value) {
 			$child->setOption($name, $value);
@@ -915,6 +954,7 @@ class Build extends Maintenance {
 		if ($child->execute() === false) {
 			$this->fatalError("Wikven: $class reported failures; aborting the build.");
 		}
+		return $child;
 	}
 
 	/**

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -471,8 +471,7 @@ class Build extends Maintenance {
 
 		$queued = $skins;
 		$running = [];
-		$failed = [];
-		$written = [];
+		$finished = [];
 		while ($queued || $running) {
 			while ($queued && count($running) < $limit) {
 				$skin = array_shift($queued);
@@ -490,34 +489,16 @@ class Build extends Maintenance {
 				// process's own stdout as they go would interleave into something no one could
 				// attribute a failure from, and the log is how a bake is debugged.
 				$this->reportPass($skin, $running[$skin], $exit);
-				$wrote = SkinPass::pagesWritten($running[$skin]['output'][1]);
-				if ($exit !== 0) {
-					$failed[] = "$skin (exit $exit)";
-				} elseif ($wrote === null) {
-					// It returned success and did not finish; SkinPass says how both.
-					$failed[] = "$skin (stopped before the end of its work)";
-				} else {
-					$written[$skin] = $wrote;
-				}
+				$finished[$skin] = ['exit' => $exit, 'output' => $running[$skin]['output'][1]];
 				unset($running[$skin]);
 			}
 		}
 
 		$this->removeDatabaseCopies($databases);
-		if ($failed) {
-			$this->fatalError('Wikven: build failed for skin ' . implode(', ', $failed));
-		}
-		// Every pass renders the same wiki, which nothing has written to since it was frozen, so a
-		// pass that produced a different number of pages from its siblings did not render all of
-		// it -- and it said so only because it was asked.
-		if (count(array_unique($written)) > 1) {
-			$parts = [];
-			foreach ($written as $skin => $count) {
-				$parts[] = "$skin wrote $count";
-			}
-			$this->fatalError(
-				'Wikven: the skin passes disagree on how much of the site there is: ' . implode(', ', $parts)
-			);
+		// What the passes returned is not enough to tell a finished one from a dead one; SkinPass
+		// weighs that with what they said, and answers in the words to stop on.
+		foreach (SkinPass::failures($finished) as $failure) {
+			$this->fatalError($failure);
 		}
 	}
 

--- a/maintenance/rename.php
+++ b/maintenance/rename.php
@@ -20,6 +20,14 @@ require_once "$IP/maintenance/Maintenance.php";
  * the same destination, because it asked the same class from the other side.
  */
 class Rename extends Maintenance {
+	/**
+	 * How many pages this pass named, for the caller that has to say what the pass produced.
+	 *
+	 * The build reads it back out of the object it ran; see Build::renderSkin(), which is what
+	 * turns a number nobody was checking into the pass's proof that it finished.
+	 */
+	public int $named = 0;
+
 	public function __construct() {
 		parent::__construct();
 		$this->addDescription('Move each cached page to the file the site is served from');
@@ -45,6 +53,7 @@ class Rename extends Maintenance {
 			$this->place($path, $filename, $name);
 			$moved++;
 		}
+		$this->named = $moved;
 		$this->output("Wikven: named $moved cached page(s) as the site serves them\n");
 	}
 

--- a/tests/phpunit/unit/SkinPassTest.php
+++ b/tests/phpunit/unit/SkinPassTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\SkinPass;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\SkinPass
+ */
+class SkinPassTest extends MediaWikiUnitTestCase {
+	/** One rule asked in two directions, which is what keeps the two sides of it agreeing. */
+	public function testAPassIsReadBackByWhatItSaid() {
+		$this->assertSame(74, SkinPass::pagesWritten(SkinPass::wrote(74)));
+	}
+
+	/** The line is read out of everything the pass wrote, which is thousands of other lines. */
+	public function testItIsFoundAmongThePassesOtherOutput() {
+		$output =
+			"Building page file cache from page_id 0!\n"
+			. "Cached page 'index' (id 1)...[view: 38671 bytes; history: 0 bytes]\n"
+			. SkinPass::wrote(74)
+			. "\n";
+
+		$this->assertSame(74, SkinPass::pagesWritten($output));
+	}
+
+	/**
+	 * The failure this exists for. A pass that died halfway wrote everything up to the point it
+	 * died, and under the standalone binary it returned 0 as well; the missing line is the only
+	 * thing that separates it from a pass that finished.
+	 */
+	public function testAPassThatStoppedHalfwaySaysNothing() {
+		$output =
+			"Building page file cache from page_id 0!\n"
+			. "Cached page 'File:card.png' (id 7)...[view: 37314 bytes; history: 0 bytes]\n"
+			. "Error: Class \"…\\TranslationFamily\" not found\n";
+
+		$this->assertNull(SkinPass::pagesWritten($output));
+	}
+
+	/** A pass with nothing to say at all is the same answer. */
+	public function testNoOutputIsNoAnswer() {
+		$this->assertNull(SkinPass::pagesWritten(''));
+	}
+
+	/** A site of one page is still a site, and zero is a number the build gets to weigh itself. */
+	public function testAPassThatWroteNothingStillSaidSo() {
+		$this->assertSame(0, SkinPass::pagesWritten(SkinPass::wrote(0)));
+	}
+
+	/** The line is the whole of a line: a pass quoting it in prose is not a pass reporting. */
+	public function testTheLineIsNotMatchedInsideAnotherOne() {
+		$this->assertNull(SkinPass::pagesWritten('see where Wikven: this pass wrote 74 page(s) is'));
+	}
+}

--- a/tests/phpunit/unit/SkinPassTest.php
+++ b/tests/phpunit/unit/SkinPassTest.php
@@ -53,4 +53,94 @@ class SkinPassTest extends MediaWikiUnitTestCase {
 	public function testTheLineIsNotMatchedInsideAnotherOne() {
 		$this->assertNull(SkinPass::pagesWritten('see where Wikven: this pass wrote 74 page(s) is'));
 	}
+
+	/** A run where every pass finished and they saw the same site has nothing to say. */
+	public function testPassesThatAgreeAreNoFailure() {
+		$this->assertSame(
+			[],
+			SkinPass::failures([
+				'vector-2022' => ['exit' => 0, 'output' => SkinPass::wrote(74)],
+				'citizen' => ['exit' => 0, 'output' => SkinPass::wrote(74)],
+				'minerva' => ['exit' => 0, 'output' => SkinPass::wrote(74)]
+			])
+		);
+	}
+
+	/** One pass is a run too, and has nobody to disagree with. */
+	public function testOnePassThatFinishedIsEnough() {
+		$this->assertSame(
+			[],
+			SkinPass::failures([
+				'vector-2022' => ['exit' => 0, 'output' => SkinPass::wrote(7)]
+			])
+		);
+	}
+
+	/**
+	 * The failure this class exists for: the pass returned success and never reached the end, and
+	 * the exit code is the one thing that cannot tell you so.
+	 */
+	public function testAPassThatReturnedSuccessWithoutFinishingIsAFailure() {
+		$this->assertSame(
+			['Wikven: build failed for skin citizen (stopped before the end of its work)'],
+			SkinPass::failures([
+				'vector-2022' => ['exit' => 0, 'output' => SkinPass::wrote(74)],
+				'citizen' => ['exit' => 0, 'output' => "Cached page 'index' (id 1)...\n"]
+			])
+		);
+	}
+
+	/** An exit code that does say so is still read, and named for what it is. */
+	public function testAPassThatReturnedFailureIsNamedByItsCode() {
+		$this->assertSame(
+			['Wikven: build failed for skin minerva (exit 137)'],
+			SkinPass::failures([
+				'minerva' => ['exit' => 137, 'output' => ''],
+				'vector-2022' => ['exit' => 0, 'output' => SkinPass::wrote(74)]
+			])
+		);
+	}
+
+	/** Every pass that went wrong is named, because a reader fixing one wants to see the rest. */
+	public function testAllTheFailedPassesAreNamedAtOnce() {
+		$this->assertSame(
+			[
+				'Wikven: build failed for skin vector-2022 (stopped before the end of its work), '
+					. 'citizen (stopped before the end of its work)'
+			],
+			SkinPass::failures([
+				'vector-2022' => ['exit' => 0, 'output' => ''],
+				'citizen' => ['exit' => 0, 'output' => '']
+			])
+		);
+	}
+
+	/**
+	 * Every pass renders the same wiki, frozen before any of them started, so passes that report
+	 * different numbers have not all rendered it -- even though each one finished and said so.
+	 */
+	public function testPassesThatDisagreeOnHowMuchOfTheSiteThereIsAreAFailure() {
+		$this->assertSame(
+			[
+				'Wikven: the skin passes disagree on how much of the site there is: '
+					. 'vector-2022 wrote 74, citizen wrote 15'
+			],
+			SkinPass::failures([
+				'vector-2022' => ['exit' => 0, 'output' => SkinPass::wrote(74)],
+				'citizen' => ['exit' => 0, 'output' => SkinPass::wrote(15)]
+			])
+		);
+	}
+
+	/** A pass that did not finish is the better complaint, so it is the one made. */
+	public function testAPassThatStoppedIsReportedRatherThanTheDisagreementItCauses() {
+		$this->assertSame(
+			['Wikven: build failed for skin citizen (stopped before the end of its work)'],
+			SkinPass::failures([
+				'vector-2022' => ['exit' => 0, 'output' => SkinPass::wrote(74)],
+				'citizen' => ['exit' => 0, 'output' => 'nothing'],
+				'minerva' => ['exit' => 0, 'output' => SkinPass::wrote(15)]
+			])
+		);
+	}
 }


### PR DESCRIPTION
Refs #659. Takes the half of it that is wikven's; the other half is the binary's dropped exit code, and this holds whether or not that is ever fixed.

A skin pass that died mid-render returned 0, so the build finished on it — `wikven: done`, exit 0, and an export holding **15 of its 222 pages**. Every page in it was perfectly good, which is why nothing downstream had anything to say.

## The exit code cannot carry this

An uncaught PHP `Error` — a missing class, a `TypeError`, an argument count — goes past `MaintenanceRunner::run()`'s catch, which takes `Exception` rather than `Throwable`, and reaches MediaWiki's handler. Its guard against exactly this is a shutdown function:

```php
// includes/Exception/MWExceptionHandler.php:194
// Make sure we don't claim success on exit for CLI scripts (T177414)
if ( wfIsCLI() ) {
    register_shutdown_function( static function (): never { exit( 255 ); } );
}
```

The standalone binary drops an exit code set from a shutdown function:

```php
register_shutdown_function(static function () { exit(7); });
```

| | that script | uncaught `Error` + the guard above |
| --- | --- | --- |
| system `php` 8.4 | **7** | **255** |
| `wikven php-cli` | **0** | **0** |

`PHP_SAPI` is `cli` under the binary, so the guard is installed; only its exit code is lost. And the build re-invokes itself through that `php-cli` once per skin, because embedded FrankenPHP leaves `PHP_BINARY` empty (`skinPassCommand()`).

## What a pass says instead

Its last line, which it can only reach by finishing:

```
Wikven: this pass wrote 74 page(s)
```

A pass that returned success without that line did not finish — whatever killed it, and whatever it managed to return. Both sides of the line live in `SkinPass`, so the sentence a pass writes and the sentence the build looks for cannot drift apart; it is the same "one rule, asked in two directions" that `OutputName` is built on.

The number rides along because it is free: `rename.php` already counted the pages it named, and nothing had asked. Every pass renders the same wiki, frozen before the passes start, so passes that disagree on how many pages there are have not all rendered it.

## Measured

Against the failure that started this — the class the export needed removed, so every pass dies on the first content page.

| | before | after |
| --- | --- | --- |
| exit | 0 | **1** |
| pages in `dist/` | 15 of 222 | 15, and not published as a build |
| what it said | `wikven: done` | the line below |

```
Wikven: build failed for skin vector-2022 (stopped before the end of its work), minerva (stopped before the end of its work), citizen (stopped before the end of its work)
```

A normal bake of `docs/` still exits 0 with 222 pages, and the three passes agree on 74. The `examples/skin-preview` tree agrees at 7, with one skin and with three — that mode renders a different site with the chrome left alone, so it is the one worth checking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_