### PR TITLE
docs: give the Korean Skins page back its two lost paragraphs

### DIFF
--- a/docs/Skins/ko.wikitext
+++ b/docs/Skins/ko.wikitext
@@ -26,26 +26,10 @@ Minerva는 나머지 둘보다 설명할 것이 많습니다. 빌드가 스킨�
 
 <!--T:6 @792bb893-->
 <code>skins</code>는 어떤 스킨을 빌드할지 정합니다. Wikven은 무엇을 나열하든 Vector를 빌드하므로, 다른 스킨을 적는 것은 대체가 아니라 추가입니다:
-</translate>
 
-<syntaxhighlight lang="yaml" copy>
-skins:
-  - MinervaNeue
-</syntaxhighlight>
-
-<translate>
 <!--T:34 @bb639b95-->
 그중 어느 것으로 사이트를 읽을지는 별개의 질문이고, MediaWiki에 이미 그 설정이 있습니다. <code>config</code> 아래 <code>DefaultSkin</code>에 스킨의 표준 이름을 적으십시오. 표준 이름은 MediaWiki가 그 스킨을 부르는 이름으로, 여러분이 나열할 때 쓴 이름과 늘 같지는 않습니다. MinervaNeue는 <code>minerva</code>, Vector는 <code>vector-2022</code>입니다.
-</translate>
 
-<syntaxhighlight lang="yaml" copy>
-skins:
-  - MinervaNeue
-config:
-  DefaultSkin: minerva
-</syntaxhighlight>
-
-<translate>
 <!--T:35 @580a1f35-->
 설정하지 않으면 빌드된 첫 스킨으로 읽습니다. 스킨이 하나뿐인 사이트에는 그것이 유일하게 필요한 답입니다. 사이트가 빌드하지 않는 스킨을 <code>DefaultSkin</code>에 적으면 그 사실을 알리고 무시합니다. 아무것도 렌더링하지 않는 기본 스킨은 출력 루트에 문서를 하나도 남기지 않기 때문입니다.
 


### PR DESCRIPTION
Two paragraphs of the **published** Korean Skins page are in English, and have been for as long as the page has existed — https://chaotic-ground.github.io/wikven/Skins/ko.html, T:6 ("skins says which skins to build…") and T:34 ("Which of them the site is read in…"). Both are translated in `docs/Skins/ko.wikitext`. Neither is used.

## Why

A translation file is a list of units and nothing else. `StalenessComputer::translationUnits()` runs each unit from its own marker to the next, so the `</translate>`, the `<syntaxhighlight>` block and the `<translate>` this file carried after T:6 all became part of T:6's translated text — and the same after T:34. Translate does not use a unit that arrives looking like that; it falls back to the source language, which is what the page shows.

Those blocks belong to no unit at all. They sit *outside* `<translate>` on the source page, so Translate renders them from the source for every language. A translation file repeating them can only do harm.

Found while splitting the search-engine section out of Deploying (#670): the new page's Korean had picked up the same shape, and T:6 came out in English in that PR's preview. Fixing it there is what made this page's identical symptom legible.

## Scope, checked rather than assumed

`git grep '^</translate>\|^<translate>' -- 'docs/*/ko.wikitext'` on `main` finds these four lines and no others, so `Skins/ko` is the only translation in the tree that carried them, and none are left after this. `Pages/ko` and `Configuration/ko` also hold `<syntaxhighlight>` blocks, but each sits *inside* a numbered unit, which is a block the source made translatable — those are correct and untouched.

No stamp changes: a stamp hashes the source unit, and no source page is touched. `analyze()` over every source page with a marked translation reports nothing but `index`'s title unit, which is untranslated on `main` too.

## What still has no guard

`checkTranslations` reads unit markers and hashes, and never asks whether a translation file contains tags it should not. That is why this sat on the published site unnoticed rather than failing a gate. Not added here — it is a check, not a content fix, and belongs on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_