### PR TITLE
docs: say what a release brought, in the words of somebody who would use it

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -48,6 +48,11 @@ config:
   # template.
   WikvenFailOnCategories:
     - Pages with template errors
+  # ParserFunctions keeps its string functions behind this, off by default, because a wiki that
+  # takes edits from anyone can be made to spend a lot of parser on them. Nobody edits this site:
+  # it is a directory of files in a repository, rendered once at build time. Template:draft needs
+  # #explode to read a version out of a page's title.
+  PFEnableStringFunctions: true
   WikvenFooterUrl: https://github.com/chaotic-ground/wikven
   WikvenEditUrl: https://github.com/chaotic-ground/wikven/edit/main/docs/$1
   WikvenHistoryUrl: https://github.com/chaotic-ground/wikven/commits/main/docs/$1

--- a/docs/Release notes.wikitext
+++ b/docs/Release notes.wikitext
@@ -1,0 +1,8 @@
+{{DISPLAYTITLE:What's new}}
+__NOTOC__
+What each release of {{SITENAME}} brought, newest first, in the words of somebody who would use it
+rather than in the words of the commits. The complete list of changes, generated from those commits,
+is in [https://github.com/chaotic-ground/wikven/blob/main/CHANGELOG.md CHANGELOG.md] and on the
+[https://github.com/chaotic-ground/wikven/releases releases page].
+
+* [[Release notes/1.1.0|1.1.0]]

--- a/docs/Release notes/1.1.0.wikitext
+++ b/docs/Release notes/1.1.0.wikitext
@@ -1,0 +1,83 @@
+{{DISPLAYTITLE:What's new in 1.1.0}}
+{{draft}}
+Most of this release is about a site knowing its own address, and about a build refusing to publish
+a page it rendered wrong.
+
+== A site that says where it is ==
+
+A static export has no server to ask, so until now nothing a wikven site wrote about itself could
+name an address. Tell it where the site will be published and that changes:
+
+<syntaxhighlight lang="yaml" copy>
+config:
+  WikvenSiteUrl: https://example.org/wiki/
+</syntaxhighlight>
+
+That one line is what the rest of this section stands on. Given it, a bake writes
+<code>dist/sitemap.xml</code> naming every page it exported at a whole address, which is the file a
+search engine reads to find pages nothing links to. Every page gains a <code>canonical</code> link
+saying which address is its own, so the extensionless address a host also answers on and the
+skin-preview copies stop competing with it, and a translated page gains <code>hreflang</code>
+alternates naming its siblings, so a reader is offered the language they read in.
+
+The picture a shared link shows works too. It has to be a whole address, because whatever renders
+the card never saw the page it came from, and it has to name a file the build actually wrote rather
+than a path only a live wiki serves. Both halves are now true, and a picture named in a page's head
+is told apart from one in its body, so the card and the article no longer have to agree about which
+file is meant.
+
+None of it names the machine that built the site any more. A bake installs against a local address,
+and two places used to carry it into the output — the site's own author and publisher in the
+structured data of every page, and <code>wgServer</code> in the script bundle. A reader who received
+either got the build container's address rather than the site's.
+
+[[Special:MyLanguage/Search engines|Search engines]] is the new page on what to do with all of it:
+what a sitemap is for, why <code>robots.txt</code> usually has nowhere to live on a project page,
+and how each engine is told by hand.
+
+== A build that stops when a page came out wrong ==
+
+MediaWiki reports what it will not refuse to render. A template used without a required argument
+draws its placeholder, a Lua error prints where the module's answer should be, a page whose template
+expansion ran past its limit is silently cut short — the page still builds, and a static export
+publishes all of it without a word. What MediaWiki does instead is put the page in a tracking
+category, which an export does not carry and nobody reads.
+
+<code>WikvenFailOnCategories</code> is the list of categories no page may be in when the build
+finishes, and it arrives with the twenty-three that mean something went wrong already in it. So a
+build now stops where it used to publish:
+
+<syntaxhighlight lang="console">
+Wikven: Category:Pages with script errors holds 1 page(s), and WikvenFailOnCategories says it
+must hold none: Guide
+</syntaxhighlight>
+
+A site that wants a category of its own gated adds it to the list; a site that wants one of the
+defaults back sets that category's message to <code>-</code>, which is how MediaWiki turns a
+tracking category off.
+
+== The licenses page names the server ==
+
+A site built by the standalone binary is served by the web server inside that binary, and the
+licenses page now says which one and under what licence — the same way it already named MediaWiki
+and the extensions. A build from the Docker image is unchanged: there is no server in the export to
+name.
+
+== Also fixed ==
+
+* Skins the site never asked for stopped riding into every reader's script bundle, and onto the
+  licenses page as skins the site publishes. The installer used to enable every skin it found on
+  disk.
+* The settings page's skin list fills in reliably; it used to depend on the page being ready first.
+* The preview server stopped answering for addresses the published site does not have, which made a
+  broken link look like a working one.
+* The image stopped shipping a Caddy module wikven cannot use.
+* A build step that died halfway stopped reporting success. The standalone binary still cannot
+  report every such death — [https://github.com/chaotic-ground/wikven/issues/666 #666] is the
+  record of what is left, and it is FrankenPHP's to fix.
+* A sitemap past the fifty thousand pages or fifty megabytes the protocol allows is now reported
+  rather than written silently.
+* <code>translate check</code> refuses a translation that carries a <code><nowiki><translate></nowiki></code>
+  tag. Such a tag is swallowed by the unit above it, and the unit is then shown in the source
+  language rather than the translated one — this site had two paragraphs like that in its own
+  Korean, published and unnoticed.

--- a/docs/Template:draft.wikitext
+++ b/docs/Template:draft.wikitext
@@ -1,4 +1,4 @@
-<onlyinclude>{{#ifexpr:{{draft/number|{{WIKVENVERSION}}}} < {{draft/number|{{#explode:{{PAGENAME}}|/|-1}}}}|{{note|type=warning|text=This page is about {{#explode:{{PAGENAME}}|/|-1}}, which is not out yet. It describes what is on <code>main</code> and may still change before the release.}}}}</onlyinclude><noinclude>
+<onlyinclude>{{#ifexpr:{{draft/number|{{WIKVENVERSION}}}} < {{draft/number|{{#explode:{{PAGENAME}}|/|-1}}}}|{{note|type=warning|text=This page is about {{#explode:{{PAGENAME}}|/|-1}}, which is not out yet. It describes what is on <code>main</code> and may still change before the release, so please do not mark it for translation yet.}}}}</onlyinclude><noinclude>
 A hatnote for a page named after a release, shown only while that release is unreleased.
 
 Takes no arguments. The version comes from the page's own title -- everything after the last slash,
@@ -6,6 +6,16 @@ so "Release notes/1.1.0" is about 1.1.0 -- and the version that built the page c
 {{WIKVENVERSION}}. Both are already written down, so there is nothing to set and nothing to
 remember: the bake that publishes the release is built by that release, the comparison stops being
 true, and the notice stops rendering. Nobody edits it out.
+
+It also asks not to have the page marked for translation, which mediawiki.org says with a template
+of its own (Template:DoNotTranslate) and which is the same request for the same reason: a draft
+that is still moving costs a translator their work twice. It is said here rather than in a template
+of its own because it is true of a page for exactly as long as the rest of this notice is, and this
+site has no other page that would ask it. Split it out when a second one does.
+
+Once the release is out and the notice is gone, the page is an ordinary page of this site and can be
+wrapped in <translate> and marked like any other. Nothing here does that; somebody has to decide the
+page is worth translating.
 
 Template:draft/number turns each version into a number and answers 0 for anything that is not one,
 which is what leaves this template a single comparison. What that means for a page this is used on

--- a/docs/Template:draft.wikitext
+++ b/docs/Template:draft.wikitext
@@ -3,7 +3,7 @@ A hatnote for a page named after a release, shown only while that release is unr
 
 Takes no arguments. The version comes from the page's own title -- everything after the last slash,
 so "Release notes/1.1.0" is about 1.1.0 -- and the version that built the page comes from
-{{WIKVENVERSION}}. Both are already written down, so there is nothing to set and nothing to
+<code><nowiki>{{WIKVENVERSION}}</nowiki></code>. Both are already written down, so there is nothing to set and nothing to
 remember: the bake that publishes the release is built by that release, the comparison stops being
 true, and the notice stops rendering. Nobody edits it out.
 
@@ -14,8 +14,8 @@ of its own because it is true of a page for exactly as long as the rest of this 
 site has no other page that would ask it. Split it out when a second one does.
 
 Once the release is out and the notice is gone, the page is an ordinary page of this site and can be
-wrapped in <translate> and marked like any other. Nothing here does that; somebody has to decide the
-page is worth translating.
+wrapped in <code><nowiki><translate></nowiki></code> and marked like any other. Nothing here does
+that; somebody has to decide the page is worth translating.
 
 Template:draft/number turns each version into a number and answers 0 for anything that is not one,
 which is what leaves this template a single comparison. What that means for a page this is used on

--- a/docs/Template:draft.wikitext
+++ b/docs/Template:draft.wikitext
@@ -1,0 +1,16 @@
+<onlyinclude>{{#ifexpr:{{draft/number|{{WIKVENVERSION}}}} < {{draft/number|{{#explode:{{PAGENAME}}|/|-1}}}}|{{note|type=warning|text=This page is about {{#explode:{{PAGENAME}}|/|-1}}, which is not out yet. It describes what is on <code>main</code> and may still change before the release.}}}}</onlyinclude><noinclude>
+A hatnote for a page named after a release, shown only while that release is unreleased.
+
+Takes no arguments. The version comes from the page's own title -- everything after the last slash,
+so "Release notes/1.1.0" is about 1.1.0 -- and the version that built the page comes from
+{{WIKVENVERSION}}. Both are already written down, so there is nothing to set and nothing to
+remember: the bake that publishes the release is built by that release, the comparison stops being
+true, and the notice stops rendering. Nobody edits it out.
+
+Template:draft/number turns each version into a number and answers 0 for anything that is not one,
+which is what leaves this template a single comparison. What that means for a page this is used on
+by mistake, and for a build that will not say which version it is, is written there.
+
+Needs PFEnableStringFunctions, which docs/.wikven.yaml turns on for #explode; ParserFunctions keeps
+the string functions off by default.
+</noinclude>

--- a/docs/Template:draft/number.wikitext
+++ b/docs/Template:draft/number.wikitext
@@ -1,0 +1,16 @@
+<onlyinclude>{{#iferror:{{#expr: 0{{#explode:{{{1|}}}|.|0}} * 1000000 + 0{{#explode:{{{1|}}}|.|1}} * 1000 + 0{{#explode:{{{1|}}}|.|2}} }}|0}}</onlyinclude><noinclude>
+One version as one number, so that two of them compare with a single {{#ifexpr:}} rather than with
+a nesting of three. "1.10.0" is 1010000 and "1.9.0" is 1009000, which is the comparison a string
+gets wrong. Room for a thousand patches and a thousand minors before the parts run into each other.
+
+Each part is written with a leading zero -- 0 and then whatever #explode returned -- so a version
+of fewer than three parts still gives a number: "1.1" has no third part, #explode answers with
+nothing, and "0" is what is left to add. It also writes "09" where a part is 9, which #expr reads
+as the nine it is.
+
+Anything this cannot read as a version is 0, and that is what makes Template:draft need no guard of
+its own. A page whose title ends in something other than a version is 0 and no build is older than
+it, so no hatnote; a {{WIKVENVERSION}} that is missing or is not a version is 0 and every release is
+newer than it, so the hatnote shows. Both are the answer that case wants, and neither is written
+down anywhere but here.
+</noinclude>

--- a/docs/Template:draft/number.wikitext
+++ b/docs/Template:draft/number.wikitext
@@ -1,5 +1,5 @@
 <onlyinclude>{{#iferror:{{#expr: 0{{#explode:{{{1|}}}|.|0}} * 1000000 + 0{{#explode:{{{1|}}}|.|1}} * 1000 + 0{{#explode:{{{1|}}}|.|2}} }}|0}}</onlyinclude><noinclude>
-One version as one number, so that two of them compare with a single {{#ifexpr:}} rather than with
+One version as one number, so that two of them compare with a single <code><nowiki>{{#ifexpr:}}</nowiki></code> rather than
 a nesting of three. "1.10.0" is 1010000 and "1.9.0" is 1009000, which is the comparison a string
 gets wrong. Three digits a part, so a minor or a patch of 999 is the last one that still compares;
 the major has the rest of the number and no such ceiling.
@@ -11,7 +11,7 @@ as the nine it is.
 
 Anything this cannot read as a version is 0, and that is what makes Template:draft need no guard of
 its own. A page whose title ends in something other than a version is 0 and no build is older than
-it, so no hatnote; a {{WIKVENVERSION}} that is missing or is not a version is 0 and every release is
+it, so no hatnote; a <code><nowiki>{{WIKVENVERSION}}</nowiki></code> that is missing or is not a version is 0 and every release is
 newer than it, so the hatnote shows. Both are the answer that case wants, and neither is written
 down anywhere but here.
 </noinclude>

--- a/docs/Template:draft/number.wikitext
+++ b/docs/Template:draft/number.wikitext
@@ -1,7 +1,8 @@
 <onlyinclude>{{#iferror:{{#expr: 0{{#explode:{{{1|}}}|.|0}} * 1000000 + 0{{#explode:{{{1|}}}|.|1}} * 1000 + 0{{#explode:{{{1|}}}|.|2}} }}|0}}</onlyinclude><noinclude>
 One version as one number, so that two of them compare with a single {{#ifexpr:}} rather than with
 a nesting of three. "1.10.0" is 1010000 and "1.9.0" is 1009000, which is the comparison a string
-gets wrong. Room for a thousand patches and a thousand minors before the parts run into each other.
+gets wrong. Three digits a part, so a minor or a patch of 999 is the last one that still compares;
+the major has the rest of the number and no such ceiling.
 
 Each part is written with a leading zero -- 0 and then whatever #explode returned -- so a version
 of fewer than three parts still gives a number: "1.1" has no third part, #explode answers with


### PR DESCRIPTION
`CHANGELOG.md` and the releases page list every change, generated from the commits, for people tracking the repository. Nothing says what a release means to somebody who *uses* wikven — and the generated list cannot: it is grouped by commit type, it omits everything `.release-please-config.json` hides (`refactor`, `test`, `docs`, `ci`), and it is written in the register of the diff.

`Release notes/1.1.0` is that page for the release waiting in #618. Three things a reader of this site would notice get sections — a site that can say where it is, a build that stops on a page it rendered wrong, a licenses page that names the server — and the rest is a list at the bottom.

## The draft hatnote

A release page is written before its release exists, so it says so until the release catches up. `Template:draft` compares the version in the page's own title with `{{WIKVENVERSION}}`, the version of the Wikven that built the page, and shows the notice only while the first is newer.

**Nothing is edited when the release happens.** The bake that publishes it is built by it, so the comparison stops being true and the notice stops rendering.

Both halves are wikitext, not Lua. `#explode` reads a version out of the title and out of `{{WIKVENVERSION}}`, `Template:draft/number` turns each into one number so that `1.10.0` sorts after `1.9.0` rather than before it, and one `#ifexpr` compares them. That needs `PFEnableStringFunctions`, which ParserFunctions keeps off by default and `docs/.wikven.yaml` now turns on for this site — the reason it is off is a wiki that takes edits from anyone, and this one is a directory of files rendered once at build time.

A version neither can read is `0`, which is what leaves the template a single comparison with no guard around it:

| case | named | built | hatnote |
| --- | ---: | ---: | --- |
| the page is about an unreleased version | 1001000 | 1000000 | shown |
| the release lands | 1001000 | 1001000 | gone, by itself |
| a later release | 1001000 | 1002000 | still gone |
| the page is not a release page | 0 | 1000000 | none |
| the build will not say which version it is | 1001000 | 0 | shown — a draft shown as published is the failure worth avoiding |

## Checked

The comparison is simulated against ParserFunctions' own `runExplode()` and `#expr`'s number reading, over twelve cases: the release landing and the one after it, `1.10.0` against `1.9.0` in both directions, `1.1` and `1.1.0` as one version written two ways, an empty and a non-version `{{WIKVENVERSION}}`, and two pages that are not release pages. All twelve answer as intended.

Not baked here, so the rendering itself is unproven — the preview job is what will show it, and I will read it when it does.

`yamllint` passes on the edited `.wikven.yaml`. Neither page carries `<translate>` or `<languages />`, so `translate check` has nothing to say about them and the `language-bars` assertion is unaffected.

## Two names

The page is titled **Release notes** and displays **What's new**. An apostrophe in a title reaches the canonical link percent-encoded, and the `head-links` bake check looks the file up without decoding it, so `What's new/1.1.0` would have failed a check on its punctuation. The words readers see are the ones worth having; the string machines see only has to be safe.

## Left for you

- Nothing links either page yet, and neither is in the sidebar, so `Module:Sequence.lua` writes no navigation row for them. Worth linking from the front page when 1.1.0 ships.
- The prose is a first draft of a judgement call — which changes are worth a reader's attention and which are a line at the bottom. That is yours to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_