### PR TITLE
fix: report a run the standalone binary's build died in

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -82,6 +82,7 @@
 		"GetCanonicalURL": "main",
 		"OutputPageAfterGetHeadLinksArray": "main",
 		"SetupAfterCache": [
+			"reporter",
 			"retrier",
 			"main"
 		],
@@ -105,6 +106,9 @@
 		},
 		"indexer": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Indexer"
+		},
+		"reporter": {
+			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Reporter"
 		},
 		"retrier": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Retrier"

--- a/includes/Hooks/Reporter.php
+++ b/includes/Hooks/Reporter.php
@@ -47,7 +47,7 @@ class Reporter implements \MediaWiki\Hook\SetupAfterCacheHook {
 		// it installs.
 		set_exception_handler(self::handler(
 			MWExceptionHandler::handleUncaughtException(...),
-			static function (int $status): void {
+			static function (int $status): never {
 				exit($status);
 			}
 		));

--- a/includes/Hooks/Reporter.php
+++ b/includes/Hooks/Reporter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Hooks;
+
+use MediaWiki\Exception\MWExceptionHandler;
+use Throwable;
+
+class Reporter implements \MediaWiki\Hook\SetupAfterCacheHook {
+	/** What core ends a run with when a throwable reaches its handler (T177414). */
+	private const FAILED = 255;
+
+	/**
+	 * @inheritDoc
+	 *
+	 * Make a run that died of an Error say so in its exit status.
+	 *
+	 * A PHP Error -- a missing class, a TypeError, an argument count -- is a Throwable and not an
+	 * Exception, so it goes past MaintenanceRunner's catch and reaches MWExceptionHandler, whose
+	 * guard against a script claiming success is a register_shutdown_function() that exits 255.
+	 * The standalone binary discards a status set from a shutdown function, and only that: three
+	 * lines of PHP measure it, exit(7) at the top of a file giving 7 under the binary and the same
+	 * exit(7) from a shutdown function giving 0.
+	 *
+	 * So this closes the gap where it opens, with the same 255 said from the exception handler
+	 * itself. It costs nothing under a real PHP binary, where both routes already answer 255.
+	 *
+	 * It matters because the binary re-invokes itself for every step of a build through that path
+	 * -- embedded FrankenPHP leaves PHP_BINARY empty, so a step runs as `<self> php-cli` -- and a
+	 * step that died of an Error hands back 0. Measured on a bake with an Error thrown right after
+	 * runJobs: the binary printed the backtrace, wrote no page at all, and finished with
+	 * "wikven: done" and exit 0. SkinPass covers a skin pass that dies halfway through rendering;
+	 * every other step of a build is this.
+	 *
+	 * Installed here rather than in WikvenSettings.php because installHandler() runs in Setup.php
+	 * after LocalSettings.php and would replace anything put there. This hook is the first thing
+	 * wikven runs after it; an Error before this point is core's to report, and under a real PHP
+	 * binary core does.
+	 */
+	public function onSetupAfterCache(): void {
+		// A web request has a response to write and a status of its own, and a test has PHPUnit's
+		// handler, which core is careful not to replace either.
+		if (MW_ENTRY_POINT !== 'cli' || defined('MW_PHPUNIT_TEST')) {
+			return;
+		}
+		// Named rather than read back out of set_exception_handler(): this stands in front of the
+		// handler installHandler() installed a few lines earlier in Setup.php, and that is the one
+		// it installs.
+		set_exception_handler(self::handler(
+			MWExceptionHandler::handleUncaughtException(...),
+			static function (int $status): void {
+				exit($status);
+			}
+		));
+	}
+
+	/**
+	 * An exception handler that reports the throwable and then ends the process.
+	 *
+	 * @param callable $report Handed the throwable, to log and print as core would.
+	 * @param callable $stop Handed the status to end the run with.
+	 * @return callable Takes the Throwable, as an exception handler is given it.
+	 */
+	public static function handler(callable $report, callable $stop): callable {
+		return static function (Throwable $error) use ($report, $stop): void {
+			// Reported first: that is what logs the error and prints the backtrace, and whoever
+			// reads the run needs those more than they need the status.
+			$report($error);
+			$stop(self::FAILED);
+		};
+	}
+}

--- a/includes/Hooks/Reporter.php
+++ b/includes/Hooks/Reporter.php
@@ -37,15 +37,26 @@ class Reporter implements \MediaWiki\Hook\SetupAfterCacheHook {
 	 * binary core does.
 	 */
 	public function onSetupAfterCache(): void {
+		self::install(MW_ENTRY_POINT, defined('MW_PHPUNIT_TEST'), 'set_exception_handler');
+	}
+
+	/**
+	 * Put the handler in front of core's, where this is a run whose status is worth correcting.
+	 *
+	 * @param string $entryPoint MW_ENTRY_POINT, naming what kind of run this is.
+	 * @param bool $underTest Whether PHPUnit is running, which owns the handler while it is.
+	 * @param callable $set Given the handler to install, as set_exception_handler is.
+	 */
+	public static function install(string $entryPoint, bool $underTest, callable $set): void {
 		// A web request has a response to write and a status of its own, and a test has PHPUnit's
 		// handler, which core is careful not to replace either.
-		if (MW_ENTRY_POINT !== 'cli' || defined('MW_PHPUNIT_TEST')) {
+		if ($entryPoint !== 'cli' || $underTest) {
 			return;
 		}
 		// Named rather than read back out of set_exception_handler(): this stands in front of the
 		// handler installHandler() installed a few lines earlier in Setup.php, and that is the one
 		// it installs.
-		set_exception_handler(self::handler(
+		$set(self::handler(
 			MWExceptionHandler::handleUncaughtException(...),
 			static function (int $status): never {
 				exit($status);

--- a/includes/Hooks/Reporter.php
+++ b/includes/Hooks/Reporter.php
@@ -17,12 +17,15 @@ class Reporter implements \MediaWiki\Hook\SetupAfterCacheHook {
 	 * A PHP Error -- a missing class, a TypeError, an argument count -- is a Throwable and not an
 	 * Exception, so it goes past MaintenanceRunner's catch and reaches MWExceptionHandler, whose
 	 * guard against a script claiming success is a register_shutdown_function() that exits 255.
-	 * The standalone binary discards a status set from a shutdown function, and only that: three
-	 * lines of PHP measure it, exit(7) at the top of a file giving 7 under the binary and the same
-	 * exit(7) from a shutdown function giving 0.
+	 * That one route is the one the standalone binary loses, and only that: embedded FrankenPHP
+	 * reads the status out of the engine and runs the shutdown functions after, so a status set
+	 * from one is set too late to be read rather than refused. Three lines of PHP measure it,
+	 * exit(7) at the top of a file giving 7 under the binary and the same exit(7) from a shutdown
+	 * function giving 0.
 	 *
 	 * So this closes the gap where it opens, with the same 255 said from the exception handler
-	 * itself. It costs nothing under a real PHP binary, where both routes already answer 255.
+	 * itself, which is early enough. It costs nothing under a real PHP binary, where both routes
+	 * already answer 255.
 	 *
 	 * It matters because the binary re-invokes itself for every step of a build through that path
 	 * -- embedded FrankenPHP leaves PHP_BINARY empty, so a step runs as `<self> php-cli` -- and a
@@ -33,8 +36,9 @@ class Reporter implements \MediaWiki\Hook\SetupAfterCacheHook {
 	 *
 	 * Installed here rather than in WikvenSettings.php because installHandler() runs in Setup.php
 	 * after LocalSettings.php and would replace anything put there. This hook is the first thing
-	 * wikven runs after it; an Error before this point is core's to report, and under a real PHP
-	 * binary core does.
+	 * wikven runs after it, and the window it leaves is not one to worry about: with no handler
+	 * installed yet, an Error before this point ends the run through PHP's own fatal path, which
+	 * says 255 under either runtime.
 	 */
 	public function onSetupAfterCache(): void {
 		self::install(MW_ENTRY_POINT, defined('MW_PHPUNIT_TEST'), 'set_exception_handler');
@@ -42,6 +46,11 @@ class Reporter implements \MediaWiki\Hook\SetupAfterCacheHook {
 
 	/**
 	 * Put the handler in front of core's, where this is a run whose status is worth correcting.
+	 *
+	 * What is handed to $set is the one thing here no test reaches: a test can watch that a
+	 * handler was installed and can drive handler() directly, but calling the installed one means
+	 * calling core's reporter and then a real exit. A bake with an Error thrown into it is what
+	 * covers this line.
 	 *
 	 * @param string $entryPoint MW_ENTRY_POINT, naming what kind of run this is.
 	 * @param bool $underTest Whether PHPUnit is running, which owns the handler while it is.

--- a/tests/phpunit/unit/ReporterTest.php
+++ b/tests/phpunit/unit/ReporterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use Error;
+use MediaWiki\Extension\Wikven\Hooks\Reporter;
+use MediaWikiUnitTestCase;
+use Throwable;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Hooks\Reporter
+ */
+class ReporterTest extends MediaWikiUnitTestCase {
+	public function testTheRunEndsWithTheStatusCoreWouldHaveUsed() {
+		$reported = null;
+		$stopped = [];
+		$handler = Reporter::handler(
+			static function (Throwable $error) use (&$reported): void {
+				$reported = $error;
+			},
+			static function (int $status) use (&$stopped): void {
+				$stopped[] = $status;
+			}
+		);
+		$error = new Error('a class the export needed was missing');
+
+		$handler($error);
+
+		$this->assertSame([255], $stopped);
+		$this->assertSame($error, $reported);
+	}
+
+	public function testTheErrorIsReportedBeforeTheRunEnds() {
+		$order = [];
+		$handler = Reporter::handler(
+			static function (Throwable $unusedError) use (&$order): void {
+				$order[] = 'reported';
+			},
+			static function (int $unusedStatus) use (&$order): void {
+				$order[] = 'stopped';
+			}
+		);
+
+		$handler(new Error('boom'));
+
+		$this->assertSame(['reported', 'stopped'], $order);
+	}
+}

--- a/tests/phpunit/unit/ReporterTest.php
+++ b/tests/phpunit/unit/ReporterTest.php
@@ -45,4 +45,34 @@ class ReporterTest extends MediaWikiUnitTestCase {
 
 		$this->assertSame(['reported', 'stopped'], $order);
 	}
+
+	public function testACommandLineRunGetsTheHandler() {
+		$installed = [];
+
+		Reporter::install('cli', false, static function (callable $handler) use (&$installed): void {
+			$installed[] = $handler;
+		});
+
+		$this->assertCount(1, $installed);
+	}
+
+	public function testAWebRequestKeepsItsOwn() {
+		$installed = [];
+
+		Reporter::install('index', false, static function (callable $unused) use (&$installed): void {
+			$installed[] = $unused;
+		});
+
+		$this->assertSame([], $installed);
+	}
+
+	public function testPhpunitKeepsItsOwn() {
+		$installed = [];
+
+		Reporter::install('cli', true, static function (callable $unused) use (&$installed): void {
+			$installed[] = $unused;
+		});
+
+		$this->assertSame([], $installed);
+	}
 }


### PR DESCRIPTION
Closes #659. #660 took the skin-pass half of it; this is the rest.

A PHP `Error` — a missing class, a `TypeError`, an argument count — is a `Throwable` and not an `Exception`, so it goes past `MaintenanceRunner`'s catch and reaches `MWExceptionHandler`, whose guard against a script claiming success is a `register_shutdown_function()` that exits 255.

## What the binary actually drops

The issue reports "`wikven php-cli` → 0" for both of its cases. Filling the table in narrows it to one route:

| | system php 8.4 | `wikven php-cli` |
| --- | ---: | ---: |
| `exit(7)` at the top of a file | 7 | **7** |
| `exit(7)` from a shutdown function | 7 | **0** |
| `exit(7)` from an exception handler | 7 | **7** |
| an uncaught `Error`, no handler installed | 255 | **255** |

Only a status set from a shutdown function is discarded — and that is the single route core takes. PHP's own fatal path propagates fine; so does an ordinary `exit()`; so does one from an exception handler.

## What it costs

The build re-invokes itself for every step through that path — embedded FrankenPHP leaves `PHP_BINARY` empty, so a step runs as `<self> php-cli` — and a step that died of an `Error` hands back 0.

Thrown right after `runJobs` in `maintenance/build.php`, on a real bake of `docs/`:

```
[…] Error: INJECTED: a class the export needed was missing
Backtrace:
…
wikven: done -> …/exitrepro/dist
$ echo $?
0
```

`dist/` held **zero** pages. That site would have published.

With this change, the same injected error:

```
wikven: step failed (exit 255)
$ echo $?
255
```

## The fix

`Hooks\Reporter` says the same 255 from the exception handler itself, where the status is not discarded. It stands in front of `MWExceptionHandler::handleUncaughtException`, so the log line and the backtrace are unchanged — a reader needs those more than the status — and then stops the process.

Installed from `SetupAfterCache` because `installHandler()` runs in `Setup.php` *after* `LocalSettings.php` and would replace anything put there; this hook is the first thing wikven runs after it. An `Error` before that point is core's to report, and under a real PHP binary core does. Only for a `cli` entry point, and never under PHPUnit — both things core is careful about for the same reasons.

It is a no-op under the image, which runs a real PHP binary where both routes already answer 255.

## Checks

`Reporter::handler()` is the rule and has unit tests: the status is 255 and the throwable reaches the reporter, and the reporter runs before the stop.

A clean bake of `docs/` with the change is **byte-identical** to one without it — `diff -rq` over the two `dist/` trees returns nothing at all. `mago format --check`, `mago lint` and `phpcs -sp` pass.

## Still open upstream

This makes wikven's builds honest; it does not fix the embedding. Any maintenance script run under the binary that relies on a shutdown function to set its status still loses it. That is FrankenPHP's to answer, and worth reporting there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_