### PR TITLE
docs: one translation unit per build step, which also fixes three wrong links

### DIFF
--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -70,24 +70,44 @@ The division is what makes the passes safe to run beside each other: the orchest
 <!--T:29-->
 ; <code>checkLuaAgainstThisBuild</code>
 : Says what this site's [[<tvar name="1">Special:MyLanguage/Lua modules</tvar>|Lua]] and this build's Lua make of each other, before anything else happens. A site that lists Scribunto where no engine can run it ends the build, because it asked for something this build cannot do; a site with <code>Module:</code> files that never listed Scribunto is only told what those files come to, since with no engine to run them an <code>#invoke</code> is published as the text of the call. It runs first so the last bake is still in place when a site is refused.
+
+<!--T:38-->
 ; <code>clearOutputDirectory</code>
 : Empties the output directory, so a bake never inherits a file from the last one.
+
+<!--T:39-->
 ; <code>setMainPage</code>
 : Points <code>MediaWiki:Mainpage</code> at the imported <code>index</code> article, so the site root resolves to <code>index.html</code>.
+
+<!--T:40-->
 ; <code>importImages</code>
 : Uploads the image files in the source directory into the <code>File:</code> namespace. It runs '''before''' the wikitext import, so pages that embed a local image render a real thumbnail instead of a broken-media placeholder.
+
+<!--T:41-->
 ; <code>importWikitext</code>
 : Imports every <code>*.wikitext</code> file (recursing into subdirectories, so a page like <code>Template:Foo/styles.css</code> can be a nested file). <code>File:</code> description pages and <code>MediaWiki:</code> system pages are saved as the current revision so their edit hooks fire; ordinary pages are imported as old revisions. The build aborts here if the main page is missing.
+
+<!--T:42-->
 ; <code>setLicensesPage</code> and <code>setSettingsPage</code>
 : Write the two pages a build generates: the [[<tvar name="1">Special:MyLanguage/Configuration#WikvenLicensesPage</tvar>|Licenses page]] listing what the site publishes and under which licenses, which the footer links from every page, and the [[<tvar name="2">Special:MyLanguage/Skins#settings</tvar>|Settings page]] carrying the reader's colour theme and skin. A source page of either name is used instead of the generated one.
+
+<!--T:43-->
 ; <code>dropDeadPlaceLinks</code> and <code>dropDeadCategoryLink</code>
 : Blank the system messages behind footer and menu entries that would link pages the export does not contain (privacy policy, disclaimers, community portal).
+
+<!--T:44-->
 ; <code>buildTranslations</code>
 : Materializes each <code><nowiki><translate></nowiki></code>-marked page's translations as real pages, so the job queue and the render passes treat them like any other page. See [[<tvar name="1">Special:MyLanguage/Translating</tvar>|Translating]].
+
+<!--T:45-->
 ; <code>RunJobs</code>
 : Runs MediaWiki's job queue, mainly thumbnail generation and link-table updates, one job type at a time in name order. The search-index job is held back to the very end, because it is enqueued per revision and would otherwise run once per pass of the queue and throw all but the last result away.
+
+<!--T:46-->
 ; <code>stampSourceHistory</code> and <code>hideBuildAuthors</code>
 : Date each page at the commit that last changed its source file, and credit that commit's author, so the footer's "last edited" line agrees with the top of the history it links to. Where the repository's history is out of reach — a shallow checkout, or a source directory that is not one — every page is dated at the commit being built and named to nobody.
+
+<!--T:47-->
 ; <code>freezePageTouched</code>
 : Pins every page's <code>page_touched</code>, which is a version input of any module carrying a version callback. This is the last write the database takes; everything after it reads.
 
@@ -100,28 +120,50 @@ Each pass renders the whole site in its own skin, into its own directory: the fi
 <!--T:32-->
 ; <code>RebuildFileCache</code>
 : Renders every content page to an HTML file. This is MediaWiki's own file cache; {{SITENAME}} treats <code>File:</code> as a content namespace too, so file description pages are exported without dumping every template.
+
+<!--T:48-->
 ; <code>retranslateChrome</code>
 : Re-renders each page written in a language other than the wiki's own — the translations, and the language copies of the [[<tvar name="1">Special:MyLanguage/Configuration#WikvenLicensesPage</tvar>|Licenses page]] the build writes — with that language as the interface language. The file cache only caches the canonical anonymous view, which would leave every one of them wearing the content language's chrome.
+
+<!--T:49-->
 ; <code>stripBuildStamps</code>
 : Removes the request ids, render ids and timestamps MediaWiki stamps into every rendered page, which differ between bakes.
+
+<!--T:50-->
 ; <code>buildStyles</code>
 : Re-renders each CSS module the pages reference into a local file, and renders the <code>site.styles</code> module (<code>MediaWiki:Common.css</code> and the skin's site CSS) to its own file.
+
+<!--T:51-->
 ; <code>bakeWebfonts</code>
 : With <code>WikvenBundleWebfonts</code> set, writes UniversalLanguageSelector's webfonts for the export's languages as a plain stylesheet with the font files beside it. A no-op otherwise.
+
+<!--T:52-->
 ; <code>buildScripts</code>
 : Dumps the JavaScript the pages need into two files: <code>startup-static.js</code> (the loader manifest, with its network auto-load removed) and <code>modules-static.js</code> (the full dependency closure, so every module self-executes). It seeds the <code>site</code> module (<code>MediaWiki:Common.js</code> and the skin's JS) and any default [[<tvar name="1">Special:MyLanguage/JavaScript</tvar>|gadgets]], which a live wiki pulls in implicitly.
+
+<!--T:53-->
 ; <code>rewriteScripts</code>
-: Rewrites the cached HTML to load the local bundle instead of <code>load.php</code>: it swaps the async startup tag for the static files plus an explicit <code>mw.loader.load()</code>, links the site styles last so they win the cascade, and removes the search box, which needs a live API, unless [[<tvar name="2">Special:MyLanguage/Searching</tvar>|SifterSearch]] is providing a static index.
+: Rewrites the cached HTML to load the local bundle instead of <code>load.php</code>: it swaps the async startup tag for the static files plus an explicit <code>mw.loader.load()</code>, links the site styles last so they win the cascade, and removes the search box, which needs a live API, unless [[<tvar name="1">Special:MyLanguage/Searching</tvar>|SifterSearch]] is providing a static index.
+
+<!--T:54-->
 ; <code>fillMinervaMenu</code>
 : Writes the site's own navigation into Minerva's main menu in each rendered page. Minerva builds that menu from its own definitions and never reads <code>MediaWiki:Sidebar</code>, and nothing in PHP can add an entry to it.
+
+<!--T:55-->
 ; <code>storeImages</code>
 : Copies every referenced image (from Wikimedia Commons via InstantCommons, or from local uploads) to a content-hashed local file and rewrites the URLs, so nothing is fetched over the network at view time.
+
+<!--T:56-->
 ; <code>rename</code>
 : Gives the namespace-prefixed cache files readable names (for example <code>ns6%3A...</code> becomes <code>File:...</code>), and reparents each page's relative links by its own depth.
+
+<!--T:57-->
 ; <code>resolveTranslationLinks</code>
 : Rewrites <code>Special:MyLanguage/</code> links over the finished tree, now that each translation is at a known path, so a link leads to the language of the page it sits on.
+
+<!--T:58-->
 ; <code>buildSitemap</code>
-: With [[<tvar name="3">Special:MyLanguage/Configuration#WikvenSiteUrl</tvar>|<code>WikvenSiteUrl</code>]] set, writes <code>sitemap.xml</code> naming every page the pass exported, at absolute URLs. A crawler needs absolute URLs, and a build has none to give until a site says where it will be published, so this writes nothing otherwise. A page that asks not to be indexed is left out, since a sitemap is an invitation to index and naming such a page would contradict the page itself; where no page is left, no file is written. Only the pass rendering into the output root writes one, for the same reason: the other passes are previews whose pages carry that refusal.
+: With [[<tvar name="1">Special:MyLanguage/Configuration#WikvenSiteUrl</tvar>|<code>WikvenSiteUrl</code>]] set, writes <code>sitemap.xml</code> naming every page the pass exported, at absolute URLs. A crawler needs absolute URLs, and a build has none to give until a site says where it will be published, so this writes nothing otherwise. A page that asks not to be indexed is left out, since a sitemap is an invitation to index and naming such a page would contradict the page itself; where no page is left, no file is written. Only the pass rendering into the output root writes one, for the same reason: the other passes are previews whose pages carry that refusal.
 
 <!--T:33-->
 A pass that renders a non-default skin also copies the search index into its own directory, so a search from that copy answers inside it.

--- a/docs/Development/ko.wikitext
+++ b/docs/Development/ko.wikitext
@@ -46,27 +46,47 @@
 <!--T:28 @c83107bc-->
 === 1단계: 위키 채우기 ===
 
-<!--T:29 @1426cdd3-->
+<!--T:29 @b4e72378-->
 ; <code>checkLuaAgainstThisBuild</code>
 : 이 사이트의 [[$1|Lua]]와 이 빌드의 Lua가 서로를 어떻게 보는지를, 다른 어떤 일이 벌어지기 전에 말합니다. Scribunto를 나열했지만 그것을 실행할 엔진이 없는 사이트는 빌드를 끝내는데, 이 빌드가 할 수 없는 일을 요구했기 때문입니다. 반면 Scribunto를 나열한 적 없이 <code>Module:</code> 파일만 있는 사이트에는 그 파일들이 무엇이 되는지를 알려주기만 합니다. 실행할 엔진이 없으면 <code>#invoke</code>는 호출문 그대로 문서에 실리기 때문입니다. 가장 먼저 실행되므로, 사이트가 거부될 때 지난 빌드 결과가 아직 그대로 남아 있습니다.
+
+<!--T:38 @36211c19-->
 ; <code>clearOutputDirectory</code>
 : 출력 디렉터리를 비워, 이전 빌드의 파일이 남지 않도록 합니다.
+
+<!--T:39 @cf4611c2-->
 ; <code>setMainPage</code>
 : <code>MediaWiki:Mainpage</code>를 가져온 <code>index</code> 문서로 지정하여, 사이트 루트가 <code>index.html</code>로 해석되도록 합니다.
+
+<!--T:40 @d3917d52-->
 ; <code>importImages</code>
 : 소스 디렉터리의 이미지 파일을 <code>File:</code> 네임스페이스로 업로드합니다. 위키텍스트 가져오기 '''전에''' 실행되므로, 로컬 이미지를 삽입한 문서가 깨진 미디어 자리표시자 대신 실제 섬네일을 렌더링합니다.
+
+<!--T:41 @d9a3a6e0-->
 ; <code>importWikitext</code>
 : 모든 <code>*.wikitext</code> 파일을 가져옵니다(하위 디렉터리까지 재귀하므로 <code>Template:Foo/styles.css</code> 같은 문서는 중첩된 파일일 수 있습니다). <code>File:</code> 설명 문서와 <code>MediaWiki:</code> 시스템 문서는 편집 훅이 발동하도록 현재 판으로 저장되고, 일반 문서는 옛 판으로 가져옵니다. 주 문서가 없으면 빌드는 여기서 중단됩니다.
+
+<!--T:42 @08aab1bf-->
 ; <code>setLicensesPage</code>와 <code>setSettingsPage</code>
 : 빌드가 생성하는 두 문서를 씁니다. 사이트가 게시하는 것과 그 라이선스를 담았고 모든 문서의 바닥글이 링크하는 [[$1|라이선스 문서]]와, 독자의 색 테마와 스킨을 담은 [[$2|설정 문서]]입니다. 같은 이름의 소스 문서가 있으면 생성본 대신 그것이 쓰입니다.
+
+<!--T:43 @98fb71f8-->
 ; <code>dropDeadPlaceLinks</code>와 <code>dropDeadCategoryLink</code>
 : 내보내기에 없는 문서로 이어질 푸터와 메뉴 항목(개인정보 정책, 면책 조항, 커뮤니티 포털)의 시스템 메시지를 비웁니다.
+
+<!--T:44 @6dff6a54-->
 ; <code>buildTranslations</code>
 : <code><nowiki><translate></nowiki></code>로 표시된 각 문서의 번역을 실제 문서로 만들어, 작업 큐와 렌더링 과정이 다른 문서와 똑같이 다루도록 합니다. [[$1|번역하기]]를 참고하십시오.
+
+<!--T:45 @9bd1de6e-->
 ; <code>RunJobs</code>
 : MediaWiki의 작업 큐를 실행합니다. 주로 섬네일 생성과 링크 테이블 갱신이며, 작업 종류별로 이름 순서대로 하나씩 처리합니다. 검색 색인 작업은 맨 끝으로 미룹니다. 판마다 큐에 들어가기 때문에, 그러지 않으면 큐를 돌 때마다 실행되고 마지막 것을 뺀 나머지 결과를 모두 버리게 됩니다.
+
+<!--T:46 @dd744387-->
 ; <code>stampSourceHistory</code>와 <code>hideBuildAuthors</code>
 : 각 문서에 그 소스 파일을 마지막으로 바꾼 커밋의 시각을 찍고 그 커밋의 작성자를 밝혀, 푸터의 "마지막 편집" 줄이 그 줄에서 이어지는 역사의 첫 항목과 맞아떨어지게 합니다. 저장소의 역사에 닿을 수 없다면 — 얕은 체크아웃이거나, 소스 디렉터리가 저장소가 아닌 경우 — 모든 문서가 빌드 중인 커밋의 시각을 갖고 작성자는 아무도 아니게 됩니다.
+
+<!--T:47 @91ab6334-->
 ; <code>freezePageTouched</code>
 : 모든 문서의 <code>page_touched</code>를 고정합니다. 이 값은 버전 콜백을 지닌 모듈의 버전 입력이기 때문입니다. 데이터베이스에 대한 마지막 쓰기이며, 이후는 모두 읽기입니다.
 
@@ -76,29 +96,51 @@
 <!--T:31 @1214ffe2-->
 각 렌더링 과정은 사이트 전체를 자기 스킨으로, 자기 디렉터리에 렌더링합니다. <code>skins</code>의 첫 스킨은 출력 루트에, 나머지는 <code>dist/&lt;skin&gt;/</code>에 렌더링됩니다. 각 과정은 데이터베이스 사본을 하나씩 받는데, SQLite는 한 번에 하나만 쓸 수 있고 렌더링 과정도 객체 캐시에는 쓰기를 하기 때문입니다.
 
-<!--T:32 @444d922c-->
+<!--T:32 @e89bbfa7-->
 ; <code>RebuildFileCache</code>
 : 모든 콘텐츠 문서를 HTML 파일로 렌더링합니다. MediaWiki 자체의 파일 캐시이며, {{SITENAME}}은 <code>File:</code>도 콘텐츠 네임스페이스로 취급하므로 모든 틀을 쏟아내지 않으면서 파일 설명 문서까지 내보냅니다.
+
+<!--T:48 @6182eb37-->
 ; <code>retranslateChrome</code>
 : 위키 자신의 언어가 아닌 언어로 쓰인 각 문서 — 번역 문서와, 빌드가 언어별로 쓰는 [[$1|라이선스 문서]] 사본 — 를 그 언어를 인터페이스 언어로 삼아 다시 렌더링합니다. 파일 캐시는 표준 익명 열람만 캐시하므로, 그대로 두면 그 문서들이 모두 콘텐츠 언어의 인터페이스를 두르게 됩니다.
+
+<!--T:49 @0c2fdc81-->
 ; <code>stripBuildStamps</code>
 : MediaWiki가 렌더링된 문서마다 찍는 요청 id, 렌더 id, 시각을 제거합니다. 빌드마다 달라지는 값들입니다.
+
+<!--T:50 @86eb8488-->
 ; <code>buildStyles</code>
 : 문서가 참조하는 각 CSS 모듈을 로컬 파일로 다시 렌더링하고, <code>site.styles</code> 모듈(<code>MediaWiki:Common.css</code>와 스킨의 사이트 CSS)을 자체 파일로 렌더링합니다.
+
+<!--T:51 @59db02d4-->
 ; <code>bakeWebfonts</code>
 : <code>WikvenBundleWebfonts</code>가 설정되어 있으면, 내보내기의 언어들에 대한 UniversalLanguageSelector의 웹폰트를 글꼴 파일과 함께 평범한 스타일시트로 씁니다. 그렇지 않으면 아무 일도 하지 않습니다.
+
+<!--T:52 @24b47511-->
 ; <code>buildScripts</code>
 : 문서에 필요한 자바스크립트를 두 파일로 덤프합니다. <code>startup-static.js</code>(네트워크 자동 로드를 제거한 로더 매니페스트)와 <code>modules-static.js</code>(전체 의존성 클로저이므로 모든 모듈이 스스로 실행됩니다)입니다. 살아 있는 위키가 암묵적으로 끌어오는 <code>site</code> 모듈(<code>MediaWiki:Common.js</code>와 스킨의 JS)과 기본 [[$1|소도구]]도 함께 심습니다.
+
+<!--T:53 @a2704415-->
 ; <code>rewriteScripts</code>
-: 캐시된 HTML이 <code>load.php</code> 대신 로컬 번들을 불러오도록 다시 씁니다. 비동기 시작 태그를 정적 파일과 명시적인 <code>mw.loader.load()</code>로 바꾸고, 사이트 스타일이 캐스케이드에서 이기도록 마지막에 링크하며, 살아 있는 API가 필요한 검색 상자를 제거합니다. 단 [[$2|SifterSearch]]가 정적 색인을 제공하는 경우는 예외입니다.
+: 캐시된 HTML이 <code>load.php</code> 대신 로컬 번들을 불러오도록 다시 씁니다. 비동기 시작 태그를 정적 파일과 명시적인 <code>mw.loader.load()</code>로 바꾸고, 사이트 스타일이 캐스케이드에서 이기도록 마지막에 링크하며, 살아 있는 API가 필요한 검색 상자를 제거합니다. 단 [[$1|SifterSearch]]가 정적 색인을 제공하는 경우는 예외입니다.
+
+<!--T:54 @2f49820b-->
 ; <code>fillMinervaMenu</code>
 : 렌더링된 각 문서의 Minerva 주 메뉴에 사이트 자체의 내비게이션을 써넣습니다. Minerva는 그 메뉴를 자체 정의에서 만들고 <code>MediaWiki:Sidebar</code>를 결코 읽지 않으며, PHP 쪽에서 항목을 더할 방법도 없습니다.
+
+<!--T:55 @ccadd486-->
 ; <code>storeImages</code>
 : 참조된 모든 이미지를(InstantCommons를 통한 위키미디어 공용의 것이든 로컬 업로드든) 내용 해시가 붙은 로컬 파일로 복사하고 URL을 다시 써서, 열람 시점에 네트워크로 가져오는 것이 없게 합니다.
+
+<!--T:56 @07eb7f56-->
 ; <code>rename</code>
 : 네임스페이스 접두사가 붙은 캐시 파일에 읽을 수 있는 이름을 줍니다(예: <code>ns6%3A...</code>가 <code>File:...</code>이 됩니다). 각 문서의 상대 링크도 그 문서 자신의 깊이에 맞게 고칩니다.
+
+<!--T:57 @bf3d5d49-->
 ; <code>resolveTranslationLinks</code>
 : 각 번역이 어느 경로에 있는지 확정된 뒤, 완성된 트리 위에서 <code>Special:MyLanguage/</code> 링크를 다시 써서 그 링크가 놓인 문서의 언어로 이어지게 합니다.
+
+<!--T:58 @32b6a575-->
 ; <code>buildSitemap</code>
 : [[<tvar name="3">Special:MyLanguage/Configuration#WikvenSiteUrl</tvar>|<code>WikvenSiteUrl</code>]]이 설정되어 있으면, 그 과정이 내보낸 모든 문서를 절대 URL로 담은 <code>sitemap.xml</code>을 씁니다. 크롤러에게는 절대 URL이 필요한데 사이트가 게시될 곳을 말해주기 전까지 빌드는 그것을 알 수 없으므로, 설정되어 있지 않으면 아무것도 쓰지 않습니다. 색인되지 않기를 요청하는 문서는 빠집니다. 사이트맵은 색인해 달라는 초대이므로 그런 문서를 담으면 문서 자신과 어긋나기 때문입니다. 남는 문서가 없으면 파일을 쓰지 않습니다. 사이트맵은 출력 루트로 렌더링하는 과정만 쓰는데, 이유는 같습니다. 나머지는 미리보기이고 그 문서들이 바로 그 거절을 달고 있습니다.
 


### PR DESCRIPTION
Closes #629.

A blank line between each `;`/`:` pair gives Translate a unit per build step.

| | before | after |
| --- | ---: | ---: |
| largest unit in `Development.wikitext` | 4,276 | 2,427 |
| units on the page | 34 | 55 |
| median unit on the page | — | 232 |

Adding a build step now re-stamps one step, not twenty-six lines.

## It was doing more than costing a translator's time

#629 says "this is not a translation *correctness* problem". It is one.

A tvar is named **within its unit**, and a unit holding twelve steps had three tvars called `"1"` in T:29 and two in T:32. They collided. Baking `main` and this branch side by side and diffing every link on the page:

| link text | published today | should be, and now is |
| --- | --- | --- |
| Lua | `Translating.html` | `Lua_modules.html` |
| Licenses page | `Translating.html` | `Configuration.html#WikvenLicensesPage` |
| Licenses page | `JavaScript.html` | `Configuration.html#WikvenLicensesPage` |

The same three, in all three languages — `Development.html`, `/en`, `/ko`. Checked against the source: `checkLuaAgainstThisBuild` writes `[[<tvar name="1">Special:MyLanguage/Lua modules</tvar>|Lua]]` and the site sends the reader to Translating.

A unit per step gives each pair its own namespace, so the names cannot collide any more. Two pairs had numbered their tvars `2` and `3` to dodge the clash inside the old unit; those are renumbered to `1`, with the Korean `$N` moved to match. Link counts are identical before and after (15/15, 16/16, 15/15), no `$N` leaks into the output, and only `Development` and its two language copies differ from a bake of `main` — nine files including the skin copies, nothing else.

## The rendering change, measured

One `<dl>` per pair rather than one for the list: `<dl>` goes 2 → 23, `<dt>`/`<dd>` stay 23/23. In a browser, against the shipped `dl{margin-top:0.2em;margin-bottom:0.5em}`:

| | before | after |
| --- | ---: | ---: |
| gap between consecutive steps | 1.4px | 7.0px |
| height of the lists | 1,943px | 2,061px |
| height of the page | 5,643px | 5,761px (+2.1%) |

Taken rather than fought with a stylesheet rule, which #629 offered as the alternative: the entries are long paragraphs, and a little more air between them reads better than none.

Worth saying against it: twelve one-item `<dl>`s carry less structure than one twelve-item `<dl>`, which assistive technology can announce. The entries here are named by their `<dt>` and read as prose rather than as a sequence anyone counts, so I took the trade — but it is a trade, and it is the one thing here I would undo on request.

## Left alone

`T:23`, the continuous-integration list, is now the largest unit in the documentation at 2,427 characters. The same blank lines split it — measured at 2.8px more between bullets, `<ul>` 3 → 16 — but it is a `*` list rather than a pipeline, and a workflow is added far less often than a build step. #629's cost argument is about editing the pipeline, so this is where I stopped.

## Checks

`translate check --gate` passes: T:29 re-stamped, twenty-two new Korean units written and stamped. The docs bake exits 0, and all five of the smoke job's Python assertions pass against it, run as CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_