### PR TITLE
docs: cut the source comments down to the size of notes

### DIFF
--- a/includes/AssetFile.php
+++ b/includes/AssetFile.php
@@ -7,12 +7,8 @@ namespace MediaWiki\Extension\Wikven;
  *
  * $wgWikvenAssetDirectory puts every generated file anywhere under the output root, so a step that
  * links one has to answer the same question the step that wrote it answered. Deriving the link and
- * the path together is what keeps the two answers from parting: a link written for one directory
- * while the file is looked for in another leaves the page with no stylesheet at all, and nothing
- * anywhere to say so.
- *
- * The href is written relative to the output root, as everything wikven writes is; a page exported
- * into a subdirectory has RelativeUrl::reparent() add a "../" per level to it.
+ * the path together keeps the two from parting: a link written for one directory while the file is
+ * looked for in another leaves the page with no stylesheet and nothing to say so.
  */
 class AssetFile {
 	/**
@@ -33,11 +29,9 @@ class AssetFile {
 	/**
 	 * What a picture the build made local is called, from the reference pages had for it.
 	 *
-	 * Content-addressed so one picture referenced twice is stored once, and so a rebuild of an
-	 * unchanged site writes the same name (#411). Kept here rather than in the step that stores
-	 * them because two things now have to agree on it: storeImages names the file, and a site's
-	 * social image has to be named in a head tag before that step has run. A rule kept twice is a
-	 * rule that drifts, and the drift here is a head tag pointing at a file nobody wrote.
+	 * Content-addressed so one picture referenced twice is stored once, and a rebuild writes the
+	 * same name (#411). Kept here because two things have to agree on it: storeImages names the
+	 * file, and a social image is named in a head tag first.
 	 *
 	 * @param string $key What identifies the picture: the storage path for a local file, the whole
 	 *   URL for a remote one. Two references to one picture must give the same key.

--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -12,10 +12,9 @@ class AssetLocalizer {
 	/**
 	 * Rewrite asset url()s in the given dumped CSS/JS files to point at copies in $dir.
 	 *
-	 * A CSS file resolves its url()s relative to itself, so a "./img-*.svg" next to it works from
-	 * any page depth. A JS bundle instead injects its CSS into the document, where url()s resolve
-	 * against the page, breaking on subpages ("index/ko.html" would fetch "index/img-*.svg"). Pass
-	 * $inline for JS bundles to embed the images as data: URIs, which are depth- and base-path-safe.
+	 * A CSS file resolves its url()s relative to itself, so a "./img-*.svg" beside it works from any
+	 * depth. A JS bundle injects its CSS into the document, where url()s resolve against the page
+	 * and break on subpages; pass $inline for those, to embed the images.
 	 */
 	public static function localizeAssets(
 		ResourceLoader $rl,
@@ -91,11 +90,9 @@ class AssetLocalizer {
 	/**
 	 * Encode raw image bytes as a data: URI usable unquoted inside url().
 	 *
-	 * CSSMin percent-encodes printable text (an SVG, typically) instead of base64-encoding it, which
-	 * is what ResourceLoader itself does for the same images when it inlines them into a CSS bundle.
-	 * It leaves the spaces bare though, because it quotes the url() it builds; here the URI goes in
-	 * unquoted (a quote inside a JS bundle's CSS string would have to be escaped), and a bare space
-	 * makes the whole declaration invalid, so put those back. Base64 output has none to put back.
+	 * CSSMin percent-encodes printable text (an SVG, typically) rather than base64-encoding it, and
+	 * leaves the spaces bare because it quotes the url() it builds. Here the URI goes in unquoted,
+	 * and a bare space makes the declaration invalid, so put those back.
 	 */
 	private static function dataUri(string $bytes, string $mime): string {
 		return str_replace(' ', '%20', CSSMin::encodeStringAsDataURI($bytes, $mime));

--- a/includes/Attempts.php
+++ b/includes/Attempts.php
@@ -6,16 +6,12 @@ namespace MediaWiki\Extension\Wikven;
  * How many times the build asks somebody else's server for something before it gives up.
  *
  * A bake fetches third-party extensions and skins over the network, and asks Commons for the
- * thumbnail of every image a page embeds. Until recently one refusal ended the build. That is a
- * build failed by a service having a bad minute rather than by anything in the source: GitHub
- * answered 500 for git and archive traffic for hours on 2026-08-17, and codeload has answered 429
- * under load. Neither says anything about the commit being built.
+ * thumbnail of every image a page embeds. One refusal used to end the build -- failed by a service
+ * having a bad minute rather than by anything in the source.
  *
- * Nothing in the box does this. MediaWiki's HttpRequestFactory and MWHttpRequest carry no retry at
- * all; wikimedia/wait-condition-loop, which core does bundle, spends a time budget waiting for a
- * condition to come true, which is not the shape of one fetch that either worked or did not and can
- * take minutes; and Guzzle's retry middleware, which core also bundles, would reach only half of
- * the callers here, since one of them repeats a `composer update` in a subprocess.
+ * Nothing in the box does this: HttpRequestFactory carries no retry, wait-condition-loop waits on
+ * a condition, and Guzzle's middleware would miss the caller that repeats a `composer update` in a
+ * subprocess.
  */
 class Attempts {
 	/** How many times one fetch is tried. Two retries is enough for a blip and short of a queue. */
@@ -26,8 +22,7 @@ class Attempts {
 	 *
 	 * False is the failure, and only false: a request can succeed with an empty body, and a caller
 	 * that answers with a bool says so by returning true. Whatever the successful attempt answered
-	 * is what comes back, so a caller that wants the body gets the body and one that only wants to
-	 * know gets its true.
+	 * is what comes back.
 	 *
 	 * @param callable():mixed $work Does the work; answers false if it failed, anything else if not.
 	 * @param int $attempts How many times to run it. Below one is treated as one: a caller that asks
@@ -54,9 +49,8 @@ class Attempts {
 	/**
 	 * Seconds to wait before attempt number $attempt: none before the first, then 2, 4, 8...
 	 *
-	 * Doubling rather than a fixed wait because the two failures worth retrying differ in what they
-	 * are asking for. A 500 wants a moment; a 429 wants to be asked less often, and answering it at
-	 * the same rate is the thing that keeps it a 429.
+	 * Doubling rather than a fixed wait because the two failures worth retrying differ: a 500 wants
+	 * a moment, and a 429 wants to be asked less often.
 	 */
 	public static function backoff(int $attempt): int {
 		return $attempt <= 1 ? 0 : 1 << ( $attempt - 1 );

--- a/includes/BuildFor.php
+++ b/includes/BuildFor.php
@@ -5,28 +5,10 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * Who this build is for: a site being published, or a skin being looked at.
  *
- * Wikven has opinions about the chrome around a page, and they are a reader's opinions: a static
- * export has no account to log into, no watchlist to add to, no talk page to post on and no server
- * to search with, so the menus offering those are emptied, the tabs are replaced with links to the
- * source files, and a footer link to the repository goes in. That is right for a published site,
- * where every affordance left standing is one that has to work.
- *
- * It is wrong for the other thing a bake is useful for. A skin author who points wikven at a
- * handful of pages to see their skin rendered wants to see *their skin* -- the personal menu it
- * draws, the tabs it lays out, the toolbox it styles -- and what they get instead is wikven's
- * reading of it, with most of that taken away. The skin is the subject, and the tool has been
- * editing the subject.
- *
- * So the chrome layer can be turned off, and this is the switch. What it does not touch is
- * everything that makes the output a working set of files: links are still rewritten to "./X.html",
- * stylesheets and scripts are still baked to local copies, the canonical link still points at the
- * main skin's copy. Those are not opinions about how a page should look; without them there is no
- * preview to look at.
- *
- * Two per-skin fixes also stay on, because they are of the same kind: Citizen's service worker,
- * which registers against a load.php the export does not have, and its search shortcuts, which
- * reach for modules the export does not ship. Both exist to stop the page asking for something
- * that is not there, which is as true of a preview as of a site.
+ * For a site, wikven empties the menus for login, watchlist, talk and search and turns the tabs
+ * into links to the source files. That is wrong for a skin preview, where the skin is the subject,
+ * so this switch turns the chrome layer off. Link rewriting, local asset copies and the two
+ * Citizen fixes stay on either way.
  */
 class BuildFor {
 	/** A site to publish: the chrome is trimmed to what a static host can stand behind. */
@@ -38,10 +20,8 @@ class BuildFor {
 	/**
 	 * Every audience a build can be for, in the spelling a site writes.
 	 *
-	 * Two of them, and the pair is why this is not a flag. They are not independent switches a
-	 * site turns on together; they are answers to one question, and the setting asks that question
-	 * once. A third would be a third value rather than a second boolean nobody knows how to
-	 * combine with the first.
+	 * Two of them, and the pair is why this is a value rather than a flag: they answer one
+	 * question, and a third would be a third value rather than a second boolean.
 	 *
 	 * @return string[]
 	 */
@@ -52,10 +32,9 @@ class BuildFor {
 	/**
 	 * The audience this build is for, falling back to a site.
 	 *
-	 * An unrecognised value reads as a site, which is the reading that publishes something a
-	 * static host can answer for; SiteConfig::lint() has already named it by then. Read from the
-	 * global rather than injected config, because the hooks that ask are the ones that already
-	 * read $wgWikvenEditUrl and its neighbours that way.
+	 * An unrecognised value reads as a site, the reading a static host can answer for;
+	 * SiteConfig::lint() has already named it. Read from the global rather than injected config
+	 * because the hooks that ask already read $wgWikvenEditUrl that way.
 	 */
 	public static function current(): string {
 		$configured = $GLOBALS['wgWikvenBuildFor'] ?? self::SITE;

--- a/includes/BuildPaths.php
+++ b/includes/BuildPaths.php
@@ -5,11 +5,9 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * Where a build reads and writes, worked out from the one directory it was pointed at.
  *
- * A bake is handed a single workdir and everything else hangs off it: the source tree it imports,
- * the export it writes, the scratch space it throws away, and the git log the bake action dumps
- * beside them. The rule is stated here once because WikvenSettings.php needs it twice -- before a
- * site's configuration is applied, and again afterwards to take back what apply() handed over --
- * and two copies of it would be free to drift apart.
+ * A bake is handed a single workdir and everything else hangs off it: the source tree, the export,
+ * the scratch space, and the git log the bake action dumps beside them. Stated here once because
+ * WikvenSettings.php needs it twice, before a site's configuration is applied and again afterwards.
  */
 class BuildPaths {
 	/**

--- a/includes/BuildStamps.php
+++ b/includes/BuildStamps.php
@@ -8,10 +8,8 @@ class BuildStamps {
 	 * What a page records about the request that rendered it, rather than about the page.
 	 *
 	 * Each entry is a pattern and its replacement. The ids are blanked rather than deleted, because
-	 * mw.config.get() on a missing key returns null where scripts expect a number; nothing in an
-	 * export can act on them anyway, since there is no api.php to ask about a revision. The
-	 * comments are dropped whole: they are debugging output for a live wiki, addressed to someone
-	 * reading view-source on a server they operate.
+	 * mw.config.get() on a missing key returns null where scripts expect a number. The comments are
+	 * dropped whole: they are debugging output for a live wiki.
 	 */
 	private const STAMPS = [
 		// A fresh id per request, and how long that request took.

--- a/includes/ComposerInstall.php
+++ b/includes/ComposerInstall.php
@@ -6,16 +6,12 @@ namespace MediaWiki\Extension\Wikven;
  * Where composer put the packages a site asked for, and whether that is where the build looks.
  *
  * A name in a site's extensions: or skins: list is a directory name, and WikvenSettings.php turns
- * it straight into a path under $IP. A composer package names its own directory instead, through
- * composer/installers, and the two do not have to agree: a "mediawiki-extension" is CamelCased
- * with a trailing "-extension" cut off (mediawiki/tabber-neue-extension -> extensions/TabberNeue),
- * a "mediawiki-skin" is not CamelCased at all (mediawiki/chameleon-skin -> skins/chameleon), and a
- * package declaring neither type lands in vendor/ like any other library.
+ * it straight into a path under $IP. A composer package names its own directory instead, and the
+ * two need not agree: an extension is CamelCased, a skin is not, and a package declaring neither
+ * type lands in vendor/.
  *
- * So a site listing "Chameleon" and asking for "mediawiki/chameleon-skin" got skins/chameleon,
- * which on a case-sensitive filesystem is a different directory. Every step succeeded: the package
- * installed, the log said "skipping skin 'Chameleon' (not bundled in this image)", the build
- * carried on, and the site went out without its skin.
+ * So a site listing "Chameleon" and asking for "mediawiki/chameleon-skin" got skins/chameleon and
+ * went out without its skin.
  */
 class ComposerInstall {
 	/**
@@ -97,9 +93,8 @@ class ComposerInstall {
 	 * What the site could write instead, where there is something worth writing.
 	 *
 	 * Only a package composer put directly under extensions/ or skins/ has a name to offer: one
-	 * that landed in vendor/ declared neither MediaWiki type, and renaming the entry would not make
-	 * it a component. A package that landed in the other of the two is a component, just not the
-	 * kind it was listed as, and the list it belongs in is the more useful half of that answer.
+	 * that landed in vendor/ declared neither MediaWiki type. A package that landed in the other of
+	 * the two is a component listed as the wrong kind.
 	 *
 	 * @param string $installPath MediaWiki's install directory ($IP).
 	 * @param string $kind 'extension' or 'skin', as the site listed it.
@@ -123,9 +118,8 @@ class ComposerInstall {
 	 * Whether a version constraint names one release and no other.
 	 *
 	 * A tarball is pinned by its sha256 and a repository by its commit; for a package the pin is an
-	 * exact version, and anything looser takes whatever the registry serves on the day. That is a
-	 * bargain a site is entitled to make -- the same one a moving `reference` makes -- so this only
-	 * decides whether the build says so.
+	 * exact version, and anything looser takes whatever the registry serves that day. That is a
+	 * bargain a site may make, so this only decides whether the build says so.
 	 *
 	 * @param string $constraint What follows the colon in "vendor/name:constraint", or "*".
 	 */

--- a/includes/ContainedPath.php
+++ b/includes/ContainedPath.php
@@ -5,22 +5,12 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * Joins a web path onto the directory it is supposed to name, or refuses it for climbing out.
  *
- * Two steps take a path out of content and look for a file at it: storeImages reads the rendered
- * HTML for $wgUploadPath references, and AssetLocalizer reads dumped CSS for url()s under /skins,
- * /resources and /extensions. Both paths come from something a site author wrote -- a page's body,
- * or MediaWiki:Common.css -- so neither is the build's own, and concatenating one onto a directory
- * hands whoever wrote it every file the build can read: the copy lands in the output directory and
- * is published with the site.
+ * Two steps take a path out of content and look for a file at it: storeImages reads rendered HTML
+ * for $wgUploadPath references, and AssetLocalizer reads dumped CSS for url()s. Both come from
+ * something a site author wrote, so concatenating one onto a directory hands them the filesystem.
  *
- * The answer is not to trust the path but to bound where it can reach, which is what this does.
- *
- * The path is judged, not where the filesystem would take it. A symlink under the root pointing out
- * of it escapes this, and is left to: neither root holds anything the author of a path put there.
- * MediaWiki writes a file's contents into the upload directory rather than a link to them, and the
- * install root is the build's own. What a source tree can bring is refused where the source tree is
- * read, by ImageImport, which can name the file it refused -- while a check here would have refused
- * the symlinked skins/ and extensions/ of a MediaWiki someone develops against, silently, which is
- * the kind of failure this class exists against.
+ * The path is judged, not where the filesystem would take it: judging the latter would refuse the
+ * symlinked skins/ of a MediaWiki someone develops against.
  */
 class ContainedPath {
 	/**

--- a/includes/FailOnCategories.php
+++ b/includes/FailOnCategories.php
@@ -5,16 +5,12 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * What a build says about a category the site asked no page to be in.
  *
- * A tracking category is how MediaWiki reports something it will not refuse to render. A template
- * used without a required argument draws its placeholder; a Lua error prints in place of the
- * module's answer; a page whose template expansion ran past its limit is silently cut short. The
- * page still builds, and a static export publishes all of it without a word -- the source is
- * valid, the build succeeds, and the rendered text quietly is not what was written.
+ * A tracking category is how MediaWiki reports something it will not refuse to render: a template
+ * used without a required argument draws its placeholder, a Lua error prints in place of the
+ * module's answer. The page still builds, and the export publishes it without a word.
  *
- * Which of those a site treats as a fault is the site's own judgement, so nothing is listed by
- * default; WikvenFailOnCategories is where a site says. The rule here is only what to do with what
- * was found, and it is the whole of it: a named category with anything in it stops the build, and
- * says which pages put it there, because the category itself is not in the export to be looked at.
+ * Which of those is a fault is the site's own judgement, so nothing is listed by default; a named
+ * category with anything in it stops the build.
  */
 class FailOnCategories {
 	/** How many pages a complaint names before it stops and counts the rest. */

--- a/includes/FetchPin.php
+++ b/includes/FetchPin.php
@@ -5,24 +5,10 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * What a fetched extension or skin was fetched from, written next to it so the next build can tell.
  *
- * A bake fetches what WikvenRepositories names, and a fetch it has already made is one it should
- * not make again: fetchExtensions skips any directory that is already there. That is right where
- * the tree came from the same source, and wrong where it did not -- move a pin to a new tag, build
- * again in a tree that survives (a bind mount, the standalone binary's own install, a container
- * that is not thrown away), and the old checkout stays, silently, with nothing on the build's
- * output to say the new pin was not what got built.
- *
- * So a fetched tree carries a line naming what fetched it, and the next build compares. Same line,
- * nothing to do; different line, the tree goes and the fetch is made again. A tree with no line at
- * all is left exactly as it was found: it is bundled in the image, or somebody put it there, and a
- * build is in no position to decide it knows better.
- *
- * A reference is not a pin, though it is written like one: `reference: main` names whatever the
- * branch points at today, and a tag can be moved. So a git fetch also records the commit it ended
- * up on, and a build that finds the source unchanged asks the remote what that reference points at
- * now -- one round trip, and only where the tree is already there -- and fetches again when the
- * answer has moved. A remote that cannot be reached is not an error: the tree that is there is
- * kept, and the build says why it could not check.
+ * fetchExtensions skips any directory already there, which is wrong where the tree came from
+ * somewhere else: move a pin to a new tag, build again in a tree that survives, and the old
+ * checkout stays. So a fetched tree carries a line naming what fetched it, and the next build
+ * compares; a tree with no line is left as found.
  */
 class FetchPin {
 	/**
@@ -40,10 +26,8 @@ class FetchPin {
 	 * What a source spec fetches, as one line: the same source is the same line.
 	 *
 	 * Keys and values rather than JSON, because the line is written into the tree it fetched and
-	 * the first thing anyone does with a file like that is read it.
-	 *
-	 * The hex pins are lowercased because the validators lowercase them and a spec may not have;
-	 * nothing else is touched, since a URL's path is the remote's to be particular about.
+	 * the first thing anyone does with a file like that is read it. The hex pins are lowercased, as
+	 * the validators lowercase them.
 	 *
 	 * @param array $spec One WikvenRepositories entry.
 	 */

--- a/includes/HeadMetadata.php
+++ b/includes/HeadMetadata.php
@@ -5,30 +5,10 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * Where in a rendered page a reference is read by something that never saw the page.
  *
- * A picture in the body and the same picture named in the head are one file and two references. The
- * body's is read by a browser that already has the page, so the copy beside it resolves, and the
- * export stays a directory anyone can move or open from disk. The head's -- an og:image, the image
- * of a schema.org block -- is read by a crawler that was handed the tag and nothing else, and a
- * path beside a page it never fetched resolves against whatever that crawler happens to be doing.
- *
- * Which of the two a reference is cannot always be read off the reference. Where this wiki stored
- * the file, the shape says it: MediaWiki hands the body File::getUrl() and metadata
- * File::getFullUrl(), so a scheme and a host arriving here is MediaWiki having already answered
- * (see UploadReference). A file a foreign repository serves is a whole URL to both, because the
- * repository is somewhere else whoever is asking -- the distinction is gone before the page is
- * written, and the only thing that still knows is where in the page the reference sits. That is
- * this.
- *
- * Two spans count. A <meta> element: everything a crawler is told about a page arrives as one, and
- * nothing rendering the page fetches its content=. A schema.org <script type="application/ld+json">
- * block: the same claims, in JSON. What is deliberately not here is the rest of the head -- a
- * stylesheet, a favicon, a preload -- which the browser fetches while rendering this page, exactly
- * as it fetches the body's pictures, and which a whole URL would pin to one host for nothing.
- *
- * Only the head is searched. A <meta> has no business outside it, and a page that talks about HTML
- * is full of text that looks like tags: MediaWiki writes that through htmlspecialchars(), so
- * "&lt;meta" could not be mistaken for a tag here anyway, but a rule that holds only because of
- * someone else's escaping is one worth not depending on.
+ * The body's pictures are read by a browser that already has the page, so a copy beside it resolves
+ * and the export stays a directory anyone can open from disk. An og:image is read by a crawler
+ * handed the tag alone. Where the shape no longer says which is which -- a foreign repository
+ * answers both whole -- where the reference sits is all that still knows.
  */
 final class HeadMetadata {
 	/** @var list<array{int, int}> Start and end offset of each span, in the page it was read from. */

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -19,16 +19,10 @@ class Adder implements
 	\MediaWiki\Hook\SidebarBeforeOutputHook,
 	\MediaWiki\Hook\SkinAddFooterLinksHook {
 	/**
-	 * Skins that move every sidebar section from the toolbox onward into their page-tools menu
-	 * (SkinVector22::extractPageToolsFromSidebar splices from the toolbox to the end), so a section
-	 * of our own lands there beside it, under a heading naming what it holds. Everywhere else the
-	 * skin list goes in the toolbox: Citizen splices the toolbox alone and Minerva reads no other
-	 * section, so a section of our own would leave their page-tools menus for the sidebar drawer,
-	 * or vanish.
-	 *
-	 * The page-tools menu is where the section is rendered, not where a reader is meant to find it:
-	 * ext.Wikven.vectorSkins moves it into the appearance menu, beside the other choices about how
-	 * a page looks. This stays as the fallback a reader without JavaScript is left with.
+	 * Skins that move every sidebar section from the toolbox onward into their page-tools menu, so
+	 * a section of our own lands there beside it. Everywhere else the skin list goes in the
+	 * toolbox, where Citizen and Minerva would not find one. ext.Wikven.vectorSkins then moves it
+	 * into the appearance menu; this is the fallback without JavaScript.
 	 */
 	private const OWN_SECTION_SKINS = ['vector-2022'];
 
@@ -45,9 +39,9 @@ class Adder implements
 	 * Offer each enabled skin's copy of this page, in the toolbox Hider has just emptied or in a
 	 * section of our own.
 	 *
-	 * Minerva is not served here. It reads no sidebar section but `navigation` and the toolbox, and
-	 * its toolbox is the page-actions menu, which is not where a site-wide setting belongs;
-	 * fillMinervaMenu.php writes the same entries into its main menu instead.
+	 * Minerva is not served here: it reads no sidebar section but `navigation` and the toolbox, and
+	 * its toolbox is the page-actions menu. fillMinervaMenu.php writes the same entries into its
+	 * main menu instead.
 	 *
 	 * @inheritDoc
 	 */
@@ -84,12 +78,10 @@ class Adder implements
 		// should look: both stop the export asking for something it does not have, which a preview
 		// has no more of than a published site does.
 		if (MW_ENTRY_POINT === 'cli' && $skin->getSkinName() === 'citizen') {
-			// Citizen registers a service worker at "$wgScriptPath/load.php" whenever the client-side
-			// script path is the wiki root (""), which is what the build installs with, and the request
-			// 404s on every page. There is no script path in a static export -- no index.php, load.php
-			// or api.php -- so say so, and the registration returns early on its own guard. Citizen is
-			// the only thing that reads the value for a decision; what else reads it builds api.php and
-			// rest.php URLs, which are dead here whichever way it is set.
+			// Citizen registers a service worker at "$wgScriptPath/load.php" whenever the client-side script
+			// path is the wiki root (""), which is what the build installs with, and the request 404s on
+			// every page. There is no script path in a static export, so say so, and the registration
+			// returns early on its own guard.
 			$out->addJsConfigVars('wgScriptPath', null);
 
 			// The skin's search shortcuts outlive the command palette the bake leaves out: skin.js
@@ -100,13 +92,10 @@ class Adder implements
 		}
 
 		// Minerva's own, and ahead of the guard for the same reason: most of what it hides is a
-		// Special: page an export has no server for, which a preview has no more of than a site.
+		// Special: page an export has no server for.
 		//
-		// A sheet of wikven's own rather than the "+skins.minerva.styles" entry under
-		// ResourceModuleSkinStyles these rules used to be, for the reason ext.Wikven.styles gives
-		// for Citizen: a second declaration of a skin's key replaces the first rather than merging,
-		// so wikven's entry and MinervaNeue's own could not both survive. Which one did came down
-		// to load order, and nothing said the other had gone.
+		// A sheet of wikven's own rather than a "+skins.minerva.styles" entry: a second declaration of a
+		// skin's key replaces the first rather than merging, so which survived came down to load order.
 		if ($skin->getSkinName() === 'minerva') {
 			$out->addModuleStyles('ext.Wikven.minervaStyles');
 		}
@@ -187,14 +176,9 @@ class Adder implements
 	/**
 	 * Ask for what Special:MobileOptions asks for, on the page the export offers in its place.
 	 *
-	 * The controls there are not the special page's markup: its script renders them from the
-	 * client preferences the page declares, which is why they can be had at all without a wiki
-	 * behind them. So the page carries the same empty form, and buildScripts.php bundles the
-	 * modules because this queued them.
-	 *
-	 * The one control not offered is "Expand all sections": clientPreferences.js draws a preference
-	 * only when the page carries its class, and no page here does, because nothing in a bake
-	 * collapses a section to begin with.
+	 * The controls there are not the special page's markup: its script renders them from the client
+	 * preferences the page declares, so the page here carries the same empty form. "Expand all
+	 * sections" is not offered, being drawn only for a page carrying its class.
 	 */
 	private function prepareSettingsPage(OutputPage $out): void {
 		$page = (string)$this->config->get('WikvenSettingsPage');
@@ -265,17 +249,9 @@ class Adder implements
 	/**
 	 * Where the footer's licenses link points.
 	 *
-	 * Root-relative like every other link the build writes, so rename.php reparents it for a
-	 * subpage along with the rest.
-	 *
-	 * Through Special:MyLanguage where Translate is loaded, which is the condition
-	 * resolveTranslationLinks.php runs on: that pass rewrites the link to the reader's own
-	 * language, or to the source page where that language has no translation. Without the prefix a
-	 * Korean reader on Licenses/ko.html would be sent to the English page, and since this link is
-	 * the site's only guaranteed route to it, there is no second way in.
-	 *
-	 * Written plainly where Translate is not loaded, because then the pass never runs and the
-	 * special page, which no export contains, would be left standing in the href.
+	 * Root-relative like every other link the build writes, and through Special:MyLanguage where
+	 * Translate is loaded, which is the condition resolveTranslationLinks.php runs on: without the
+	 * prefix a Korean reader on Licenses/ko.html would be sent to the English page.
 	 */
 	public static function licensesHref(Title $licenses, bool $translated): string {
 		$namespace = (string)$licenses->getNsText();
@@ -283,10 +259,8 @@ class Adder implements
 			return './' . OutputName::href(OutputName::of($namespace, $licenses->getDBkey()));
 		}
 		// Built as the title it stands for, rather than spelt out, so this marker and the one
-		// GetLocalURL writes for a real Special:MyLanguage link are the same string in either
-		// spelling of the file names -- which is what resolveMyLanguage() matches on. "Special" is
-		// the canonical namespace name, the one Hooks\Main::nameFor() writes whatever this wiki
-		// calls that namespace itself, so the two markers agree in the content language too.
+		// GetLocalURL writes for a real Special:MyLanguage link are the same string in either spelling
+		// of the file names, which is what resolveMyLanguage() matches on.
 		$page = Title::makeName($licenses->getNamespace(), $licenses->getDBkey());
 		return './' . OutputName::href(OutputName::of('Special', "MyLanguage/$page"));
 	}

--- a/includes/Hooks/Declarer.php
+++ b/includes/Hooks/Declarer.php
@@ -11,16 +11,11 @@ use MediaWiki\Languages\LanguageNameUtils;
  * Says what language the pages the build writes for itself are in.
  *
  * A page is in the wiki's content language unless something answers otherwise, and for a
- * translation page Translate is what answers: it takes this same hook and reads the language off
- * the end of the title. The licenses page the build writes per language has exactly that shape and
- * nobody to answer for it, so every copy went out as content-language English however Korean or
- * Khmer the text on it was.
+ * translation page Translate is what answers. The licenses page the build writes per language has
+ * that shape and nobody to answer for it, so every copy went out as English.
  *
  * Three things read that answer and all three were wrong: the "lang" attribute on <html>, the
- * :lang() rule ULS uses to pick a bundled webfont -- so Khmer headings drew in whatever the reader
- * happened to have, which on a site that bundles a Khmer font is that feature not working -- and
- * the language SifterSearch files the page under, which put it in the English index to be stemmed
- * by English rules.
+ * :lang() rule ULS uses to pick a webfont, and the language SifterSearch files the page under.
  */
 class Declarer implements PageContentLanguageHook {
 	private LanguageFactory $languageFactory;

--- a/includes/Hooks/Hider.php
+++ b/includes/Hooks/Hider.php
@@ -64,13 +64,10 @@ class Hider implements
 		// pointing at the login page, so ext.Wikven.styles still hides what it re-adds.
 		unset($links['actions']['watch'], $links['actions']['unwatch']);
 
-		// The discussion tab. A static export cannot carry a discussion -- there is nothing behind
-		// the tab to read and no way to post to it -- and MediaWiki has no setting that turns talk
-		// namespaces off (T35298), so it is dropped from the navigation every skin builds from.
-		// A `#ca-talk` rule in ext.Wikven.styles is not enough: that id is core's own on the tab,
-		// and Minerva renders the same data through a tab bar of its own that keeps no id to hide.
-		// Both menus, because a skin still asking core for the legacy `namespaces` one is rendered
-		// from that copy rather than from `associated-pages`.
+		// The discussion tab. MediaWiki has no setting that turns talk namespaces off (T35298), so it is
+		// dropped from the navigation every skin builds from. A `#ca-talk` rule is not enough: Minerva
+		// renders the same data through a tab bar that keeps no id. Both menus, because a skin asking
+		// core for the legacy `namespaces` one is rendered from that copy.
 		foreach (['associated-pages', 'namespaces'] as $menu) {
 			foreach (array_keys($links[$menu] ?? []) as $key) {
 				// 'talk' in the main namespace, '<subject>_talk' everywhere else.

--- a/includes/Hooks/Indexer.php
+++ b/includes/Hooks/Indexer.php
@@ -10,10 +10,8 @@ use MediaWiki\Title\Title;
  * What the search index is asked to leave out.
  *
  * SifterSearch declares SifterSearchIndexPageHook for this, and this does not implement it: the
- * interface is only on disk where SifterSearch is installed, and a class that implements a missing
- * one cannot be loaded at all -- not by the test suite, which installs neither. MediaWiki dispatches
- * a hook by method name regardless, so what the interface buys is a signature check, and what it
- * costs here is the class being unloadable wherever the optional dependency is absent.
+ * interface is only on disk where SifterSearch is installed, and a class implementing a missing one
+ * cannot be loaded at all. MediaWiki dispatches by method name regardless.
  *
  * @see \MediaWiki\Extension\SifterSearch\Hook\SifterSearchIndexPageHook for the signature.
  */
@@ -21,12 +19,9 @@ class Indexer {
 	/**
 	 * How the source language of a translation page is looked up.
 	 *
-	 * A seam, so the rule below can be tested without Translate: it is an optional dependency the
-	 * test suite does not install, and asking it is a static call there is otherwise no way past.
-	 * The rule is the part worth testing; the lookup is one question put to somebody else.
-	 *
-	 * Phan wants the nullable return parenthesised; without that it reads the annotation as far as
-	 * "callable(Title)", gives up on the rest, and then calls the assignment below void.
+	 * A seam, so the rule below can be tested without Translate, which the test suite does not
+	 * install. Phan wants the nullable return parenthesised, or it reads the annotation only as far
+	 * as "callable(Title)".
 	 *
 	 * @var callable(Title):(?string)
 	 */
@@ -43,16 +38,9 @@ class Indexer {
 	/**
 	 * Leave out a translation page written in the language it was translated from.
 	 *
-	 * Marking a page for translation gives it a translation page per language, the source language
-	 * included, so "Installation" and "Installation/en" carry the same English text under two
-	 * titles. Both are pages of the export and both were indexed, so an English reader searching was
-	 * offered the same thing twice (#454). Indexing per language cannot separate them, being one
-	 * language by construction, and neither can $wgSifterSearchNamespaces, both being NS_MAIN.
-	 *
-	 * The source page is the one kept. It is where the site's own links land -- resolveTranslationLinks
-	 * sends a Special:MyLanguage link from an untranslated page to the source page, and the export's
-	 * front door, index.html, is the source page of the main page -- and it is the only one of the
-	 * two that a page nobody marked for translation has at all.
+	 * A marked page gets a translation page per language, the source language included, so an
+	 * English reader was offered "Installation" and "Installation/en" both (#454). The source page
+	 * is the one kept: it is where the site's own links land, and the only one an unmarked page has.
 	 */
 	public function onSifterSearchIndexPage(Title $title, bool &$index) {
 		$sourceLanguage = ( $this->sourceLanguageOf )($title);
@@ -64,11 +52,9 @@ class Indexer {
 	/**
 	 * The language a translation page is in: the segment after its source page's title.
 	 *
-	 * Cut here rather than asked of Title::getSubpageText(), which answers with the whole title
-	 * unless subpages are switched on for the namespace -- and nothing switches them on for NS_MAIN,
-	 * where these pages live. Translate names a translation page "<source>/<language>" whatever
-	 * MediaWiki thinks a subpage is, so the last segment is the language either way, and reading it
-	 * as one is safe only because the lookup above has already said this is a translation page.
+	 * Not Title::getSubpageText(), which answers with the whole title unless subpages are on for
+	 * the namespace, and nothing turns them on for NS_MAIN. Translate names these
+	 * "<source>/<language>" whatever MediaWiki thinks a subpage is.
 	 */
 	private static function translationLanguage(Title $title): ?string {
 		$text = $title->getText();
@@ -80,9 +66,8 @@ class Indexer {
 	 * The language a translation page was translated from, or null where it is not one.
 	 *
 	 * What is asked of Translate is whether this is a translation page, not whether the title looks
-	 * like one: isTranslationPage() answers no for a subpage somebody merely named after a language,
-	 * since it checks that the page above it is marked for translation. A wiki that keeps a page of
-	 * its own called "Foo/en" therefore keeps it in the index.
+	 * like one: isTranslationPage() checks that the page above it is marked, so a wiki keeping a
+	 * page of its own called "Foo/en" keeps it in the index.
 	 */
 	private static function translateSourceLanguage(Title $title): ?string {
 		if (!ExtensionRegistry::getInstance()->isLoaded('Translate')) {

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -65,18 +65,9 @@ class Main implements
 	/**
 	 * The whole URL of the page, for a caller that asked for one.
 	 *
-	 * getFullURL() and getCanonicalURL() each run their own hook after calling getLocalURL() and
-	 * expanding the result, and each is handed the same Title this build already knows how to name.
-	 * So the answer is recomputed from that title rather than recovered from the string: which of
-	 * the three hooks ran is the only honest signal that a caller wanted an absolute URL, and core
-	 * delivers it.
-	 *
-	 * Without it they get what expand() makes of a relative link, which is not a URL at all --
-	 * "./index.html" comes back as "index.html", and a caller that prepends a scheme publishes
-	 * "http:index.html". That is what WikiSEO put in og:url on every page.
-	 *
-	 * Where the site has not said where it is published there is no address to give, so the value
-	 * is left as it was: a wrong absolute URL would be worse than an obviously relative one.
+	 * Which of the three URL hooks ran is the only honest signal that a caller wanted an absolute
+	 * URL, so the answer is recomputed from the Title rather than from what expand() made of a
+	 * relative link -- which was "http:index.html" in WikiSEO's og:url.
 	 *
 	 * @inheritDoc
 	 */
@@ -111,10 +102,8 @@ class Main implements
 	/**
 	 * A file this build wrote, named relative to the output root.
 	 *
-	 * A page links to it from beside itself, which is what makes an export work from any
-	 * directory. Its whole URL needs the address the site is published at, and where the site
-	 * has not said there is none to give: a wrong absolute URL is worse than an obviously
-	 * relative one, so a caller that asked for one is left with what it had.
+	 * A page links to it from beside itself, which is what makes an export work from any directory.
+	 * Its whole URL needs the address the site is published at, and there may be none.
 	 *
 	 * @return array{local:string,whole:?string}
 	 */
@@ -128,11 +117,8 @@ class Main implements
 	/**
 	 * Where a title points in this export, or null where the build leaves the URL alone.
 	 *
-	 * One decision for all three URL hooks, so a Commons file, a Special:Translate link and an
-	 * edit link are answered the same whether the caller wanted a relative URL or a whole one.
-	 * Both answers are worked out here rather than one derived from the other: 'local' is what a
-	 * page links to, and 'whole' the address the export is served at, null where the site has not
-	 * said where that is.
+	 * One decision for all three URL hooks, so a Commons file and an edit link are answered the
+	 * same whether the caller wanted a relative URL or a whole one.
 	 *
 	 * @param Title $title
 	 * @param string $query
@@ -179,11 +165,9 @@ class Main implements
 			}
 		}
 
-		// Vector renders the collapsed search box as a link to Special:Search -- the page the "f"
-		// accesskey opens, and at a narrow viewport the whole of the search affordance -- and the
-		// export has no such page. Where search lands here is SifterSearch's results page, so send
-		// it there instead of at a 404. SifterSearch retargets the link itself once its script
-		// runs; writing the link out right is what makes the exported page correct on its own.
+		// Vector renders the collapsed search box as a link to Special:Search, which the export has
+		// no page for; where search lands here is SifterSearch's results page. Its script retargets
+		// the link too, but writing it out right makes the page correct on its own.
 		if ($title->isSpecial('Search')) {
 			$search = $this->searchHref($query);
 			// Nowhere to land: the toggle stays the button its own script treats it as, and there
@@ -199,8 +183,8 @@ class Main implements
 		$action = $params['action'] ?? null;
 		// A diff is history too. The export holds one revision of a page, so what changed is only
 		// in the repository, and a link asking to see it belongs where the history link goes:
-		// Citizen's "last modified" button asks for the latest diff ("diff" with no value), and
-		// without this it resolves to the page it is already on.
+		// Citizen's "last modified" button asks for the latest diff, and without this it resolves
+		// to the page it is already on.
 		$wantsHistory = $action === 'history' || array_key_exists('diff', $params);
 		// For edit/history, $1 is the source filename so the link targets the editable file.
 		if ($action === 'edit' && $editUrl) {
@@ -223,18 +207,9 @@ class Main implements
 	/**
 	 * The namespace and title a link is written from.
 	 *
-	 * A page is named as this wiki names it, which is the answer rename.php gets from the content
-	 * language when it names the file, so link and file agree. A special page is named canonically
-	 * instead, because it has no file: no export contains one, so where such a link survives it is
-	 * a marker for a later pass -- Special:MyLanguage, which resolveTranslationLinks.php rewrites
-	 * to the reader's own copy of the target, and which Hooks\Adder writes by that spelling too.
-	 *
-	 * A marker has to be one string, and this wiki's own spelling is several: the namespace is
-	 * that language's word for it ("특수" on a Korean wiki), the special page answers to aliases of
-	 * its own ("내언어"), and an alias is matched however it was capitalised, so even an English wiki
-	 * writes "Special:Mylanguage/X" for a link typed that way. Written canonically, all of those
-	 * arrive as the marker that pass matches on; the special pages that are not markers name a file
-	 * no export has in either spelling, and stay the dead links they already were.
+	 * A page is named as this wiki names it. A special page is named canonically instead: it has no
+	 * file, so a surviving link is a marker for a later pass -- Special:MyLanguage -- and this
+	 * wiki's own spelling of one is several strings, not one.
 	 *
 	 * @return array{string,string} Namespace text and dbkey, as OutputName::of() takes them.
 	 */
@@ -256,10 +231,8 @@ class Main implements
 	 * Where a search goes in the export: the results page, carrying the term the link asks for
 	 * (SifterSearch's widget reads it from "?search="), or nowhere.
 	 *
-	 * With no results page named there is nowhere to land, so the link is left the button its own
-	 * script already treats it as: Vector's toggle prevents the navigation and opens the box, which
-	 * is the whole of what it is for, and a reader without scripts has no search here either way --
-	 * Pagefind answers in the browser. That beats a link to a page that answers 404.
+	 * With none named the link is left the button its own script treats it as; a reader without
+	 * scripts has no search here either way, Pagefind answering in the browser.
 	 */
 	private function searchHref(string $query): ?string {
 		$results = Search::resultsPage();
@@ -318,16 +291,9 @@ class Main implements
 	/**
 	 * Let core wire up Citizen's search box again, so SifterSearch's typeahead reaches it.
 	 *
-	 * Citizen sets SkinPageReadyConfig's "search" to false, because its own search is the command
-	 * palette rather than the box core would attach to. An export has no backend for the palette,
-	 * so rewriteScripts leaves the plain form the skin renders underneath it standing instead --
-	 * and that form is what core's wiring, and through it the Pagefind typeahead SifterSearch
-	 * substitutes, attaches to. Everything else the flag governs is the box we are keeping.
-	 *
-	 * Registered at run time rather than in extension.json because order decides this: handlers
-	 * declared there run in load order, and wikven loads before the skins do, so a handler of ours
-	 * would be overruled by Citizen's. HookContainer::register() appends after every extension and
-	 * skin handler, which is the only place a correction can sit.
+	 * Citizen sets SkinPageReadyConfig's "search" to false, its own search being the command
+	 * palette, which an export has no backend for. Registered at run time because extension.json
+	 * handlers run in load order, and wikven loads before the skins.
 	 */
 	private function restoreCitizenSearchWiring(): void {
 		if (!Search::isActive()) {
@@ -341,17 +307,9 @@ class Main implements
 	/**
 	 * Leave ULS's input methods with no field to attach to.
 	 *
-	 * ULSIMEEnabled, which WikvenSettings turns off, does not stop the request: ext.uls.interface
-	 * binds a focus handler to every text field whatever that flag says, and the flag is read
-	 * inside ext.uls.ime, which the handler has fetched from load.php by then. So the empty
-	 * selector list is what actually keeps the export quiet on the first click into a field.
-	 *
-	 * It has to be set here rather than in WikvenSettings.php, because an empty array is the one
-	 * value ExtensionRegistry does not keep: it reads as "not set", and the extension's own
-	 * default replaces it wholesale when the registry applies extension.json config.
-	 *
-	 * The key is the test for ULS: it exists because ULS's extension.json declares it, which is
-	 * also why this asks has() first -- get() throws on a key nothing has defined.
+	 * ULSIMEEnabled does not stop the request: ext.uls.interface binds a focus handler whatever it
+	 * says, and reads the flag inside ext.uls.ime. Set here because an empty array reads to
+	 * ExtensionRegistry as "not set".
 	 */
 	private function unbindUlsInputMethods(): void {
 		if (!$this->config->has('ULSImeSelectors')) {
@@ -416,18 +374,10 @@ class Main implements
 			'href' => str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $viewSourceUrl)
 		];
 
-		// Citizen draws the page actions as icon buttons and stops rendering their labels below
-		// desktop width (font-size: 0, Pagetools.less), so a tab it has no icon for is a blank box
-		// the width of its padding: nothing to read and little to hit. Its icons come from a map
-		// keyed by the names core uses, which this tab -- being ours -- is not in; what the skin
-		// does for every entry is turn an 'icon' the item carries into the markup, so the tab has
-		// to bring its own. wikiText rather than the editLock the skin gives core's "View source",
-		// because the Edit tab beside it works: a padlock would read as a permission this reader is
-		// missing rather than as a link to the file.
-		//
-		// Citizen alone, because core hands the key to whichever skin renders the page. Vector 2022
-		// suppresses icons on the tabs themselves, but not in the page-tools dropdown it copies
-		// them into, where Edit and View history next to it have none.
+		// Citizen draws page actions as icon buttons and drops their labels below desktop width
+		// (Pagetools.less), so a tab it has no icon for is a blank box; its icon map is keyed
+		// by core's names, which this tab is not among. Vector 2022 needs none: it suppresses
+		// icons on the tabs themselves.
 		if ($sktemplate->getSkinName() === 'citizen') {
 			$links['views']['wikven-viewsource']['icon'] = 'wikiText';
 		}
@@ -480,15 +430,9 @@ class Main implements
 	/**
 	 * What the head says about this document's own address, and about its translations.
 	 *
-	 * Every page is written once per skin and served at more than one address besides: a host that
-	 * answers /Development for Development.html gives the same document two of them, and nothing in
-	 * the page said which one it is. A whole canonical url settles all of it at once -- the skin
-	 * copies, the extension-less form, and any other spelling a host invents -- because it names
-	 * the one address rather than ruling the others out one at a time.
-	 *
-	 * Both a canonical url and an hreflang value have to be whole, so where the site has not said
-	 * where it is published there is no set to write and only the skin copies have anything left
-	 * to say; see duplicatedByThisSkin().
+	 * Every page is written once per skin and served at more than one address besides. A whole
+	 * canonical url settles all of that at once, and needs the address the site is published at;
+	 * without one, only the skin copies have anything to say.
 	 *
 	 * @param Title $title The page being rendered.
 	 * @param string $skin The skin rendering this copy of it.
@@ -524,10 +468,8 @@ class Main implements
 	/**
 	 * What a page can still say about its address with no whole one to give.
 	 *
-	 * A skin copy duplicates the main skin's copy of the same page, and that one is in the export
-	 * beside it, so it can be pointed at from one directory up without knowing where the site is
-	 * published. The main skin's own copy has nothing to say here: the addresses it would be
-	 * distinguishing itself from are a host's invention, and naming one needs the site's address.
+	 * A skin copy duplicates the main skin's copy, which is in the export beside it, so it can be
+	 * pointed at from one directory up. The main skin's own copy has nothing to say here.
 	 *
 	 * @return array<string,string>
 	 */
@@ -561,15 +503,9 @@ class Main implements
 	/**
 	 * The pages this document shares its content with: which one owns it, and one page per language.
 	 *
-	 * A translatable page is three or more pages. "Development" is the source, written in whatever
-	 * language its author wrote it in, and "Development/ko" is the Korean one. Translate also makes
-	 * a translation page for the source's own language -- "Development/en" -- and that page is the
-	 * source page's article again, word for word, at a second address.
-	 *
-	 * hreflang has no way to say that a language is at two addresses, so one of them has to own the
-	 * language, and it is the source page: every link in the export names it, and "/en" is reached
-	 * only from a language bar. So the source page is what "en" points at, and "/en" says the
-	 * source page is where its content really lives.
+	 * "Development", "Development/ko" and "Development/en" are three pages of one article. hreflang
+	 * cannot say a language is at two addresses, so the source page owns it: every link in the
+	 * export names it.
 	 *
 	 * @return array{owner:Title,source:Title,languages:array<string,Title>}
 	 */
@@ -614,12 +550,8 @@ class Main implements
 	/**
 	 * The licenses page's family, which is not Translate's.
 	 *
-	 * The build writes that page and a copy per language the source tree translates into, so they
-	 * are ordinary pages that Translate has never heard of -- and without this the one page on the
-	 * site that is genuinely three languages would be the one page saying nothing about them.
-	 *
-	 * LicensesPage answers which titles those are; the set of copies is read from the source tree,
-	 * so it is asked once and kept. Every page of every skin pass comes through here.
+	 * The build writes that page and a copy per translated language, so they are ordinary pages
+	 * Translate has never heard of. The set of copies is read from the source tree once.
 	 *
 	 * @return ?array{owner:Title,source:Title,languages:array<string,Title>} Null where the title
 	 *   is not part of that family.
@@ -634,11 +566,9 @@ class Main implements
 		if (LicensesPage::generatedLanguage($title, $isKnownLanguage) === null && !$title->equals($page)) {
 			return null;
 		}
-		// Only the copies that are really there. LicensesPage reads the source tree, which says
-		// which languages the site is translated into; build.php writes a copy per language it
-		// could translate the page's messages into, and without Translate that is none of them.
-		// An alternate naming a page the export does not have is a link to a 404 in every other
-		// page's head, and a set with one of those in it is a set a search engine throws away.
+		// Only the copies that are really there: build.php writes one per language it could
+		// translate the page's messages into, and without Translate that is none of them. An
+		// alternate naming a page the export does not have is a set a search engine throws away.
 		$this->licensesCopies ??= array_filter(
 			LicensesPage::generatedCopies(
 				(string)$this->config->get('WikvenSourceDirectory'),

--- a/includes/Hooks/Reporter.php
+++ b/includes/Hooks/Reporter.php
@@ -14,31 +14,10 @@ class Reporter implements \MediaWiki\Hook\SetupAfterCacheHook {
 	 *
 	 * Make a run that died of an Error say so in its exit status.
 	 *
-	 * A PHP Error -- a missing class, a TypeError, an argument count -- is a Throwable and not an
-	 * Exception, so it goes past MaintenanceRunner's catch and reaches MWExceptionHandler, whose
-	 * guard against a script claiming success is a register_shutdown_function() that exits 255.
-	 * That one route is the one the standalone binary loses, and only that: embedded FrankenPHP
-	 * reads the status out of the engine and runs the shutdown functions after, so a status set
-	 * from one is set too late to be read rather than refused. Three lines of PHP measure it,
-	 * exit(7) at the top of a file giving 7 under the binary and the same exit(7) from a shutdown
-	 * function giving 0.
-	 *
-	 * So this closes the gap where it opens, with the same 255 said from the exception handler
-	 * itself, which is early enough. It costs nothing under a real PHP binary, where both routes
-	 * already answer 255.
-	 *
-	 * It matters because the binary re-invokes itself for every step of a build through that path
-	 * -- embedded FrankenPHP leaves PHP_BINARY empty, so a step runs as `<self> php-cli` -- and a
-	 * step that died of an Error hands back 0. Measured on a bake with an Error thrown right after
-	 * runJobs: the binary printed the backtrace, wrote no page at all, and finished with
-	 * "wikven: done" and exit 0. SkinPass covers a skin pass that dies halfway through rendering;
-	 * every other step of a build is this.
-	 *
-	 * Installed here rather than in WikvenSettings.php because installHandler() runs in Setup.php
-	 * after LocalSettings.php and would replace anything put there. This hook is the first thing
-	 * wikven runs after it, and the window it leaves is not one to worry about: with no handler
-	 * installed yet, an Error before this point ends the run through PHP's own fatal path, which
-	 * says 255 under either runtime.
+	 * An Error goes past MaintenanceRunner's catch to MWExceptionHandler, whose guard is a shutdown
+	 * function exiting 255 -- which the standalone binary reads the status too early to see, so a
+	 * build step that died handed back 0. Installed from a hook because core's installHandler()
+	 * runs after LocalSettings.php.
 	 */
 	public function onSetupAfterCache(): void {
 		self::install(MW_ENTRY_POINT, defined('MW_PHPUNIT_TEST'), 'set_exception_handler');
@@ -47,10 +26,8 @@ class Reporter implements \MediaWiki\Hook\SetupAfterCacheHook {
 	/**
 	 * Put the handler in front of core's, where this is a run whose status is worth correcting.
 	 *
-	 * What is handed to $set is the one thing here no test reaches: a test can watch that a
-	 * handler was installed and can drive handler() directly, but calling the installed one means
-	 * calling core's reporter and then a real exit. A bake with an Error thrown into it is what
-	 * covers this line.
+	 * What is handed to $set is the one thing here no test reaches: calling the installed handler
+	 * means calling core's reporter and then a real exit.
 	 *
 	 * @param string $entryPoint MW_ENTRY_POINT, naming what kind of run this is.
 	 * @param bool $underTest Whether PHPUnit is running, which owns the handler while it is.

--- a/includes/Hooks/Retrier.php
+++ b/includes/Hooks/Retrier.php
@@ -25,9 +25,8 @@ class Retrier implements \MediaWiki\Hook\SetupAfterCacheHook {
 	 *
 	 * Let a remote file repository retry a request instead of treating the first failure as final;
 	 * see RetryingForeignRepo for why one failed request is otherwise fatal. Core fills in the rest
-	 * of each repository's settings (its directory and backend, and the InstantCommons entry
-	 * itself) in SetupDynamicConfig.php, which runs after LocalSettings.php, so the class is
-	 * swapped here rather than the repository being declared with it in the first place.
+	 * of each repository's settings in SetupDynamicConfig.php, which runs after LocalSettings.php,
+	 * so the class is swapped here rather than declared with the repository.
 	 */
 	public function onSetupAfterCache(): void {
 		// The read goes through the service and the write cannot: Config is read-only, and what

--- a/includes/Hooks/Versioner.php
+++ b/includes/Hooks/Versioner.php
@@ -10,14 +10,11 @@ use MediaWiki\Registration\ExtensionRegistry;
 /**
  * Serves {{WIKVENVERSION}}: the version of the Wikven that is building this page.
  *
- * A site saying which Wikven built it had to write the number by hand and remember to change it,
- * and the documentation had the same problem in a worse place -- it tells readers which tag to pin
- * an action to, so a stale number there is a workflow that does not resolve. A variable is read at
- * build time and is right by construction; release-please already keeps extension.json's version
- * in step with the tag it cuts.
+ * A site saying which Wikven built it had to write the number by hand, and the documentation had
+ * the same problem in a worse place -- it tells readers which tag to pin an action to, so a stale
+ * number there is a workflow that does not resolve. A variable is right by construction.
  *
- * MediaWiki's own {{CURRENTVERSION}} answers for MediaWiki. This answers for what wrote the site,
- * which is the other half of the question and the half a wikven site is likelier to be asked.
+ * MediaWiki's own {{CURRENTVERSION}} answers for MediaWiki; this answers for what wrote the site.
  */
 class Versioner implements GetMagicVariableIDsHook, ParserGetVariableValueSwitchHook {
 	private const VARIABLE = 'wikvenversion';

--- a/includes/ImageImport.php
+++ b/includes/ImageImport.php
@@ -14,17 +14,10 @@ class ImageImport {
 	/**
 	 * The files core's importer will consider, found the way importImages.php finds them.
 	 *
-	 * Subdirectories included, because pages are read from them too: a source tree where
-	 * "Guide/Setup.wikitext" is the page "Guide/Setup" is one where "Guide/diagram.png" is the
-	 * image that page embeds, and reading one and not the other left the page with a red link and
-	 * the build with nothing to say about it. Matches on the extension without regard to case.
-	 *
-	 * Walks exactly what core's importImages walks, symlinked directories included, because the
-	 * point of this list is to be the same files core is about to import. It refused to follow a
-	 * linked directory once, which sounds safer and was not: core follows one (its findFiles tests
-	 * is_dir, which a link to a directory satisfies), so every file under it was imported while
-	 * this list -- and therefore outside(), collisions() and failed() -- could not see any of them.
-	 * Where a walk stops is not where to answer a symlink; outside() is.
+	 * Subdirectories included, because pages are read from them too, and matched on the extension
+	 * without regard to case. Symlinked directories are followed because core's findFiles tests
+	 * is_dir, which a link satisfies: refusing to follow one left every file under it imported and
+	 * invisible to outside(), collisions() and failed().
 	 *
 	 * @param string $directory Source directory, without a trailing slash.
 	 * @param string[] $extensions Allowed extensions, as $wgFileExtensions holds them.
@@ -58,19 +51,9 @@ class ImageImport {
 	/**
 	 * Files that would import as the same page, keyed by the name they would share.
 	 *
-	 * A File: title is the file's name and nothing else -- core takes wfBaseName($file) and makes
-	 * the title from that -- so two images with one name in two directories are one page. The
-	 * importer takes the first and skips the second, the name being taken, with a line among
-	 * thousands; whichever page embedded the second then shows the other one's picture. Reading
-	 * subdirectories is what makes this reachable, so it is answered where it becomes reachable.
-	 *
-	 * The name a file claims is the name after core normalises it, not the name on disk: a title
-	 * collapses every run of space, underscore and the other whitespace it knows to one underscore
-	 * and trims those off the ends, so "Bakery oven.png" and "Bakery_oven.png" are one page and
-	 * comparing the two strings would have said they were two. Case is left alone: default.yml sets
-	 * CapitalLinks to false -- the entry page is the lowercase "index" -- so "diagram.png" and
-	 * "Diagram.png" really are two titles here, and reporting them would fail a build that is fine.
-	 * A site that turns CapitalLinks back on makes that pair one page again, and this will not say so.
+	 * A File: title is wfBaseName($file) and nothing else, so two images with one name in two
+	 * directories are one page: the importer takes the first and skips the second. The name
+	 * compared is the one core normalises to; case is left alone, CapitalLinks being off.
 	 *
 	 * @param string[] $sources Absolute paths, as sources() returns them.
 	 * @return array<string, string[]> Shared name => the paths that claim it, two or more of them.
@@ -92,11 +75,8 @@ class ImageImport {
 	/**
 	 * The File: page a file of this name imports as, as far as two of them being one page goes.
 	 *
-	 * MediaWiki\Title\TitleParser does this to every title it makes: runs of space, underscore and
-	 * the space-like characters listed here collapse to a single underscore, and those are trimmed
-	 * off both ends. Kept to that one rule -- the parser also normalises Unicode and rejects titles
-	 * outright, neither of which changes whether two files answer to one name often enough to carry
-	 * a copy of core's parser in here.
+	 * TitleParser does this to every title: runs of space, underscore and the space-like characters
+	 * listed here collapse to one underscore and are trimmed off both ends. Kept to that one rule.
 	 *
 	 * @param string $name A file's base name.
 	 * @return string The name two files have to share to be one page.
@@ -114,21 +94,9 @@ class ImageImport {
 	/**
 	 * Files among $sources that are not really in the source tree, which is not a thing to import.
 	 *
-	 * is_file() follows a link and so does the walk, so a source tree can offer one named
-	 * picture.png, or a whole linked directory of them, and have the build upload whatever is on the
-	 * other side -- files outside the tree, on the machine doing the building, published with the
-	 * site. A tree of wiki content has no use for one, so rather than resolve them they are refused,
-	 * by name, where the tree is read.
-	 *
-	 * Asked of the resolved path rather than of each entry, because the file at the end is what gets
-	 * uploaded: a link to a file and a real file under a linked directory both leave the tree, and
-	 * only one of the two is itself a link. A name that resolves to nothing -- a link with nothing on
-	 * the other side -- is refused here too, since containment cannot be shown for it.
-	 *
-	 * This is where wikven answers symlinks at all. ContainedPath, which bounds the paths that come
-	 * back out of rendered pages, does not: the directories it bounds hold nothing an author put
-	 * there, and a check in it would silently refuse the symlinked skins/ of a MediaWiki checkout
-	 * somebody develops against.
+	 * is_file() follows a link and so does the walk, so a source tree could have the build upload
+	 * whatever is on the other side. Asked of the resolved path, the file at the end being what
+	 * gets uploaded.
 	 *
 	 * @param string $directory Source directory, as sources() was given it.
 	 * @param string[] $sources Absolute paths, as sources() returns them.

--- a/includes/LazyModules.php
+++ b/includes/LazyModules.php
@@ -6,26 +6,11 @@ namespace MediaWiki\Extension\Wikven;
  * The modules MediaWiki loads by looking at a rendered page, decided here instead of in a browser.
  *
  * Core queues most of a page's JavaScript while rendering it, and the build reads that queue out of
- * the HTML. Two features are not queued. mediawiki.page.ready waits until the page is in a browser,
- * searches the DOM, and asks load.php for what it finds:
+ * the HTML. Two are not: mediawiki.page.ready waits until the page is in a browser, looks for
+ * .mw-collapsible and table.sortable, and asks load.php for what it finds.
  *
- *     if ( config.collapsible ) {
- *         $collapsible = $content.find( '.mw-collapsible' );
- *         if ( $collapsible.length ) { modules.push( 'jquery.makeCollapsible' ); }
- *     }
- *     if ( config.sortable ) {
- *         $sortable = $content.find( 'table.sortable' );
- *         if ( $sortable.length ) { modules.push( 'jquery.tablesorter' ); }
- *     }
- *     if ( modules.length ) { mw.loader.using( modules ).then( ... ); }
- *
- * An export has no load.php, so that request fails and the feature is silently absent: no toggle on
- * a collapsible, no sorting on a sortable table, and content marked mw-collapsed shown rather than
- * hidden (#483). Nothing else about the page is wrong, which is what makes it easy to miss.
- *
- * The decision itself is kept: same flags, same selectors, same "only if the page has one". Only its
- * timing moves, from the browser to the build, because that is the one thing a static site cannot
- * do the way MediaWiki does. Whatever core adds to that list next is another line in MODULES.
+ * An export has no load.php, so the feature is silently absent (#483). The decision itself is kept;
+ * only its timing moves.
  */
 class LazyModules {
 	/**
@@ -59,10 +44,8 @@ class LazyModules {
 	/**
 	 * Whether the HTML carries an element with this class, optionally only on one tag.
 	 *
-	 * Read off the markup rather than parsed, because the caller has one string per page and a DOM
-	 * for each would cost more than the question is worth. The class is matched as a whole token, so
-	 * "mw-collapsible" does not answer for "mw-collapsible-content" -- the toggle and content
-	 * wrappers core generates carry names that a substring match would take for the thing itself.
+	 * Read off the markup rather than parsed, the caller having one string per page. The class is
+	 * matched as a whole token, so "mw-collapsible" does not answer for "mw-collapsible-content".
 	 *
 	 * @param string $html
 	 * @param string $class The class to look for.

--- a/includes/LicensesPage.php
+++ b/includes/LicensesPage.php
@@ -29,10 +29,9 @@ class LicensesPage {
 	/**
 	 * The language a title is a generated copy in, or null where it is not one.
 	 *
-	 * Generated is the whole of it. The build writes copies only where it wrote the page itself --
-	 * a site that provides its own is left alone, subpages and all -- so a subpage under a page the
-	 * source tree provides belongs to the site, or to Translate, and this must not answer for it.
-	 * The source tree is what says which, and it is the same answer in every pass.
+	 * Generated is the whole of it. The build writes copies only where it wrote the page itself, so
+	 * a subpage under a page the source tree provides belongs to the site, or to Translate, and
+	 * this must not answer for it.
 	 *
 	 * @param Title $title
 	 * @param callable(string):bool $isKnownLanguage
@@ -67,9 +66,7 @@ class LicensesPage {
 	 *
 	 * The languages are the ones the source tree carries translations in, because those are the
 	 * ones build.php writes a copy for. Which of those copies are the build's own is the question
-	 * above, asked once per language: a site that provides its own page, or its own copy in one
-	 * language, keeps it, and a caller that re-rendered it would be dressing someone else's page in
-	 * a language nobody asked for.
+	 * above, asked once per language.
 	 *
 	 * @param string $sourceDir
 	 * @param callable(string):bool $isKnownLanguage

--- a/includes/ModuleRenderer.php
+++ b/includes/ModuleRenderer.php
@@ -16,19 +16,10 @@ class ModuleRenderer {
 	/**
 	 * Render the modules named by $context and return the response body.
 	 *
-	 * ResourceLoader::respond() is load.php's web entry point: before echoing the module body it
-	 * calls sendResponseHeaders(), which emits Content-Type, ETag, Cache-Control and Expires with
-	 * header() (and, for an image request, Image::sendResponseHeaders()). The build drives it from
-	 * CLI maintenance scripts that have already written to stdout, so headers_sent() is true and
-	 * every one of those header() calls raises "Cannot modify header information - headers already
-	 * sent", hundreds of times per bake. Output buffering cannot help: ob_start() does not un-send
-	 * headers, which is why the ob_start()/ob_get_clean() pairs that used to wrap respond() here
-	 * captured the body but not the warnings.
-	 *
-	 * makeModuleResponse() is the same body generation without the response wrapper -- it is what
-	 * core itself calls to embed a module in HTML (ClientHtml::makeLoad()). This method adds back
-	 * the parts of respond() that shape the body rather than the response: splitting the requested
-	 * names into registered modules and missing ones, and preloading module info.
+	 * ResourceLoader::respond() sends response headers before the body, and the build drives it from
+	 * CLI scripts that have already written to stdout, so each header() call raises "headers already
+	 * sent". makeModuleResponse() is the same body generation without that wrapper; this adds back
+	 * the parts of respond() that shape the body.
 	 *
 	 * @param ResourceLoader $rl
 	 * @param Context $context Modules, language, skin and 'only' mode to render.
@@ -114,12 +105,9 @@ class ModuleRenderer {
 	/**
 	 * The comment respond() would have prefixed for modules that are not registered.
 	 *
-	 * A response that carries scripts reports them to the client itself, as a "missing" load state
-	 * built by makeModuleResponse(); one that does not (a styles response) can only say so in a
-	 * comment, and respond() is what prepends it. Nothing in the build asks for an unregistered
-	 * module -- the CSS files buildStyles renders are only created for modules ResourceLoader
-	 * knows (Hooks\Main::addStyleToList()) -- so this exists to keep a broken build's output what
-	 * it always was, rather than to be read.
+	 * A response carrying scripts reports them to the client itself, as a "missing" load state; one
+	 * that does not can only say so in a comment. Nothing in the build asks for an unregistered
+	 * module, so this exists to keep a broken build's output what it always was.
 	 *
 	 * @param Context $context
 	 * @param string[] $missing Requested module names that are not registered.

--- a/includes/OutputName.php
+++ b/includes/OutputName.php
@@ -5,55 +5,39 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * What a page is called in the output, and what a link has to say to reach it.
  *
- * These are two questions and they had two answers, which is how they came to disagree. The build
- * writes each page through MediaWiki's file cache, which names a file by url-encoding "ns<N>:<dbkey>"
- * and escaping the dots; rename.php then puts a readable namespace back and restores the dots and
- * the subpage slashes. Every link, meanwhile, was written from the title as MediaWiki spells it. For
- * a title made of letters the two agree by luck. For "Vector (skin)" one said Vector_%28skin%29.html
- * and the other said Vector_(skin).html, and the reader got a 404 out of a build that exited 0.
+ * The two disagreed: the file cache named "Vector_%28skin%29.html" while links were written from
+ * the title as "Vector_(skin).html", and a build that exited 0 gave the reader a 404. A static
+ * server url-decodes the path it asks for, so a link is not an escaped name but the url-encoding
+ * of one:
  *
- * The 404 is not the whole of it. A static server url-decodes the path it is asked for, so a link
- * saying "Vector_%28skin%29.html" asks for the file "Vector_(skin).html" -- the percent-escapes in a
- * link are not a way of naming a file that has percent signs in it. A file really called
- * "Vector_%28skin%29.html" is reachable only at "Vector_%2528skin%2529.html". So a name and a link
- * cannot simply be made to match by escaping the link; the link is the *url-encoding of the name*,
- * and that is the relationship this class keeps:
- *
- *     file  = the page's name on disk, in whichever spelling the site asked for
- *     href  = href(file), which is the only string that reaches it
- *
- * Everything that writes a link calls href(); rename.php and the passes that read the output call
- * the name side. One rule, asked in two directions, instead of two rules that agreed by accident.
+ *     file  = the page's name on disk, in the spelling the site asked for
+ *     href  = href(file), the only string that reaches it
  */
 class OutputName {
 	/**
 	 * Names as the titles are written: "Vector_(skin).html", "File:Bakery_oven.jpg.html".
 	 *
 	 * The prettiest urls, and what this documentation site is published under. Windows cannot hold
-	 * a file whose name has a colon in it, so a site whose output directory is a Windows filesystem
-	 * -- a bind mount from Docker Desktop, say -- cannot write a page outside the main namespace
-	 * this way, and wants ENCODED instead.
+	 * a colon in a file name, so a site whose output directory is a Windows filesystem -- a bind
+	 * mount from Docker Desktop, say -- wants ENCODED instead.
 	 */
 	public const READABLE = 'readable';
 
 	/**
 	 * Names with every escape the file cache made left in place: "File%3ABakery_oven.jpg.html".
 	 *
-	 * Nothing but letters, digits, "%", ".", "-", "_" and the "/" of a subpage, so any filesystem
-	 * can hold it. The cost is in the urls, which carry that "%" doubled: the link to that page
-	 * reads "./File%253ABakery_oven.jpg.html", for the reason the class comment gives.
+	 * Nothing but letters, digits, "%", ".", "-", "_" and a subpage "/", so any filesystem can
+	 * hold it. The cost is in the urls, which carry that "%" doubled:
+	 * "./File%253ABakery_oven.jpg.html".
 	 */
 	public const ENCODED = 'encoded';
 
 	/**
 	 * The escapes a readable name keeps: " * ? \ -- and only those.
 	 *
-	 * These are the characters MediaWiki lets a title carry ($wgLegalTitleChars) that a Windows
-	 * path cannot, other than the two that are answered elsewhere: ":", which READABLE keeps and
-	 * ENCODED exists to escape, and "/", which is a subpage separator and becomes a real directory
-	 * either way. Keeping them escaped costs nothing legible -- a page called "What?" is rare, and
-	 * "What%3F.html" is still a name a person can read -- and it saves the sites that never have
-	 * one from needing ENCODED at all.
+	 * The characters $wgLegalTitleChars allows that a Windows path cannot, other than ":", which
+	 * ENCODED exists to escape, and "/", which becomes a real directory either way. A page called
+	 * "What?" is rare, and "What%3F.html" still reads.
 	 */
 	private const KEPT = ['%22', '%2A', '%3F', '%5C'];
 
@@ -87,18 +71,17 @@ class OutputName {
 	 */
 	public static function of(string $namespaceText, string $dbkey, ?string $scheme = null): string {
 		// urlencode is the file cache's own escaping, so this asks the same question rename.php
-		// answers from the other side and the two cannot drift apart. The extension is the cache's
-		// too -- HTMLFileCache writes .html -- and is added here so both directions hand back a
-		// whole file name rather than one of them expecting a caller to finish it.
+		// answers from the other side. The ".html" is the cache's too, so both directions hand
+		// back a whole file name.
 		return self::assemble($namespaceText, urlencode($dbkey), $scheme ?? self::current()) . '.html';
 	}
 
 	/**
 	 * The same file, worked out from the name the file cache gave it.
 	 *
-	 * rename.php reads the cache directory and has no titles to hand, only "ns6%3ABakery_oven%2Ejpg.html";
-	 * fillMinervaMenu.php walks the same directory before that pass has run. A name with no "ns<N>%3A"
-	 * prefix was not written by the cache -- it is left exactly as it is.
+	 * rename.php reads the cache directory with no titles to hand; fillMinervaMenu.php walks it
+	 * before that pass has run. A name with no "ns<N>%3A" prefix was not written by the cache and
+	 * is left exactly as it is.
 	 *
 	 * @param string $cacheName A base name, e.g. "ns6%3ABakery_oven%2Ejpg.html".
 	 * @param callable(int):string $namespaceText Namespace number to its text in the content language.
@@ -118,14 +101,9 @@ class OutputName {
 	/**
 	 * The link that reaches a file, which is that file's name url-encoded.
 	 *
-	 * Only three characters are escaped, because only three cannot stand in the path of a url: "%",
-	 * which would otherwise be read as the start of an escape and turn the name into a different
-	 * one; "?", which would start a query string; and "#", which would start a fragment. Everything
-	 * else a name here can hold -- "(", "&", "+", ":", a Korean syllable -- is a character a path
-	 * may carry as it is, and escaping it would only make the url harder to read.
-	 *
-	 * "%" is escaped first and its own "%25" is not escaped again, which is what makes a kept "%3F"
-	 * come out as "%253F" and reach the file that is really called "What%3F.html".
+	 * Only "%", "?" and "#" are escaped: they would otherwise start an escape, a query and a
+	 * fragment, and everything else a name can hold is already a path character. "%" goes first,
+	 * and its own "%25" is not escaped again, so a kept "%3F" comes out as "%253F".
 	 */
 	public static function href(string $file): string {
 		return str_replace(['%', '?', '#'], ['%25', '%3F', '%23'], $file);
@@ -134,9 +112,8 @@ class OutputName {
 	/**
 	 * The file a link reaches: href() read backwards.
 	 *
-	 * The passes that resolve links have to look for the file a link names, and a link is not that
-	 * name. "%3F" and "%23" are undone before "%25" so that a "%253F" -- a link to a file whose own
-	 * name has "%3F" in it -- comes back as "%3F" rather than as "?".
+	 * "%3F" and "%23" are undone before "%25", so a "%253F" -- a link to a file whose own name has
+	 * "%3F" in it -- comes back as "%3F" rather than as "?".
 	 */
 	public static function file(string $href): string {
 		return str_replace('%25', '%', str_replace(['%3F', '%23'], ['?', '#'], $href));
@@ -145,11 +122,9 @@ class OutputName {
 	/**
 	 * A namespace and an already-escaped body, in the site's spelling.
 	 *
-	 * The namespace is escaped here rather than handed in escaped, because it arrives as the
-	 * content language spells it and the body arrives as the file cache left it. Both then go
-	 * through one spelling, which is what keeps a name in a namespace whose own text is not plain
-	 * letters -- "도움말", "MediaWiki・トーク" -- from coming out half escaped and half not under
-	 * ENCODED, where the body's own bytes are escaped and the namespace's were not.
+	 * The namespace arrives as the content language spells it and the body as the file cache left
+	 * it, so both go through one spelling here. That is what keeps a namespace whose own text is
+	 * not plain letters -- "도움말", "MediaWiki・トーク" -- from coming out half escaped under ENCODED.
 	 */
 	private static function assemble(string $namespaceText, string $body, string $scheme): string {
 		$body = self::spell($body, $scheme);
@@ -163,11 +138,9 @@ class OutputName {
 	/**
 	 * One escaped string, written as the site spells it.
 	 *
-	 * Two escapes are undone in both spellings. "%2E" is the file cache's own doing -- it escapes
-	 * every dot to keep an extension from being mistaken for the file's -- and a name with no dot in
-	 * it cannot end in ".html". "%2F" is the subpage separator, and a subpage is exported into a
-	 * real directory, so it has to be a real slash before anything counts the depth. A readable name
-	 * then gives up the rest of its escaping too, but for KEPT.
+	 * Two escapes are undone either way: "%2E", the cache escaping every dot, without which a name
+	 * cannot end in ".html", and "%2F", the subpage separator, exported as a real directory. A
+	 * readable name gives up the rest too, but for KEPT.
 	 */
 	private static function spell(string $escaped, string $scheme): string {
 		$escaped = str_replace(['%2E', '%2F'], ['.', '/'], $escaped);

--- a/includes/PageTranslation/StalenessComputer.php
+++ b/includes/PageTranslation/StalenessComputer.php
@@ -7,15 +7,12 @@ use InvalidArgumentException;
 /**
  * Unit-level staleness of a translation against its source page.
  *
- * Both the source (a <translate>-marked page) and each translation carry the same
- * <!--T:n--> unit markers; a translation marker also records the source unit hash it
- * was synced to (<!--T:n @<hash>-->). A translation unit is stale when the current
- * source unit no longer hashes to that stamp. This is pure string work, shared by the
- * CI check and the build-time materialize step, so both judge staleness identically.
+ * Both the source and each translation carry the same <!--T:n--> unit markers; a translation
+ * marker also records the source unit hash it was synced to (<!--T:n @<hash>-->), and the unit is
+ * stale when the current source no longer hashes to that stamp. Pure string work, shared by the
+ * CI check and the build-time materialize step.
  *
- * A page's title is a unit too, under the reserved id "title": it behaves like every other unit
- * except that its source text is the page's own title rather than a span of the wikitext, so the
- * callers that know which page they are looking at pass that title in.
+ * A page's title is a unit too, under the reserved id "title", whose source text callers pass in.
  */
 class StalenessComputer {
 	public const OK = 'ok';
@@ -27,14 +24,9 @@ class StalenessComputer {
 	 * Reserved unit id for a page's translated title, wikven's spelling of Translate's own
 	 * "Page display title" unit.
 	 *
-	 * Like Translate's, this unit is not part of the page contents: its source text is the page's
-	 * own title, which the source wikitext never repeats, so it exists only in a translation file
-	 * ("<!--T:title @<hash>-->" followed by the translated title).
-	 *
-	 * mark() only ever hands out numbers, so the tooling never produces this id; the unit scan does
-	 * accept it, though, so a source page could still carry a hand-written "<!--T:title-->". That
-	 * unit would collide with the page title and be lost, so sourceUnits() rejects it outright and
-	 * usesReservedId() lets the check report it.
+	 * Its source text is the page's own title, which the source wikitext never repeats, so it
+	 * exists only in a translation file. The unit scan accepts this id, so sourceUnits() rejects a
+	 * hand-written one and usesReservedId() reports it.
 	 */
 	public const TITLE_UNIT_ID = 'title';
 
@@ -83,8 +75,7 @@ class StalenessComputer {
 	 * Assign <!--T:n--> markers to the still-unmarked units inside a page's <translate> blocks.
 	 *
 	 * Units are the blank-line-separated blocks Translate segments on; an already-marked unit keeps
-	 * its number and new ones continue from the highest on the page. The marker goes on its own line
-	 * before the unit, which both the unit scan and Translate's own re-parse honour. Idempotent.
+	 * its number and new ones continue from the highest on the page. Idempotent.
 	 *
 	 * @param string $text
 	 * @param string[] $translations The page's existing translations, whose own markers say which
@@ -152,8 +143,7 @@ class StalenessComputer {
 	 *
 	 * This is what tells a translation from a page that merely sits where one would: a translation
 	 * is written unit by unit against a marked source and carries that source's numbers, and
-	 * nothing else in a source tree has a reason to. scaffold() writes them for a new one, so every
-	 * translation made the documented way has them from the moment it is created.
+	 * scaffold() writes them for a new one.
 	 *
 	 * @param string $text A page's wikitext.
 	 */
@@ -164,20 +154,9 @@ class StalenessComputer {
 	/**
 	 * Where a translation carries a <translate> tag, which belongs to the source page alone.
 	 *
-	 * A translation file is a list of units and nothing else: translationUnits() runs each unit
-	 * from its own marker to the next, so anything between two markers becomes part of the unit
-	 * before it. A </translate> written into a translation is therefore not ignored -- it is
-	 * appended to a unit's translated text, and Translate does not use a unit that arrives looking
-	 * like that. It falls back to the source language instead, which is a translation silently not
-	 * shown: nothing 404s, nothing is stale, and the paragraph is simply in English.
-	 *
-	 * That shipped. docs/Skins/ko.wikitext carried the tags around two code blocks it had copied
-	 * from its source page, and two paragraphs of the published Korean page were in English from
-	 * the day it was written until #674, with every gate green.
-	 *
-	 * Armoured nowiki is masked first, exactly as blockRanges() and Translate itself read a page: a
-	 * translation writing about the tag inside <nowiki> is documenting it rather than carrying it,
-	 * and four units of this project's own Korean do that.
+	 * A translation file is a list of units and nothing else: a </translate> written into one is
+	 * appended to that unit's translated text, and Translate falls back to the source language
+	 * rather than use it. docs/Skins/ko.wikitext shipped that way until #674.
 	 *
 	 * @param string $translationText A translation file's wikitext.
 	 * @return list<int> The 1-based line of each tag, in the order they appear.
@@ -204,12 +183,8 @@ class StalenessComputer {
 	 * Whether scaffold() may write over what is already at a translation's path.
 	 *
 	 * A file named for a language that carries no unit marker is a page of its own -- "API/id" is
-	 * about identifiers, not Indonesian -- and that is what every other reader here takes it for.
-	 * Appending markers to one would answer that question the other way behind its author's back:
-	 * the page would become a translation of its parent and go missing from the site with nothing
-	 * said. So it is left alone and reported, rather than scaffolded into.
-	 *
-	 * Nothing there at all, or a file holding only whitespace, is nobody's page and is written to.
+	 * about identifiers, not Indonesian. Appending markers to one would make it a translation of
+	 * its parent and lose it from the site, so it is left alone and reported.
 	 *
 	 * @param ?string $existing What is at the translation's path, or null when nothing is.
 	 */
@@ -255,10 +230,9 @@ class StalenessComputer {
 	/**
 	 * Split a source page into units keyed by their <!--T:n--> marker id.
 	 *
-	 * A source page is Translate's format, so it is read Translate's way round: cut each <translate>
-	 * block into units first, then find the marker inside one. Scanning for markers first and cutting
-	 * between them would put the marker at a unit's edge, which is only where parseUnit() finds it
-	 * when the unit is written in the ordinary form.
+	 * Read Translate's way round: cut each <translate> block into units first, then find the marker
+	 * inside one. Scanning for markers first would put the marker at a unit's edge, which is only
+	 * where parseUnit() finds it in the ordinary form.
 	 *
 	 * @return array<string,array{hash:?string,text:string}> id => [null, unit text]
 	 */
@@ -291,8 +265,8 @@ class StalenessComputer {
 	 * Every unit a translation of this page owes: the page-title unit, when the page has a
 	 * translatable title, followed by the <!--T:n--> units of its wikitext.
 	 *
-	 * The title unit comes first, as it does in Translate, and carries the page title as its source
-	 * text, so renaming the page restamps to a different hash and the translated title goes stale.
+	 * The title unit comes first, as in Translate, and carries the page title as its source text,
+	 * so renaming the page restamps to a different hash and the translated title goes stale.
 	 *
 	 * @param string $sourceText
 	 * @param ?string $pageTitle The page's own title, or null for a page with no translatable title.
@@ -415,9 +389,8 @@ class StalenessComputer {
 	 * Byte ranges of the <translate> block contents in a source page, each as [start, endExclusive].
 	 *
 	 * Translate armours <nowiki> before it looks for a block, so a whole pair shown in one is
-	 * invisible to it; blanking the span with a same-length filler keeps every offset the page's own.
-	 * A <nowiki> merely inside a block still yields its markers, because Translate unarmours a block's
-	 * contents before segmenting them.
+	 * invisible to it; blanking the span with a same-length filler keeps every offset the page's
+	 * own. A <nowiki> merely inside a block still yields its markers.
 	 *
 	 * @return list<array{int,int}>
 	 */
@@ -444,17 +417,8 @@ class StalenessComputer {
 	 * Byte ranges of the verbatim spans in a page, each as [start, endExclusive].
 	 *
 	 * A self-contained regex rather than MediaWiki's tag extractor, so this class stays pure string
-	 * work usable outside a MediaWiki bootstrap; it recognises paired and self-closing forms with
-	 * optional attributes, in any letter case, which is all the docs pages use.
-	 *
-	 * An unclosed verbatim tag runs to the end of the page, matching how MediaWiki renders it. That
-	 * is the safer reading: the alternative -- treating the span as absent -- would hand the rest of
-	 * the page back to the marker scan, turning example text into counted units. But an HTML comment
-	 * is inert to MediaWiki's parser, so a tag name it merely mentions -- e.g. "<!-- don't wrap this
-	 * in <nowiki> -->" -- must not seed a span in the first place: read as a real opener, that "runs
-	 * to the end of the page" rule would swallow every marker after it. Scanning match by match,
-	 * instead of in one preg_match_all pass, lets a match like that be skipped in place, so a genuine
-	 * span later in the page is still found.
+	 * work. An unclosed tag runs to the end of the page, as MediaWiki renders it; but a tag name an
+	 * HTML comment merely mentions must not seed a span. Hence match by match.
 	 *
 	 * @return list<array{int,int}>
 	 */

--- a/includes/PageTranslation/TranslationAdvice.php
+++ b/includes/PageTranslation/TranslationAdvice.php
@@ -5,19 +5,13 @@ namespace MediaWiki\Extension\Wikven\PageTranslation;
 /**
  * What `translate check` found, written for the person who wrote the translation.
  *
- * The check's own output is GitHub Actions annotations: one line per finding, on the file it
- * belongs to, which is the right shape for someone reading a diff and the wrong one for someone
- * meeting this workflow for the first time. An annotation says "Stale translation unit T:3 (ko)";
- * it does not say that a stamp is what makes a unit current, or which command writes one.
+ * The check's own output is GitHub Actions annotations, the right shape for someone reading a diff
+ * and the wrong one for someone meeting this workflow: "Stale translation unit T:3 (ko)" does not
+ * say what a stamp is or which command writes one. So the findings are also gathered into one
+ * comment, grouped by what went wrong.
  *
- * So the same findings are also gathered into one comment: grouped by what went wrong, each group
- * saying what to run, and the whole thing ending on what does and does not fail the build.
- *
- * Every word of it is a message in i18n/, because the person being advised is by definition
- * someone working in another language: the comment can be rendered once per language, so a
- * contributor who sent a Korean translation reads the advice in Korean under the English. The
- * messages are reached through a callable rather than wfMessage() directly, so the shape of the
- * comment is tested without a wiki behind it.
+ * Every word of it is a message in i18n/, reached through a callable so the comment can be tested
+ * without a wiki.
  */
 class TranslationAdvice {
 	/**
@@ -87,14 +81,9 @@ class TranslationAdvice {
 	/**
 	 * The same advice, but only about the paths a change touches.
 	 *
-	 * A check reads the whole source tree, which is what a maintainer wants and the opposite of
-	 * what a comment wants: a page that has been waiting for a translation since long before this
-	 * change is not this contributor's to answer, and saying so on every change is how a comment
-	 * stops being read at all. So the comment is kept to the files in front of the reader.
-	 *
-	 * A translation counts as touched when its own file was, and also when the source page it
-	 * translates was: editing an English page is exactly what makes its translations stale, and
-	 * the person who did it is the one who needs to hear so.
+	 * A page waiting for a translation since long before this change is not this contributor's to
+	 * answer. A translation counts as touched when its own file was, and when its source page was:
+	 * editing an English page is what makes its translations stale.
 	 *
 	 * @param list<string> $paths As the findings name their files: repo-relative, in the same
 	 *   shape --path-prefix produces.
@@ -109,8 +98,8 @@ class TranslationAdvice {
 	 * The comment for a run that found something, or null for one that found nothing.
 	 *
 	 * A finding carries a kind and a file, then whichever of source, unit, lang, line and detail
-	 * its kind has to say. Written here as a plain string map rather than as the shape, which no
-	 * longer fits on a line the coding standard will take.
+	 * its kind has to say. Written as a plain string map rather than as the shape, which no longer
+	 * fits on a line the coding standard will take.
 	 *
 	 * @param list<array<string,string>> $findings
 	 * @param list<string> $languages Rendered once each, in this order.
@@ -134,10 +123,8 @@ class TranslationAdvice {
 	 * The body of a run that found nothing, which is how a consumer tells that from a finding.
 	 *
 	 * CLEAR_MARKER on its own line is what says so; what to do about it is the consumer's to
-	 * decide. wikven's own action deletes the comment it left before, because a comment saying
-	 * there is nothing wrong is one nobody needs and the run's annotations hold the record either
-	 * way. The prose below is for a consumer that keeps its comment and wants something to put
-	 * where the complaint stood.
+	 * decide. wikven's own action deletes the comment it left before; the prose below is for a
+	 * consumer that keeps its comment.
 	 *
 	 * @param list<string> $languages
 	 */
@@ -262,9 +249,8 @@ class TranslationAdvice {
 	/**
 	 * The message for a comment about everything, or the one that says it is about a change.
 	 *
-	 * Two messages rather than one hedged wording, because a comment that has been narrowed and
-	 * one that has not are saying different things, and a reader deciding whether the check is
-	 * quiet about the rest of the wiki should not have to guess which they are holding.
+	 * Two messages rather than one hedged wording, because a comment that has been narrowed and one
+	 * that has not are saying different things.
 	 */
 	private function key(string $key): string {
 		return $this->paths === null ? $key : "$key-scoped";

--- a/includes/PageTranslation/TranslationFamily.php
+++ b/includes/PageTranslation/TranslationFamily.php
@@ -5,16 +5,11 @@ namespace MediaWiki\Extension\Wikven\PageTranslation;
 /**
  * Which page answers for which language in a translatable page's family.
  *
- * A translatable page is three or more pages: "Development" is the source, written in whatever
- * language its author wrote it in, and "Development/ko" is the Korean one. The rule that needs
- * saying out loud is the one about the source's own language. Translate makes a translation page
- * for it too -- "Development/en" -- and that page is the source page's article again, word for
- * word, at a second address. hreflang has no way to say a language is at two addresses, so one of
- * them has to own it, and it is the source page: that is the address every link in the export
- * names, and "/en" is reached only from a language bar.
- *
- * Names rather than titles, and no Translate here, for the reason StalenessComputer beside it
- * gives: the rule is decided in one place, and the place that decides it can be read on its own.
+ * A translatable page is three or more pages: "Development" is the source and "Development/ko" the
+ * Korean one. The rule worth saying out loud is the one about the source's own language. Translate
+ * makes "Development/en" too, which is the source page's article again at a second address, and
+ * hreflang cannot say a language is at two -- so the source page owns it, being the address every
+ * link in the export names.
  */
 class TranslationFamily {
 	/**

--- a/includes/PageTranslation/TranslationSource.php
+++ b/includes/PageTranslation/TranslationSource.php
@@ -44,14 +44,9 @@ class TranslationSource {
 	/**
 	 * The source text of a page's title translation unit, or null when its title is not translatable.
 	 *
-	 * The unit's source text is the page's own title, exactly as Translate synthesizes its
-	 * "Page display title" unit from the page name: nothing is added to the source wikitext, so an
-	 * English page renders as it did before and a rename is what makes the translated title stale.
-	 *
-	 * A page that sets {{DISPLAYTITLE:}} itself is excluded. That magic word sits outside
-	 * <translate>, so it is copied verbatim into every translation page and runs there too, fixing
-	 * the same title in every language; asking for a translation Translate could not apply would
-	 * only invite one that silently does nothing.
+	 * The unit's source text is the page's own title, as Translate synthesizes its "Page display
+	 * title" unit. A page setting {{DISPLAYTITLE:}} itself is excluded: that word sits outside
+	 * <translate>, so it is copied into every translation and fixes one title for every language.
 	 *
 	 * @param string $baseFile Absolute path of the base page's source file.
 	 * @param string $sourceDir Source directory the file lives under; the title is relative to it.
@@ -115,16 +110,9 @@ class TranslationSource {
 	/**
 	 * Whether an absolute path is a translation file.
 	 *
-	 * True when it is named "<lang>.wikitext" for a known language, its sibling base page
-	 * "<dir>.wikitext" is translatable, and it carries <!--T:n--> unit markers. Used to keep
-	 * translation files out of the plain import.
-	 *
-	 * The markers are what settle it. Hundreds of language codes are also ordinary English words --
-	 * "id", "no", "is", "it", "as", "be" -- so the name alone had a translatable page's "API/id"
-	 * subpage read as an Indonesian translation, and the page then went missing from the site with
-	 * nothing said. A page written to stand on its own has no reason to carry a source page's unit
-	 * numbers, and a translation cannot be written without them: they are how a unit is translated
-	 * at all, and scaffold() puts them in a new translation before anyone types into it.
+	 * True when it is named "<lang>.wikitext" for a known language, its sibling base page is
+	 * translatable, and it carries <!--T:n--> unit markers. The markers settle it: hundreds of
+	 * language codes are also English words, so the name alone had "API/id" read as Indonesian.
 	 *
 	 * @param string $absolutePath
 	 * @param callable(string):bool $isKnownLanguage
@@ -164,11 +152,9 @@ class TranslationSource {
 	/**
 	 * Subpages that a language code names but that are read as pages of their own, keyed by code.
 	 *
-	 * The other half of what filesNamedForALanguage() finds: named for a language, sitting under a
-	 * translatable page, and carrying no unit marker, so nothing here reads them as translations.
-	 * That is usually right -- "API/id" is about identifiers, not Indonesian -- and when it is not,
-	 * this is what lets checkTranslations say so instead of leaving a translation quietly imported
-	 * as an ordinary subpage.
+	 * Named for a language, sitting under a translatable page, and carrying no unit marker. That
+	 * reading is usually right -- "API/id" is about identifiers, not Indonesian -- and when it is
+	 * not, this is what lets checkTranslations say so.
 	 *
 	 * @param string $baseFile
 	 * @param callable(string):bool $isKnownLanguage
@@ -216,10 +202,9 @@ class TranslationSource {
 	/**
 	 * The translation files a base page has, keyed by the language each is written in.
 	 *
-	 * A caller that has the base file gets its translations by the paths they were found at, rather
-	 * than by rebuilding them from the page title: a title has been through MediaWiki's
-	 * normalization and no longer spells the file it came from ("Getting_Started.wikitext" imports
-	 * as "Getting Started"), so a rebuilt path can miss a translation that is sitting right there.
+	 * By the paths they were found at rather than rebuilt from the page title: a title has been
+	 * through MediaWiki's normalization and no longer spells the file it came from
+	 * ("Getting_Started.wikitext" imports as "Getting Started").
 	 *
 	 * @param string $baseFile
 	 * @param callable(string):bool $isKnownLanguage
@@ -237,9 +222,7 @@ class TranslationSource {
 	 * Every language the source tree carries a translation in.
 	 *
 	 * The languages a site is built in are the ones its pages have translations for. Read from the
-	 * files rather than from a setting, because there is no setting: nothing declares a site's
-	 * languages, so a second list to keep in step with this one would be a list to fall out of step
-	 * with it.
+	 * files because there is no setting to read: a second list would be one to fall out of step.
 	 *
 	 * @param string $sourceDir
 	 * @param callable(string):bool $isKnownLanguage

--- a/includes/Png.php
+++ b/includes/Png.php
@@ -11,14 +11,8 @@ class Png {
 	 * Return the PNG without the chunks whose payload is a timestamp.
 	 *
 	 * A thumbnail of unchanged source differs between bakes because ImageMagick stamps what it
-	 * writes: a tIME chunk, date:create/date:modify/date:timestamp text chunks, and, from the
-	 * -thumbnail operator, Thumb::MTime holding the source file's mtime. MediaWiki removes only
-	 * Thumb::URI (BitmapHandler, T108616) and offers no way to pass -strip, so the export strips
-	 * them on its way out instead.
-	 *
-	 * Only clocks are dropped. The comment naming the source file, the colour profile, the rest of
-	 * the Thumb::* family (size, dimensions, mimetype) and the image data are all kept, and
-	 * removing whole chunks leaves every remaining CRC valid.
+	 * writes: a tIME chunk, date:* text chunks, and Thumb::MTime. MediaWiki removes only Thumb::URI
+	 * and offers no way to pass -strip. Only clocks are dropped, and every remaining CRC stays valid.
 	 *
 	 * @param string $data Raw file contents.
 	 * @return string|null The rewritten PNG, or null if this is not a PNG whose chunks parse

--- a/includes/RelativeUrl.php
+++ b/includes/RelativeUrl.php
@@ -10,21 +10,9 @@ class RelativeUrl {
 	/**
 	 * Add a "../" per level to every root-relative reference in a page moved $depth subdirectories down.
 	 *
-	 * Wikven links everything relative to the output root ("./x", or "../x" one level above it, as the
-	 * non-main-skin canonical does). A subpage title such as "Manual/Config" caches to a flat file but
-	 * is exported into a real "Manual/" directory; its references then need a "../" per level so links
-	 * and files agree on a static host. Absolute, protocol-relative and data: URLs carry no leading
-	 * "./" and are left alone. Covers href/src/srcset attributes, CSS url(), the page's own
-	 * JavaScript config (see reparentConfigVars()) and its schema.org block (reparentJsonLd()).
-	 *
-	 * Each candidate is required to sit inside a real "<tag ...>" span (or, for url(), inside a
-	 * <style> block too): MediaWiki escapes preformatted text with htmlspecialchars(..., ENT_NOQUOTES),
-	 * which turns a documentation example's own "<a href=\"./intro\">" into "&lt;a href=\"./intro\"&gt;"
-	 * -- the quotes survive, but neither escaped angle bracket is a real "<" or ">", so nothing there
-	 * reads as a tag span and the example's href is correctly left alone.
-	 *
-	 * The printfooter's link arrives without the "./" it was written with, so it is rebased on its
-	 * own; see rebasePrintFooter() below.
+	 * A subpage title such as "Manual/Config" caches to a flat file but is exported into a real
+	 * "Manual/" directory, so its references need a "../" per level. Covers href/src/srcset, CSS
+	 * url(), the page's own JavaScript config and its schema.org block.
 	 */
 	public static function reparent(string $html, int $depth): string {
 		if ($depth < 1) {
@@ -100,21 +88,9 @@ class RelativeUrl {
 	/**
 	 * Rebase the root-relative URLs a page carries in its JavaScript config.
 	 *
-	 * Title::getLocalURL() answers "./Page.html" here (Hooks\Main::onGetLocalURL), and a URL that
-	 * shape means "from the output root" -- a claim only true of a page sitting at the root. In an
-	 * attribute the passes above correct it; the same string handed to the client through
-	 * mw.config rides in the page's RLCONF object, where nothing was correcting it. Core writes one
-	 * itself for a redirect (wgInternalRedirectTargetUrl), and any extension that asks a Title for
-	 * its URL and exports it as a config var writes another.
-	 *
-	 * Only that object is rewritten, and in it only strings that begin with "./" or "../". The rest
-	 * of the page cannot be treated this way, since a bare string carries no marker telling a URL
-	 * of ours from a path a page merely shows -- these very docs write "./Page.html" as text.
-	 * RLCONF is a span MediaWiki wrote, not the wikitext, and everything in it is data for scripts.
-	 *
-	 * What this cannot reach is a local URL baked into a ResourceLoader module's bundle: one file
-	 * serves every page at every depth, so there is no depth to correct it by, and an extension
-	 * shipping one has to anchor it itself (#425).
+	 * "./Page.html" means "from the output root", a claim only true of a page at the root. In an
+	 * attribute the passes above correct it; the same string handed to the client through mw.config
+	 * rides in RLCONF, where nothing was. Only that object: a bare string carries no marker.
 	 *
 	 * @param string $html A rendered page.
 	 * @param callable(string):string $rebase Takes the matched "." or "..", returns its replacement.
@@ -147,17 +123,10 @@ class RelativeUrl {
 	/**
 	 * Rebase the root-relative URLs a page carries in its schema.org block.
 	 *
-	 * The claim reparentConfigVars() answers, one escaping further along. Where a site has said
-	 * where it is published, a picture named in machine-read metadata gets a whole URL and no depth
-	 * can apply to it. Where it has not, storeImages can only name the file from the output root,
-	 * and a "./assets/..." written into a JSON document is spelled ".\/assets\/...": json_encode()
-	 * escapes a slash unless told not to. The passes above look for an attribute value or a bare
-	 * "./", so none of them sees that, and a subpage's schema.org image resolves inside the
-	 * subpage's own directory.
-	 *
-	 * Scoped to the block for the reason reparentConfigVars() is scoped to RLCONF: a bare string
-	 * carries no marker telling a URL of ours from a path a page merely shows. A ld+json script is
-	 * a span an extension wrote, and everything in it is data about the page rather than prose.
+	 * The claim reparentConfigVars() answers, one escaping further along: json_encode() spells
+	 * "./assets/..." as ".\/assets\/...", which none of the passes above sees, so a subpage's
+	 * schema.org image resolved inside the subpage's own directory. Scoped to the block for the
+	 * reason reparentConfigVars() is scoped to RLCONF.
 	 *
 	 * @param string $html A rendered page.
 	 * @param callable(string):string $rebase Takes the matched "." or "..", returns its replacement.
@@ -182,10 +151,8 @@ class RelativeUrl {
 	 * The offset just past the "}" closing the object literal that opens at $open, or null if the
 	 * text runs out first.
 	 *
-	 * Braces inside a string are not counted, so a config value holding one -- a message with a
-	 * "{{PLURAL:}}" left in it, a regular expression -- does not end the object early, and the
-	 * object's own end is found however many nested objects it holds. The alternative, a non-greedy
-	 * match up to the next "};", stops at the first config value that contains that pair.
+	 * Braces inside a string are not counted, so a config value holding one does not end the object
+	 * early. A non-greedy match up to the next "};" stops at the first value that contains it.
 	 */
 	private static function objectEnd(string $text, int $open): ?int {
 		$depth = 0;
@@ -219,16 +186,9 @@ class RelativeUrl {
 	 * Rebase the printfooter's "Retrieved from" link, the one reference that reaches a page having
 	 * lost the "./" the rest of this class goes by.
 	 *
-	 * Skin::printSource() builds it from Title::getCanonicalURL() and expands the result a second
-	 * time; each expansion runs UrlUtils' dot-segment removal over the URL, which drops the leading
-	 * "./" that Hooks\Main::onGetLocalURL wrote. What survives is still a path from the output root
-	 * -- it just no longer says so, so the passes above walk past it, and from a page exported into
-	 * a subdirectory it resolves inside that subdirectory and answers 404. A top-level page is
-	 * unaffected, its link being right from the root by accident.
-	 *
-	 * A bare relative href is exactly the shape that carries no marker telling a link of ours from
-	 * a path a page merely shows, which is why only core's printfooter div is rebased: everything
-	 * in there is the line core has just built out of this page's own URL.
+	 * Skin::printSource() expands Title::getCanonicalURL() a second time, and UrlUtils' dot-segment
+	 * removal drops the leading "./". What survives is still a path from the output root but no
+	 * longer says so, so from a subdirectory it answers 404.
 	 */
 	private static function rebasePrintFooter(string $html, string $up): string {
 		return preg_replace_callback(
@@ -253,10 +213,8 @@ class RelativeUrl {
 	 * Whether $href is a bare path from the output root -- what the printfooter's link is left as.
 	 *
 	 * Everything else names something the depth of the page cannot move: an absolute URL, a path
-	 * from the host root, a fragment or query on the page itself, or -- for a link that kept its
-	 * marker, and so was rebased by reparent() already -- a path the "./" prefix has spoken for.
-	 * A namespaced title such as "File:Oven.jpg.html" reads like a scheme and is not one, hence
-	 * the test for "://" rather than for a colon.
+	 * from the host root, a fragment, or a link that kept its marker. A title such as
+	 * "File:Oven.jpg.html" reads like a scheme, hence the test for "://".
 	 */
 	private static function isRootRelative(string $href): bool {
 		if ($href === '') {
@@ -303,19 +261,12 @@ class RelativeUrl {
 	}
 
 	/**
-	 * Resolve Translate's "Special:MyLanguage/Target" links (that special page is not exported) to a
-	 * static target: "Target/<lang>.html" when a translation for the page's language exists, else the
-	 * source "Target.html". The link's existing relative prefix (already depth-correct after reparent)
-	 * and any "#fragment" are kept, so the target stays reachable from any page depth.
+	 * Resolve Translate's "Special:MyLanguage/Target" links, that special page not being exported,
+	 * to a static target: "Target/<lang>.html" where a translation exists, else "Target.html".
 	 *
-	 * "Special:MyLanguage" is matched as the canonical spelling alone, which is the only one that
-	 * reaches here: both sides that write this marker -- Hooks\Main::nameFor() for a link on a page,
-	 * Hooks\Adder::licensesHref() for the footer's -- write it canonically however this wiki spells
-	 * that namespace and that special page itself. The colon is matched in both spellings OutputName
-	 * writes, because the marker is built as a link like any other: under encoded file names it
-	 * arrives as "Special%253A". What follows it is the target's own link, so appending
-	 * "/<lang>.html" to it names the translation's link, and $hasTranslation is handed that link to
-	 * turn back into a file name.
+	 * Matched as the canonical spelling alone, which is the only one that reaches here: both sides
+	 * that write this marker write it canonically. The colon is matched in both spellings
+	 * OutputName writes.
 	 *
 	 * @param string $html
 	 * @param string|null $lang The page's language, or null for a source page (always the source target).

--- a/includes/RetryingForeignRepo.php
+++ b/includes/RetryingForeignRepo.php
@@ -7,17 +7,12 @@ use RuntimeException;
 
 /**
  * A foreign file repository (Wikimedia Commons through InstantCommons, or any other api.php repo)
- * that gives a request the remote failed to answer a second and a third chance, and that says so
+ * that gives a request the remote failed to answer a second and a third chance, and says so
  * plainly when it still has no thumbnail to show for it.
  *
- * Every parse of a page embedding a Commons image asks commons.wikimedia.org for that image's
- * thumbnail URL, and MediaWiki makes that request once, with no retry. A lookup that comes back
- * empty is not merely a missing thumbnail either: ForeignAPIFile::transform() then takes an error
- * path that reads the media handler's language, which nothing on that path ever sets, so the parse
- * dies with "Need to set language before accessing" and takes the whole build with it. Repeating
- * the request, as StoreImages already repeats the downloads of the images themselves, means one
- * hiccup at Commons no longer does that; failing the lookup loudly means that when the image
- * really cannot be had, the build says which one and why instead of quoting that riddle.
+ * Every parse of a page embedding a Commons image asks for its thumbnail URL, and MediaWiki makes
+ * that request once. An empty lookup is not merely a missing thumbnail: ForeignAPIFile::transform()
+ * then reads a media handler language nothing sets, so the parse dies and takes the build with it.
  */
 class RetryingForeignRepo extends ForeignAPIRepo {
 	/**
@@ -25,13 +20,8 @@ class RetryingForeignRepo extends ForeignAPIRepo {
 	 *
 	 * Core's only caller of this is the ForeignAPIFile::transform() branch described above, which
 	 * cannot cope with a false: it reads a language off a media handler that has none, and throws.
-	 * A thumbnail this repository cannot produce is a build that cannot produce a self-contained
-	 * site, so end it here, where the file and the reason are still known, rather than three
-	 * frames later with neither. StoreImages already aborts the build on the same grounds when it
-	 * cannot download an image, "rather than publish output that still hotlinks images".
-	 *
-	 * This fails no build that would otherwise have passed: every false returned from here is
-	 * already fatal today, just unreadably so.
+	 * So end the build here, where the file and the reason are still known, rather than three
+	 * frames later with neither. Every false returned from here is already fatal today.
 	 */
 	public function getThumbUrlFromCache($name, $width, $height, $params = '') {
 		$url = parent::getThumbUrlFromCache($name, $width, $height, $params);
@@ -67,14 +57,10 @@ class RetryingForeignRepo extends ForeignAPIRepo {
 	/**
 	 * @inheritDoc
 	 *
-	 * Named here rather than passed to each request, because httpGet() above hands core the
-	 * options and core writes this key over whatever came in: the string a lookup goes out
-	 * under is this method's answer and nothing else. Left alone it is "MediaWiki/1.46.0
-	 * (server) ForeignAPIRepo/2.1", which names the library and the class doing the asking but
-	 * not the tool that wanted it -- and a bake asks Commons more than it asks anyone: a page
-	 * with ten images is ten lookups. wikven goes in front, where the policy wants the thing
-	 * making the requests, and core's own string keeps everything it said, including the extra
-	 * a repository configured with 'userAgent' asked for.
+	 * Named here rather than passed to each request, because httpGet() above hands core the options
+	 * and core writes this key over whatever came in. Left alone it is "MediaWiki/1.46.0 (server)
+	 * ForeignAPIRepo/2.1", which names the library and not the tool that wanted it -- and a bake
+	 * asks Commons more than it asks anyone.
 	 */
 	public function getUserAgent() {
 		return UserAgent::tool() . ' ' . parent::getUserAgent();

--- a/includes/Scribunto.php
+++ b/includes/Scribunto.php
@@ -5,26 +5,13 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * Whether this build can render Lua, and what to say when it cannot.
  *
- * Scribunto is ordinary equipment on a MediaWiki wiki, and wikven's two products disagree about it.
- * The image compiles luasandbox into its PHP and bundles the extension, so a site that lists
- * Scribunto bakes Lua there. The standalone binary has no such extension -- static-php-cli, which
- * builds its PHP, offers no Lua extension among the hundred and thirty it supports -- and reaches
- * Lua only through Scribunto's other engine, which shells out to a lua binary. It gets one on 64-bit
- * x86 Linux, where the interpreter Scribunto itself ships will run; anywhere else the site has to
- * name one of its own.
+ * Scribunto is ordinary equipment on a MediaWiki wiki, and wikven's two products disagree about
+ * it: the image compiles luasandbox into its PHP and bundles the extension, while the standalone
+ * binary reaches Lua only by shelling out to a lua binary, which it has on 64-bit x86 Linux and
+ * nowhere else.
  *
- * Until now that disagreement was silent, and silence was the worst of it. Measured on a bake of one
- * page invoking one module, every one of these exited 0:
- *
- *   Scribunto listed, engine present     rendered "Lua says hello"
- *   not listed, module named bare        rendered "{{#invoke:Greet|hello}}", module file ignored
- *   not listed, module named .wikitext   rendered "{{#invoke:Greet|hello}}", module published as
- *                                        Module%3AGreet.html, its Lua source now a page of the site
- *
- * So a reader got braces where the page meant to say something, and in one case the module's source
- * became a page. Neither is worth being quiet about, and they are not worth the same answer either:
- * a site that asked for Scribunto where it cannot run is told no, and a site that never asked for it
- * is only told what its Module: files are doing. See problem() and warning().
+ * That disagreement used to be silent -- a page invoking a module rendered
+ * "{{#invoke:Greet|hello}}" and the bake exited 0. See problem() and warning().
  */
 class Scribunto {
 	/** The extension a site lists to ask for Lua. */
@@ -36,11 +23,9 @@ class Scribunto {
 	/**
 	 * The source files that are Lua modules.
 	 *
-	 * Read off the file name rather than asked of MediaWiki, because the question is put when
-	 * Scribunto may not be loaded, and NS_MODULE does not exist until it is. That is also why the
-	 * prefix is the canonical one: without the extension there is no localised namespace name to
-	 * compare against, so a site whose module files are named in another language is not recognised
-	 * here. Documented as the convention rather than guessed at.
+	 * Read off the file name rather than asked of MediaWiki, because NS_MODULE does not exist until
+	 * Scribunto is loaded. That is also why the prefix is the canonical one, documented as a
+	 * convention rather than guessed at.
 	 *
 	 * @param string[] $relativePaths Source paths, relative to the source directory.
 	 * @param string[] $prefixes Namespace prefixes to count as modules.
@@ -62,13 +47,9 @@ class Scribunto {
 	/**
 	 * Why this build cannot do what the site asked for, or null if it can.
 	 *
-	 * One rule, and it is about a request this build cannot honour: a site that lists Scribunto where
-	 * no engine can run it. That is the standalone binary, and the message names it. The alternative
-	 * is a published site with braces where the pages meant to say something, which is worse than
-	 * being told no.
-	 *
-	 * A site with no modules that lists Scribunto anyway is left alone: nothing is broken, the
-	 * extension simply has nothing to do.
+	 * One rule, about a request this build cannot honour: a site that lists Scribunto where no
+	 * engine can run it. The alternative is a published site with braces where the pages meant to
+	 * say something.
 	 *
 	 * @param bool $listed Whether the site lists Scribunto in extensions.
 	 * @param bool $engineAvailable Whether a Lua engine can run here.
@@ -97,12 +78,9 @@ class Scribunto {
 	/**
 	 * What the site should know about its Module: files, or null if there is nothing to say.
 	 *
-	 * A source tree with module files and no Scribunto in extensions is not an error. The site never
-	 * asked for Lua, and what those files are is a guess read off a name: they may be on their way in,
-	 * on their way out, or kept for something else entirely. Deciding that a file called Module:
-	 * means the bake must not happen is deciding for the site, so this only says what it sees --
-	 * the invocations stay in the pages as their own source text, and a module named with the
-	 * .wikitext marker is exported -- and lets the bake go on.
+	 * A source tree with module files and no Scribunto in extensions is not an error: the site
+	 * never asked for Lua, and what those files are is a guess. So this says what it sees and lets
+	 * the bake go on.
 	 *
 	 * @param bool $listed Whether the site lists Scribunto in extensions.
 	 * @param string[] $modulePages Module source files found, from modulePages().

--- a/includes/Search.php
+++ b/includes/Search.php
@@ -26,12 +26,9 @@ class Search {
 	/**
 	 * The page SifterSearch lists a query's matches on, or null where the site names none.
 	 *
-	 * Read as a title, because that is what SifterSearch does with the setting: a value that is not
-	 * one names no page, and its own handler gives up on it rather than wiring anything to it.
-	 *
-	 * Not gated on isActive(), unlike hasResultsPage() below: what this answers is where a search
-	 * link can land, and the page a site named is that place whether or not an index was built for
-	 * it. Where search is off entirely the box is hidden anyway, so nothing offers such a link.
+	 * Read as a title, because that is what SifterSearch does with the setting. Not gated on
+	 * isActive(): this answers where a search link can land, and the page a site named is that
+	 * place whether or not an index was built for it.
 	 */
 	public static function resultsPage(): ?Title {
 		$page = (string)( $GLOBALS['wgSifterSearchResultsPage'] ?? '' );
@@ -45,9 +42,8 @@ class Search {
 	 * Whether submitting a plain search form reaches results.
 	 *
 	 * SifterSearch retargets the skin's form at its results page, and only when one is configured
-	 * (it is not by default). Skins whose box is wired up by the on-focus typeahead do not care:
-	 * that module takes the submit to the top Pagefind result instead. A skin left with nothing
-	 * but the form -- Citizen, whose own search is its command palette -- has only this path.
+	 * (it is not by default). Skins wired up by the on-focus typeahead do not care; one left with
+	 * nothing but the form -- Citizen -- has only this path.
 	 */
 	public static function hasResultsPage(): bool {
 		return self::isActive() && self::resultsPage() !== null;
@@ -56,22 +52,13 @@ class Search {
 	/**
 	 * Where a skin copy loads the Pagefind bundle from, given the path the site serves its own at.
 	 *
-	 * A result carries the URL the page had under the crawl root, and the client resolves that
-	 * against the bundle's own parent directory, so the bundle's location is what decides which
-	 * copy of the site a search answers with. One bundle at the export root answers every copy
-	 * with the root copy's pages, which is a reader who chose a skin being taken out of it the
-	 * moment they search (#399). SifterSearch anchors the results page's own URL at the same
-	 * parent, so that leaves the copy too.
-	 *
-	 * The copy's bundle therefore sits beside the copy's pages: the site's path with the copy's
-	 * directory inserted ahead of its last segment, so "/wikven/pagefind/" becomes
-	 * "/wikven/citizen/pagefind/". Everything downstream is SifterSearch's own arithmetic on that
-	 * one value, which is why nothing here has to know about results, forms or suggestions.
+	 * A result carries the URL the page had under the crawl root and the client resolves it against
+	 * the bundle's parent, so one bundle at the export root answers every copy with the root copy's
+	 * pages (#399).
 	 *
 	 * @param string $bundlePath The site's own bundle path, e.g. "/wikven/pagefind/".
 	 * @param string $directory The copy's directory name, which is the skin's, e.g. "citizen".
-	 * @return ?string null where the site's path says nothing about where this site's root is: a
-	 *   bundle served from another host, or a protocol-relative one, has no copy to put beside it.
+	 * @return ?string null where the site's path says nothing about where this site's root is.
 	 */
 	public static function copyBundlePath(string $bundlePath, string $directory): ?string {
 		if ($directory === '' || !str_starts_with($bundlePath, '/') || str_starts_with($bundlePath, '//')) {
@@ -99,20 +86,9 @@ class Search {
 	/**
 	 * The bundle's entry file with its language map in a fixed order, or null to leave it alone.
 	 *
-	 * Pagefind writes the map in whatever order it iterated the languages, which is not the same
-	 * order twice, so two bakes of one source disagree on this file while agreeing on every index
-	 * it points at -- the hashes and page counts come out identical. A site with one language never
-	 * showed it, having nothing to order; a translated site does, and it broke the promise that two
-	 * bakes are byte-identical (#411). This is the same work as StripBuildStamps: the build owns
-	 * that promise, so the build settles what a tool upstream of it left unsettled.
-	 *
-	 * Only the order changes, and only of that one map. Key order carries no meaning in JSON, so
-	 * nothing that reads the bundle can tell -- the client looks languages up by name.
-	 *
-	 * Re-encoding need not reproduce Pagefind's own bytes, only the same bytes every time, which is
-	 * all the promise asks; the flags keep it close anyway, so a diff against an older bake stays
-	 * readable. Anything this cannot parse, or that does not hold the map, is returned as null and
-	 * left as it is: a bundle this does not understand is not one to rewrite.
+	 * Pagefind writes the map in whatever order it iterated the languages, so two bakes of one
+	 * source disagree on this file while agreeing on every index it points at (#411). Key order
+	 * carries no meaning in JSON.
 	 *
 	 * @param string $json The contents of pagefind-entry.json.
 	 * @return ?string The re-encoded file, or null when there is nothing safe to do.

--- a/includes/SiteConfig.php
+++ b/includes/SiteConfig.php
@@ -48,11 +48,9 @@ class SiteConfig {
 	/**
 	 * Config the build works out for itself, which a site's file cannot set.
 	 *
-	 * These name where the build reads from and writes to, and it derives all three from
-	 * WIKVEN_WORKDIR: the source directory it was pointed at, the output directory beside it, and
+	 * All three come from WIKVEN_WORKDIR: the source directory, the output directory beside it, and
 	 * the git log the bake action dumps there. A site that set one would move where its pages come
-	 * from without moving where its own config file is looked for, so WikvenSettings.php puts them
-	 * back after a site's config is applied and lint says here that it will.
+	 * from without moving where its own config file is looked for.
 	 */
 	public const DERIVED_CONFIG = [
 		'WikvenSourceDirectory',
@@ -63,12 +61,9 @@ class SiteConfig {
 	/**
 	 * Config the build works out from the site's own lists, which a site's file cannot set either.
 	 *
-	 * A site says which skins to build under `skins` and which to read the site in with
-	 * DefaultSkin, and the build turns those two answers into the skin names MediaWiki knows and
-	 * the one whose pages go to the output root. WikvenMissing is not an answer at all: it is what
-	 * the build found missing while loading those lists. Writing any of the three here would be
-	 * answering a question the file has already asked properly, and WikvenSettings.php overwrites
-	 * all three after a site's config is applied; lint says here that it will.
+	 * A site says which skins to build and which to read it in with DefaultSkin; the build turns
+	 * those into the names MediaWiki knows and the one whose pages go to the output root.
+	 * WikvenMissing is what it found missing while loading them.
 	 */
 	public const DERIVED_SKIN_CONFIG = [
 		'WikvenSkins',
@@ -163,13 +158,9 @@ class SiteConfig {
 	 * Config-schema failures, as lines naming the setting that is wrong.
 	 *
 	 * SettingsBuilder::validate() checks the settings core defines against their schema, which is
-	 * how a site hears that it wrote a list where a number belongs instead of meeting a stack trace
-	 * further into the boot with nothing in it about its own file. Core renders a StatusValue as a
-	 * debug table wrapped at twenty-five characters; the name and the reason are what a person
-	 * needs, so they are pulled out here.
-	 *
-	 * Only errors are read. The validator also warns that it declined to check a map with integer
-	 * keys, which is not something a site can act on and would be printed by every build.
+	 * how a site hears that it wrote a list where a number belongs. Core renders a StatusValue as a
+	 * debug table wrapped at twenty-five characters, so the name and the reason are pulled out
+	 * here. Only errors are read.
 	 *
 	 * @param StatusValue $status What SettingsBuilder::validate() returned.
 	 * @return string[] One line per failed setting, empty when the config conforms.
@@ -196,14 +187,9 @@ class SiteConfig {
 	/**
 	 * Config names declared by a set of extension and skin manifests, as a lookup set.
 	 *
-	 * A manifest declares its settings in a "config" map, and ExtensionRegistry turns each name in
-	 * it straight into a global. Nothing on that path reaches the schema SettingsBuilder validates
-	 * against, so core is never in a position to say that a name a site wrote belongs to no one.
-	 * Reading the manifests is what is left.
-	 *
-	 * A manifest declaring a prefix other than "wg" is skipped whole. A site's file reaches globals
-	 * through $wgSettings, which writes that prefix and no other, so those settings cannot be
-	 * written from a config file at all, and counting them as known would say they can.
+	 * ExtensionRegistry turns each name under a manifest's "config" map straight into a global, and
+	 * nothing on that path reaches the schema SettingsBuilder validates against. A manifest
+	 * declaring a prefix other than "wg" is skipped whole: $wgSettings writes no other.
 	 *
 	 * @param string[] $manifestPaths Absolute paths to extension.json/skin.json files.
 	 * @return array<string,true> Config names, as keys.
@@ -235,8 +221,7 @@ class SiteConfig {
 	 * Config names a site wrote that nothing defines, each with a near miss where there is one.
 	 *
 	 * This is the quietest mistake a config file can make: the name is written into a global, no
-	 * code ever reads that global, and the build succeeds having ignored the line. Every other
-	 * report in this class is about a value; this one is about a name.
+	 * code ever reads that global, and the build succeeds having ignored the line.
 	 *
 	 * @param string[] $configKeys The names under "config" in the site's file.
 	 * @param string[] $defined Every config name something here defines.
@@ -261,10 +246,9 @@ class SiteConfig {
 	/**
 	 * The defined name closest to $name, or null when none of them is close enough to suggest.
 	 *
-	 * A misspelling is a character or two out. Past that a suggestion is a guess, and offering one
-	 * costs more than the warning gains: a site told it meant something else goes and reads about
-	 * a setting it never wanted. The allowance grows with the name, because a short name reaches an
-	 * unrelated one in fewer edits than a long one does.
+	 * A misspelling is a character or two out. Past that a suggestion is a guess that costs more
+	 * than the warning gains. The allowance grows with the name: a short one reaches an unrelated
+	 * name in fewer edits.
 	 *
 	 * @param string $name A config name nothing defines.
 	 * @param string[] $defined Every config name something here defines.
@@ -292,9 +276,8 @@ class SiteConfig {
 	 * Is $name usable as the directory name of a bundled extension or skin?
 	 *
 	 * The names in a site's extensions and skins lists become paths under $IP, so a name carrying a
-	 * path separator names a directory somewhere else entirely -- one in the mounted source tree,
-	 * say -- and would be loaded as if the image had shipped it. maintenance/fetchExtensions.php
-	 * asks the same of every WikvenRepositories key.
+	 * path separator names a directory somewhere else entirely and would be loaded as if the image
+	 * had shipped it. fetchExtensions.php asks the same of every WikvenRepositories key.
 	 *
 	 * @param string $name A name from a config file's 'extensions' or 'skins' list.
 	 * @return bool Whether the name is a plain directory name.

--- a/includes/SiteUrl.php
+++ b/includes/SiteUrl.php
@@ -7,38 +7,14 @@ use GuzzleHttp\Psr7\UriResolver;
 use InvalidArgumentException;
 
 /**
- * Where a built site will be published, and so the one place an absolute URL for a page can come
- * from.
+ * Where a built site will be published, and so the one place an absolute URL can come from.
  *
- * A published export needs absolute URLs for things that are about the site rather than in it: a
- * sitemap's <loc>, an hreflang alternate, an og:url. Their formats require them -- the sitemap
- * protocol says a URL "must begin with the protocol", and hreflang alternates "must be
- * fully-qualified" -- so none of them can be written with the relative links the pages themselves
- * carry.
+ * A sitemap's <loc>, an hreflang alternate and an og:url must be fully qualified, and nothing else
+ * in a build knows where the output is going: onGetLocalURL rewrites every link to a file beside
+ * the one asking. So a site says where it publishes or those features stay off; a value that says
+ * nothing and one this cannot use both hand back ''.
  *
- * Nothing else in a build knows this. The install runs against http://localhost:4000 and
- * Hooks\Main::onGetLocalURL rewrites every local URL to a file beside the one asking, which is what
- * makes an export work from any directory and any host. Both are right, and both mean the build
- * cannot work out where its output is going. A site says so or the absolute-URL features stay off,
- * which is the honest answer: a sitemap naming pages a crawler cannot resolve is worse than no
- * sitemap.
- *
- * A value that says nothing, and one this cannot use, are the same thing here: both give an
- * instance that knows no base and hands back '' from everything. Nothing about the pages changes
- * either way; only what is written about them.
- *
- * Where the value comes from is the caller's business. Reading $wgWikvenSiteUrl is one line in
- * WikvenSettings.php, and keeping it there is what lets this be built from a written string in a
- * test, from configuration in a maintenance script, and from the settings file before MediaWiki has
- * services to ask.
- *
- * The URL work is Guzzle's. It arrives with MediaWiki -- core requires guzzlehttp/guzzle, which
- * requires guzzlehttp/psr7 -- and includes/AutoLoader.php loads vendor before Setup.php reaches
- * LocalSettings, so it is there for the settings file that the extension's own autoloader is not
- * yet up for. Hand-rolled parsing was tried and got four cases wrong that a site can plausibly
- * write: a base carrying a query or a fragment had the trailing slash appended after it, a
- * mixed-case host went to a crawler unnormalised as a second origin, and a password in the base was
- * copied into every URL built from it.
+ * The URL work is Guzzle's, which arrives with core.
  */
 final class SiteUrl {
 	/** The published base, ending in a slash, or '' where the site has not said. */
@@ -53,19 +29,10 @@ final class SiteUrl {
 	/**
 	 * A written value read as a base, usable or not.
 	 *
-	 * Only http and https are accepted, and that check is wikven's rather than the library's: a URL
-	 * parser's job is to read what it is given, so Guzzle reads a mailto: or an irc: as the valid
-	 * URL it is. A crawler is the reader of everything built here and fetches neither, so a base in
-	 * another scheme would produce a document full of URLs nothing can follow.
-	 *
-	 * A query, a fragment and a password are dropped rather than refused. Each is a thing a site can
-	 * reasonably write into the address bar it copied from, none of them survives being a directory
-	 * that file names hang off, and refusing the whole base over one would leave the site with no
-	 * sitemap at all.
-	 *
-	 * The trailing slash is settled here rather than at each use: a base and a file name are joined
-	 * by every caller, and "https://example.org/wiki" with "index.html" is a different page from
-	 * "https://example.org/wiki/" with the same, in the direction that loses the last path segment.
+	 * Only http and https, which is wikven's check rather than the library's: a crawler fetches
+	 * neither a mailto: nor an irc:. A query, a fragment and a
+	 * password are dropped rather than refused. The trailing slash is settled here because every
+	 * caller joins a file name to it.
 	 */
 	public static function fromWritten(string $written): self {
 		$trimmed = trim($written);
@@ -101,10 +68,8 @@ final class SiteUrl {
 	/**
 	 * The scheme and host of the base, for $wgCanonicalServer, or '' where there is no base.
 	 *
-	 * Core keeps the two halves apart -- $wgCanonicalServer is scheme and host, a path lives in
-	 * $wgArticlePath -- and a site should not have to. It writes the whole URL once and this hands
-	 * core the half it understands, so what core and any extension build from it is right about the
-	 * host even where the path is wikven's to add.
+	 * Core keeps the two halves apart -- a path lives in $wgArticlePath -- and a site should not
+	 * have to. It writes the whole URL once and this hands core the half it understands.
 	 */
 	public function canonicalServer(): string {
 		return $this->base === '' ? '' : (string)( new Uri($this->base) )->withPath('');
@@ -113,13 +78,9 @@ final class SiteUrl {
 	/**
 	 * The absolute URL of a file the build wrote, or '' where the site has not said where it is.
 	 *
-	 * The name arrives from OutputName already encoded for a static server, so it is resolved rather
-	 * than encoded again -- encoding it twice is how a percent sign becomes %25.
-	 *
-	 * The "./" is what makes that resolution mean what it says. Under RFC 3986 a reference whose
-	 * first segment holds a colon is a URL with a scheme, and the default file-name spelling keeps
-	 * colons: "File:Note_icon.svg.html" is a real name on wikven's own documentation site. Resolved
-	 * bare it stays "file:Note_icon.svg.html" -- relative, lower-cased, and silently not the page.
+	 * The name arrives from OutputName already encoded, so it is resolved rather than encoded
+	 * again. The "./" matters: under RFC 3986 a first segment holding a colon is a scheme, so
+	 * "File:Note_icon.svg.html" resolved bare comes back lower-cased and not the page.
 	 */
 	public function forFile(string $href): string {
 		if ($this->base === '') {

--- a/includes/SitemapLimits.php
+++ b/includes/SitemapLimits.php
@@ -5,18 +5,13 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * What a sitemap that is past the protocol's limits says about itself.
  *
- * One sitemap is capped twice over -- "no more than 50,000 URLs and must be no larger than 50MB
- * (52,428,800 bytes)" -- and a site over either has to split across several files with a sitemap
- * index naming them. Splitting is not built (#626). This is only the sentence a build says about a
- * sitemap it wrote anyway, and it exists because until now only the count was ever asked about.
+ * One sitemap is capped twice over -- 50,000 URLs and 50MB -- and a site over either has to split
+ * across several files. Splitting is not built (#626); this is only the sentence a build says
+ * about a sitemap it wrote anyway.
  *
- * The count is the cap a realistic site reaches first. Measured from the file this project's own
- * documentation bake produces: 74 URLs in 6,180 bytes, 83 bytes each, so 50,000 URLs of that shape
- * would come to about 4.0 MB -- an order of magnitude under the byte cap, and the count itself a
- * factor of roughly 675 away. Reaching 50 MB while still under 50,000 URLs takes about 1,000 bytes
- * per URL, a location around 900 characters; deep subpage titles in a non-Latin script,
- * percent-encoded, could plausibly get there. Such a site wrote an oversized sitemap, had it
- * rejected, and heard nothing at all, because the only cap it passed was the one nothing checked.
+ * The count is the cap a realistic site reaches first: this project's own bake writes 83 bytes a
+ * URL, so 50,000 of them come to about 4 MB. Reaching 50 MB first takes locations around 900
+ * characters.
  */
 class SitemapLimits {
 	/** URLs one sitemap may name before it has to be split across several. */
@@ -26,21 +21,17 @@ class SitemapLimits {
 	 * Bytes one sitemap may reach, uncompressed.
 	 *
 	 * The protocol spells the number out -- "50MB (52,428,800 bytes)" -- so the megabyte here is
-	 * 1024 * 1024 rather than 1,000,000 and nobody has to guess which was meant. Uncompressed is
-	 * the measurement it caps, and it is also the only one there is to take here: the document is
-	 * written as plain XML, and whatever serves it compresses it or does not.
+	 * 1024 * 1024. Uncompressed is what it caps and the only measurement there is: the document is
+	 * plain XML, and whatever serves it compresses it or does not.
 	 */
 	public const BYTES = 50 * 1024 * 1024;
 
 	/**
 	 * What is wrong with a sitemap of this size, or null where it is inside both caps.
 	 *
-	 * Both caps are weighed into one sentence, so a file over both is a single complaint rather
-	 * than two that differ by a clause. The tail is the same either way: the file is written
-	 * regardless. That was chosen so a site which grows past a cap still has something on disk and
-	 * a message explaining it, rather than a sitemap that silently vanishes at some page count; the
-	 * opposite argument -- that a file a crawler rejects is worth nothing, and its presence hides
-	 * the problem from anyone not reading build logs -- is for whoever builds splitting to weigh.
+	 * Both caps are weighed into one sentence, so a file over both is a single complaint. The file
+	 * is written either way, so a site that grows past a cap still has something on disk and a
+	 * message explaining it.
 	 *
 	 * @param string $file What was written, so the complaint names the thing to go and look at.
 	 * @param int $urls How many pages it names.

--- a/includes/SkinOutput.php
+++ b/includes/SkinOutput.php
@@ -11,25 +11,13 @@ use SplFileInfo;
 /**
  * The pages one skin pass owns, out of everything under its output directory.
  *
- * A pass renders into $wgWikvenHtmlDirectory, and for the main skin that directory is dist/
- * itself: the parent of every other skin's output (dist/citizen/, dist/minerva/) and of the
- * history/ tree renderSkin() deletes. So "everything under my output directory" is not the same
- * set as "my pages", and a pass must never touch a path outside its own: another skin's page
- * resolves its links against the wrong root when read from here, and writing one races the pass
- * that owns it once the passes run together (#407, #409).
+ * For the main skin that directory is dist/ itself, the parent of every other skin's output, so
+ * "everything under my output directory" is not "my pages": writing one races the pass that owns
+ * it (#407, #409).
  *
- * Which directory belongs to which is decided by name, and a page can take a skin's name. Nothing
- * capitalizes it out of the way: wikven's own defaults set CapitalLinks off, so a title keeps the
- * case its file was written in, and a subpage of "citizen" makes the same dist/citizen/ the Citizen
- * pass renders into. The exclusion below is by name too, so on such a site the main pass skips that
- * page along with the skin's copies -- resolveTranslationLinks, the only caller, leaves its
- * Special:MyLanguage links unresolved.
- *
- * That is not a case to fix here. Once the two are in one directory nothing tells them apart: a
- * name is all either has, and reading the page would mean writing into the directory the Citizen
- * pass is writing to, which is the race this exists to prevent. Choosing the skin's copies is the
- * safe half of an unresolvable collision. What fixes it is not naming a page after a skin, which
- * Special:MyLanguage/Pages#reserved-names asks of a site.
+ * Which directory belongs to which is decided by name, and with CapitalLinks off a page can take a
+ * skin's name. The main pass then skips that page with the skin's copies -- the safe half of a
+ * collision nothing can resolve.
  */
 class SkinOutput {
 	/**

--- a/includes/SkinPass.php
+++ b/includes/SkinPass.php
@@ -5,18 +5,10 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * What a skin pass says when it has finished, and how the build reads that back.
  *
- * The build renders each skin in a process of its own and asks it the usual question -- what did
- * you exit with. That answer cannot be trusted here. An uncaught PHP Error goes past
- * MaintenanceRunner's catch, which takes Exception rather than Throwable, and reaches MediaWiki's
- * handler; its guard against claiming success on the way out is a shutdown function calling
- * exit(255), and the standalone binary drops an exit code set from a shutdown function. So a pass
- * that died halfway through rendering returned 0, and a build reported success over an export
- * holding 15 of its 222 pages -- every page in it perfectly good, which is why nothing downstream
- * had anything to say.
- *
- * A line a pass can only write by reaching the end of its own work does not have that problem,
- * whatever killed the pass and whatever it managed to return. Both sides of it are here, so the
- * sentence a pass writes and the sentence the build looks for cannot drift apart.
+ * What a pass exits with cannot be trusted here: an uncaught PHP Error reaches MediaWiki's handler,
+ * whose guard is a shutdown function calling exit(255), and the standalone binary drops a code set
+ * from one. So a pass that died halfway through returned 0, and a build reported success over an
+ * export of 15 pages out of 222. A line a pass can only write at the end of its own work cannot.
  */
 class SkinPass {
 	private const WROTE = 'Wikven: this pass wrote';
@@ -37,8 +29,6 @@ class SkinPass {
 	 *
 	 * Three questions, and the second is the one this class exists for: did the pass return
 	 * success, did it say it finished, and do the passes agree on how much of the site there is.
-	 * The third is nearly free -- every pass renders the same wiki, which nothing has written to
-	 * since it was frozen, so passes that report different numbers have not all rendered it.
 	 *
 	 * @param array<string,array{exit:int,output:string}> $passes Skin name to what it returned and said.
 	 * @return string[] Empty where every pass finished and they agree.

--- a/includes/SkippedHistoryAction.php
+++ b/includes/SkippedHistoryAction.php
@@ -7,21 +7,13 @@ use MediaWiki\Actions\Action;
 /**
  * The history action, registered so it can render nothing.
  *
- * rebuildFileCache.php caches two actions for every page it walks, unconditionally: ?action=view,
- * which is the export, and ?action=history, which is not. Nothing ever asks the export for a local
- * history page -- Hooks\Main::onGetLocalURL sends a history request to $wgWikvenHistoryUrl, and
- * Hooks\Hider removes the link entirely when that is not configured -- and the tree it writes is
- * deleted at the end of the pass. It was a database query, a formatted list and a full skin render
- * per page, in every pass, on every bake, thrown away in full each time (#408).
+ * rebuildFileCache.php caches two actions for every page it walks: ?action=view, the export, and
+ * ?action=history, which is not. The tree it writes is deleted at the end of the pass -- a query,
+ * a list and a full skin render per page, thrown away each time (#408).
  *
- * Core offers no way to ask for one action and not the other: the script has no --actions option,
- * and turning history off with $wgActions['history'] = false is worse than useless, since
- * Action::factory() then returns false and the script calls show() on it. So the action stays
- * registered, as something that costs nothing to run: OutputPage::output() returns immediately
- * once disabled, so the script's capture comes back empty, and HTMLFileCache::saveToFileCache()
- * writes nothing for output under 512 bytes. No render, no file, no history/ tree.
- *
- * Only the bake loads this. A wiki serving the history action wants core's own HistoryAction.
+ * Core offers no way to ask for one and not the other, and $wgActions['history'] = false is worse
+ * than useless: Action::factory() returns false and show() is called on it. So the action stays
+ * registered, costing nothing.
  */
 class SkippedHistoryAction extends Action {
 	/** @inheritDoc */

--- a/includes/SourceAuthors.php
+++ b/includes/SourceAuthors.php
@@ -9,15 +9,10 @@ use MediaWiki\User\UserRigorOptions;
 /**
  * The accounts a build writes pages under: one per author the source history names.
  *
- * A revision has to belong to someone, and the point of reading the history (see SourceHistory) is
- * that the name the footer shows is the name the "View history" link's commit list shows. These
- * accounts are as throwaway as the wiki holding them: the export carries no user pages and no
- * contributions, so nothing is claimed of a name beyond having written the page.
- *
- * A name MediaWiki will not take is retried as the other names that author has committed under.
- * Only when none of them is usable, and for a page the history says nothing about, does this fall
- * back to the account the build itself writes under, which build.php's hideBuildAuthors() then
- * hides rather than offer to the reader as an author.
+ * A revision has to belong to someone, and the point of reading the history is that the name the
+ * footer shows is the one the "View history" commit list shows. A name MediaWiki will not take is
+ * retried as the other names that author has committed under; only when none is usable does this
+ * fall back to the account the build writes under, which hideBuildAuthors() then hides.
  */
 class SourceAuthors {
 	private UserFactory $factory;

--- a/includes/SourceHistory.php
+++ b/includes/SourceHistory.php
@@ -7,24 +7,12 @@ use MediaWiki\Utils\ExecutableFinder;
 /**
  * When each source file last changed, and who changed it, as the repository's git history tells it.
  *
- * The wiki a bake fills is thrown away afterwards and has no edit history of its own: every page is
- * written in a single import pass, so whatever that pass stamps on the revision is what the reader
- * is told. The file's mtime used to be that stamp, which on a CI runner is the moment the checkout
- * was made -- the same instant for every page, and a different one for every bake of the same
- * commit, which is also the one date SOURCE_DATE_EPOCH cannot freeze (#406).
+ * The wiki a bake fills has no edit history of its own: every page is written in one import pass,
+ * so what that pass stamps is what the reader is told. The file's mtime gave the moment of the
+ * checkout -- one instant for every page, and the one date SOURCE_DATE_EPOCH cannot freeze.
  *
- * git holds the real answer, and it is the one the "View history" link already sends the reader to:
- * the top entry of that list is the commit this reads. Two ways in, since the history is not always
- * reachable from where the bake runs:
- *
- * - A dump of `git log`, named by $wgWikvenSourceHistoryFile. actions/bake mounts the source
- *   directory alone into the container, with no .git beside it, so it writes this on the runner.
- * - git itself, when the source directory is inside a checkout the build can reach: a standalone
- *   binary run from a repository, or an image run with the repository itself as the source.
- *
- * Neither being available is not an error. The build then dates every page at the commit it is
- * building (SOURCE_DATE_EPOCH) and names no author, which is true of the whole export rather than
- * of each page in it.
+ * Two ways in: a dump of `git log` named by $wgWikvenSourceHistoryFile, or git itself. Neither
+ * being available is not an error.
  */
 class SourceHistory {
 	/**
@@ -137,11 +125,8 @@ class SourceHistory {
 	 * Who last changed the file, as git records their name, and then every other name that same
 	 * author has committed under, newest first.
 	 *
-	 * A git author name is free text and MediaWiki's is not, so the name on the commit is not
-	 * always one an account can carry ("A / B" holds a slash, which usernames cannot). The rest of
-	 * the list is the way out that invents nothing: it is the same person, spelled as they have
-	 * spelled themselves elsewhere in this repository, matched on the email git records beside the
-	 * name. Empty when the history does not cover the file, or records no author for it.
+	 * A git author name is free text and MediaWiki's is not ("A / B" holds a slash). The rest of the
+	 * list invents nothing: the same person as spelled elsewhere here, matched on the email.
 	 *
 	 * @return list<string>
 	 */

--- a/includes/Stylesheet.php
+++ b/includes/Stylesheet.php
@@ -7,13 +7,9 @@ class Stylesheet {
 	/**
 	 * Write one stylesheet out, and say what went wrong when it did not reach the disk.
 	 *
-	 * The caller is meant to stop the build on a problem rather than move on to the next module:
-	 * a bake that filled the disk, or wrote into a read-only export directory, used to leave the
-	 * site unstyled and say so only through wfDebug(), which goes nowhere without a debug log a
-	 * wikven build never configures. An unstyled site is not something to hand over with exit 0.
-	 *
-	 * The write's own warning is left to be printed, since it carries the reason the file could
-	 * not be opened; this message adds the name the build knows the file by.
+	 * The caller is meant to stop the build rather than move on to the next module: a bake that
+	 * filled the disk used to leave the site unstyled and say so only through wfDebug(), which goes
+	 * nowhere.
 	 *
 	 * @param string $filename Where the stylesheet goes.
 	 * @param string $text The CSS to write there.

--- a/includes/TarballChecksum.php
+++ b/includes/TarballChecksum.php
@@ -5,26 +5,19 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * The sha256 a WikvenRepositories tarball entry pins, and whether a download is the file it names.
  *
- * Configuration promises this: "64 hex characters; the build aborts on a mismatch", and tells a
- * site to pin one "for a tamper-evident, reproducible build". A tarball is the one fetch method
- * whose source can change under a site without its configuration changing -- a URL serves whatever
- * it serves today -- so the pin is the only thing between a site and running code nobody chose.
+ * Configuration promises this: "64 hex characters; the build aborts on a mismatch". A tarball is
+ * the one fetch method whose source can change under a site without its configuration changing, so
+ * the pin is the only thing between a site and running code nobody chose.
  *
- * Kept here rather than inside the maintenance script so the promise can be held to a test: what a
- * spec pins, what counts as a sha256, and whether a file answers to one are three questions with
- * answers that do not need a wiki.
+ * Kept here rather than inside the maintenance script so the promise can be held to a test.
  */
 class TarballChecksum {
 	/**
 	 * The checksum a spec pins, lowercased and trimmed, or null where it pins none.
 	 *
-	 * Says nothing about whether the value is a checksum; that is isValid()'s question, asked
-	 * separately so a spec that pins nonsense is told apart from one that pins nothing.
-	 *
-	 * Null is a pin, not the absence of one. "sha256:" with nothing after it is how YAML spells a
-	 * key whose value the author has not filled in yet, and reading that as "pins nothing" fetched
-	 * the tarball unverified without a word -- the one outcome the key exists to prevent. Only a
-	 * spec with no sha256 key at all pins nothing.
+	 * Says nothing about whether the value is a checksum; that is isValid()'s question. Null is a
+	 * pin, not the absence of one: "sha256:" with nothing after it is a key nobody has filled in
+	 * yet, and reading that as "pins nothing" fetched the tarball unverified.
 	 *
 	 * @param array $spec One WikvenRepositories entry.
 	 */

--- a/includes/UploadReference.php
+++ b/includes/UploadReference.php
@@ -5,40 +5,13 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * What a rendered page says about a picture it shows, and what the export should say instead.
  *
- * A page's pictures come from one of two places, and the export publishes both the same way: the
- * build copies each file into the asset directory under a content-addressed name, and every
- * reference to it has to be moved with it. A file this wiki stored reaches the page as a URL under
- * $wgUploadPath, a directory the export does not publish; a file a foreign repository serves --
- * Wikimedia Commons through InstantCommons -- reaches it as that repository's own URL, which the
- * export must stop depending on. Hence the two named constructors: one pattern each, one answer
- * for both.
+ * Every picture is copied into the asset directory under a content-addressed name, so every
+ * reference moves with it: a stored file is named under $wgUploadPath, a hotlinked one at its
+ * repository's host.
  *
- * That much is a rewrite. What makes it a decision is that a page says the same URL in more than
- * one way, and the ways are not interchangeable.
- *
- * A page's body gets a stored picture from File::getUrl(), a path from the site root. Machine-read
- * metadata -- an og:image, a schema.org image -- gets File::getFullUrl(), which is that same URL
- * expanded against $wgServer and so carries a scheme and a host. MediaWiki has already decided
- * which question was asked, and the answer is in the text: a reference that arrived whole is one
- * something will read away from the page, where a path beside the page means nothing. So a whole
- * URL is answered with a whole URL, and a root-relative one with the file beside the page. There is
- * no hook to ask instead -- File::getUrl() is memoised and FileRepo::getZoneUrl() is a configured
- * string -- but there is no need for one, because nothing has thrown the distinction away yet.
- *
- * A foreign repository throws it away. Its files are somewhere else whoever is asking, so both
- * calls answer with the same whole URL and the shape of a hotlink says nothing about who reads it.
- * Answering every one of them whole would drag the body's pictures onto the published host, and
- * answering every one of them beside the page is what left an og:image naming "./assets/img-*.jpg"
- * -- a card no crawler can resolve. What still knows is where in the page the reference sits, so
- * that is asked: HeadMetadata. It is asked of a stored picture too, and only ever agrees with the
- * shape there, which is the point -- the rule is "read away from the page", and the shape was
- * always the proxy for it.
- *
- * The second spelling is the escaping. json_encode() writes a slash as "\/" unless told otherwise,
- * and an extension writing a JSON-LD block calls it plainly, so the same URL reads "\/images\/x.png"
- * there. A pattern that knows only the first spelling walks straight past it and leaves a URL
- * naming a directory, or a host, the export does not serve -- which is how one page could carry a
- * rewritten og:image and a dead schema.org image for the same file.
+ * A page spells the same URL two ways. Root-relative in the body and whole in head metadata, where
+ * whole means something reads it away from the page; a foreign repository answers both whole, so
+ * HeadMetadata is asked where it sits.
  */
 final class UploadReference {
 	/** A slash as a page can spell it: bare in an attribute, backslash-escaped inside JSON. */
@@ -80,13 +53,9 @@ final class UploadReference {
 	/**
 	 * References to pictures a foreign repository serves, which the page names at that host.
 	 *
-	 * There is no "host" group: every one of these carries a scheme and a host, so a group holding
-	 * it would say "whole" about the body's pictures as loudly as about the head's, and mean
-	 * nothing. Where they are read is decided by where they sit instead.
-	 *
-	 * The query is part of the reference rather than trimmed off it, unlike a stored picture's: a
-	 * repository's thumbnailer answers the URL it was given, and what a page asked for is the only
-	 * description of the file the export has.
+	 * No "host" group: every one of these carries one, so it would say "whole" about the body's
+	 * pictures as loudly as about the head's. The query is kept, unlike a stored picture's, because
+	 * a thumbnailer answers the URL it was given.
 	 *
 	 * @param string $host The repository's file host, e.g. "upload.wikimedia.org".
 	 * @param SiteUrl $siteUrl Where the export is published, if the site has said.
@@ -102,12 +71,10 @@ final class UploadReference {
 	 * Point every reference in $html at the file the build published instead.
 	 *
 	 * @param string $html A rendered page.
-	 * @param callable(string):(string|null) $publish Given what the reference names -- for a stored
-	 *   picture what follows the upload path ("/Card.png", "/thumb/Card.png/100px-Card.png"), for a
-	 *   hotlinked one the whole URL -- the reference the build publishes that file under
-	 *   ("./assets/img-*.ext"), or null if it could not be published. Asked once per reference
-	 *   rather than per occurrence, so the caller that reads and copies is the one that remembers;
-	 *   a reference it cannot answer is left as the page wrote it, for it to report.
+	 * @param callable(string):(string|null) $publish Given what the reference names -- what follows
+	 *   the upload path, or the whole URL for a hotlink -- the reference the build publishes that
+	 *   file under, or null if it could not be published. Asked once per reference; one it cannot
+	 *   answer is left as the page wrote it, for the caller to report.
 	 */
 	public function rewrite(string $html, callable $publish): string {
 		$metadata = HeadMetadata::of($html);
@@ -115,17 +82,15 @@ final class UploadReference {
 		return preg_replace_callback(
 			$this->pattern,
 			function (array $m) use ($publish, $metadata): string {
-				// One name per file, whatever the reference looked like: a stored picture's
-				// trailing ?query is left out by the pattern, so a page's several sizes and cache
-				// stamps of one picture are one question, and the escaping is undone here, so a
-				// file written both ways is one path and not two.
+				// One name per file, whatever the reference looked like: the pattern leaves out a
+				// stored picture's trailing ?query, and the escaping is undone here, so a file
+				// written both ways is one path and not two.
 				$href = $publish(str_replace('\\/', '/', $m['ref'][0]));
 				if ($href === null) {
 					return $m[0][0];
 				}
 				// PREG_OFFSET_CAPTURE gives every match its position, which is the only reason the
-				// span check above can be asked anything; a group the pattern does not have, or one
-				// that did not take part, is absent or empty here.
+				// span check can be asked anything; a group that did not take part is empty here.
 				$whole = $this->siteUrl->isKnown() && ( ( $m['host'][0] ?? '' ) !== '' || $metadata->holds($m[0][1]) );
 				$out = $whole ? $this->siteUrl->forFile(ltrim($href, './')) : $href;
 

--- a/includes/UserAgent.php
+++ b/includes/UserAgent.php
@@ -5,24 +5,15 @@ namespace MediaWiki\Extension\Wikven;
 /**
  * What wikven calls itself on the servers it fetches from.
  *
- * A bake reaches other people's machines: it asks Commons for the thumbnail of every image a page
- * embeds and downloads each one, and it clones or downloads whatever third-party extensions and
- * skins the site declares. All of that arrives on somebody else's logs, and what it says there is
- * the only chance they have of telling this traffic apart from anything else -- of knowing which
- * tool made it, which version, and where to go about it. Wikimedia asks for exactly that in its
- * User-Agent policy, and it is the party wikven talks to most.
- *
- * Left alone, none of it says wikven. MediaWiki's HttpRequestFactory signs a request "MediaWiki/"
- * and its own version, which names the library doing the sending and not the thing that asked for
- * it: an operator reading that has no way to reach anyone, and every wikven build in the world
- * looks like a wiki. So requests carry this instead, and the shape is the one the policy asks for
- * -- the tool, its version, where it lives, and the library underneath:
+ * A bake reaches other people's machines -- Commons for every embedded image, git for every
+ * declared extension -- and their logs are their only chance of telling this traffic apart.
+ * Wikimedia's User-Agent policy asks for that, and MediaWiki's own "MediaWiki/1.46.0" names the
+ * library rather than the tool, so requests carry this instead:
  *
  *     Wikven/0.1.0 (+https://github.com/chaotic-ground/wikven) MediaWiki/1.46.0
  *
- * The version is read from extension.json rather than written here twice, so a release moves it
- * without anyone remembering to. The class is dependency-free on purpose: fetchExtensions runs
- * before wikven's autoloader exists and loads it by path, the same way it loads Attempts.
+ * The version is read from extension.json rather than written here twice. Dependency-free on
+ * purpose: fetchExtensions loads it by path, before wikven's autoloader exists.
  */
 class UserAgent {
 	/**
@@ -63,10 +54,9 @@ class UserAgent {
 	/**
 	 * The same, after whatever the client would have said on its own.
 	 *
-	 * For a client that is not wikven's to speak for entirely. git is the one: its own string is
-	 * "git/2.43.0", and some proxies pass HTTP git traffic only when the User-Agent still looks
-	 * like a git client's, so replacing it outright would break a fetch on networks nobody here
-	 * can see. Adding to it says who is driving without taking that away.
+	 * git is the one. Some proxies pass HTTP git traffic only when the User-Agent still looks like
+	 * a git client's, so replacing "git/2.43.0" outright would break a fetch on networks nobody
+	 * here can see.
 	 */
 	public static function after(string $client): string {
 		$client = trim($client);

--- a/includes/Webfonts/FontCopier.php
+++ b/includes/Webfonts/FontCopier.php
@@ -6,10 +6,8 @@ namespace MediaWiki\Extension\Wikven\Webfonts;
  * Copy the woff2 files a baked stylesheet names out of UniversalLanguageSelector's font repository.
  *
  * The stylesheet and the files it points at are one thing: an @font-face whose url() answers 404
- * leaves the reader with exactly the tofu the bundled font was there to spare them, and nothing on
- * the page says why. So this reports every file that did not arrive rather than counting the ones
- * that did -- a bake that ships nine fonts of the ten its stylesheet names got the site something
- * other than what it asked for, and the caller is the one that has to be able to tell.
+ * leaves the reader with exactly the tofu the bundled font was there to spare them. So this reports
+ * every file that did not arrive rather than counting the ones that did.
  */
 class FontCopier {
 	/**

--- a/includes/Webfonts/FontRepository.php
+++ b/includes/Webfonts/FontRepository.php
@@ -3,20 +3,15 @@
 namespace MediaWiki\Extension\Wikven\Webfonts;
 
 /**
- * Turn UniversalLanguageSelector's font-repository data into a static @font-face
- * stylesheet, so an export can ship webfonts without ULS's runtime JavaScript.
+ * Turn UniversalLanguageSelector's font-repository data into a static @font-face stylesheet, so an
+ * export can ship webfonts without ULS's runtime JavaScript.
  *
- * ULS applies, with no reader interaction, the first font listed for a language,
- * unless that first entry is "system" (the OS font, i.e. no webfont). This class
- * reproduces exactly that default: for each language whose default is a real
- * font, it emits an @font-face for the font and its bold/italic variants, and a
- * :lang() rule that applies it. The alternative fonts a reader could pick from
- * the ULS menu are dropped, since a static page carries no menu.
+ * ULS applies, with no reader interaction, the first font listed for a language, unless that entry
+ * is "system". This reproduces that default: an @font-face for the font and its bold and italic
+ * variants, and a :lang() rule that applies it.
  *
- * The font url()s are written relative to a caller-supplied base, meant to be the
- * path from the stylesheet's own location to the copied woff2 files. Because the
- * URLs in an external stylesheet resolve against the stylesheet, not the page
- * linking it, they render correctly from any page depth or host subdirectory.
+ * The url()s are written relative to a caller-supplied base -- the path from the stylesheet to the
+ * copied woff2 files -- so they resolve from any page depth.
  */
 class FontRepository {
 	/** @var array<string,string[]> Language code => font family names, in preference order. */

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -23,56 +23,43 @@ $wgFileCacheDirectory = $wikvenDist;
 $wgWikvenSourceDirectory = $wikvenSrc;
 $wgWikvenHtmlDirectory = $wikvenDist;
 
-// That file cache holds two actions per page, and the export is one of them. rebuildFileCache.php
-// renders ?action=history for every page as well, in every skin pass, into a tree the pass then
-// deletes -- and no exported page ever links to a local history page. Swap the action for one that
-// renders nothing rather than pay for it (see SkippedHistoryAction for why not $wgActions off).
-// Through $GLOBALS because the setting defaults to an empty array that is never written here.
+// That file cache holds two actions per page, and the export is one of them: rebuildFileCache.php
+// renders ?action=history for every page in every skin pass, into a tree the pass then deletes.
+// Swap it for an action that renders nothing (see SkippedHistoryAction for why not $wgActions).
 $GLOBALS['wgActions']['history'] = MediaWiki\Extension\Wikven\SkippedHistoryAction::class;
 
-// Per-page "last edited" dates and authors come from the source tree's git history. A bake usually
-// cannot reach it -- actions/bake mounts the source directory alone, without the .git beside it --
-// so the action dumps the log on the runner and mounts it here instead. Absent, the build asks git
-// directly, which answers when the source directory is itself in a checkout (see SourceHistory).
+// Per-page "last edited" dates come from the source tree's git history, which a bake usually
+// cannot reach: actions/bake mounts the source directory without the .git beside it, so the action
+// dumps the log on the runner and mounts it here instead. See SourceHistory.
 $wgWikvenSourceHistoryFile = $wikvenPaths['history'];
 
 // $wgCacheEpoch would otherwise follow LocalSettings.php's mtime, which the entrypoint rewrites
 // every bake, and it is a version input of any module carrying a versionCallback.
 $wgInvalidateCacheOnLocalSettingsChange = false;
 
-// The database queue pops jobs in random order by default (JobQueueDB::optimalOrder), to spread
-// concurrent runners over different rows. A build has one runner and wants a fixed order: the jobs
-// that render translated pages create those pages, so a random order gives them different page and
-// revision ids on every bake.
-// Only the order is overridden, so the class and claimTTL core picked stay as they are.
+// The database queue pops jobs in random order by default, to spread concurrent runners over
+// different rows. A build has one runner and wants a fixed order: the jobs that render translated
+// pages create those pages, so a random order gives them different ids on every bake.
 $GLOBALS['wgJobTypeConf']['default']['order'] = 'fifo';
 
 // The NewPP limit report is a wall-clock measurement of the parse, so it differs between bakes.
 // It is addressed to someone debugging a live wiki, and nothing in an export can act on it.
 $wgEnableParserLimitReporting = false;
 
-// Run the whole build as of one instant. Every revision and upload is created while the build runs,
-// so with a live clock the pages report themselves as edited seconds ago, differently in each bake:
-// "last edited" lines, File: history, {{CURRENTTIMESTAMP}}, page_touched, cache stamps. Freezing the
-// clock settles all of them at the source, which is what SOURCE_DATE_EPOCH means
-// (https://reproducible-builds.org/docs/source-date-epoch/); wikven's GitHub action passes the
-// commit being built, so the dates are true of it. Without it a fixed date is used, a wrong-but-
-// fixed one being easier to live with than a wrong-and-moving one.
+// Run the whole build as of one instant. Every revision and upload is created while the build
+// runs, so with a live clock the pages report themselves as edited seconds ago, differently in
+// each bake. That is what SOURCE_DATE_EPOCH means; wikven's GitHub action passes the commit being
+// built. Without it a fixed date is used.
 $wikvenEpoch = getenv('SOURCE_DATE_EPOCH');
 $wikvenEpoch = is_string($wikvenEpoch) && preg_match('/^\d+$/', trim($wikvenEpoch))
 	? (int)trim($wikvenEpoch)
 	: 946_684_800;
 Wikimedia\Timestamp\ConvertibleTimestamp::setFakeTime($wikvenEpoch);
 
-// A build parses every page many times over (the import, the job queue, the translated pages, one
-// pass per skin), and each parse of a page embedding a Wikimedia Commons image asks
-// commons.wikimedia.org for that image's thumbnail URL again. MediaWiki caches those lookups in
-// the main object cache, which the installer leaves at CACHE_NONE; all that is left then is a
-// three-entry per-process cache, which a site using more than three distinct Commons URLs
-// immediately thrashes. Point the main cache at the build's own database so each lookup is made
-// once per build instead of once per parse. The parser cache is unaffected: CACHE_ANYTHING already
-// resolved to the database. The lookups still left are worth retrying rather than trusting to one
-// attempt; the Retrier hook handler sees to that.
+// A build parses every page many times over, and each parse of a page embedding a Commons image
+// asks commons.wikimedia.org for that image's thumbnail URL again. MediaWiki caches those lookups
+// in the main object cache, which the installer leaves at CACHE_NONE, leaving a three-entry
+// per-process cache a site with four Commons URLs thrashes. Point it at the build's own database.
 $wgMainCacheType = CACHE_DB;
 
 // The frozen clock makes this one impossible to invalidate: CacheTime::expired() tests
@@ -110,11 +97,9 @@ unset($wgFooterIcons['poweredby']);
 
 // Detect image backend at run time; SVG never via ImageMagick (IM7 lacks `convert`).
 $wikvenFindExe = static function (array $names) {
-	// Core's own environment checks locate the very same binaries with this, so the two agree on where
-	// they are: it splits PATH on PATH_SEPARATOR and also searches the standard bin directories a
-	// stripped-down PATH omits (/usr/local/bin, /opt/csw/bin, ...). It reaches nothing but getenv() and
-	// is_executable() at this point, so it is safe this early; guarded anyway, since LocalSettings runs
-	// before the extension can assume anything about the core it was dropped into.
+	// Core's own environment checks locate the same binaries with this, so the two agree on where they
+	// are: it splits PATH and also searches the standard bin directories a stripped-down PATH omits.
+	// It reaches nothing but getenv() and is_executable(), so it is safe this early.
 	if (class_exists(\MediaWiki\Utils\ExecutableFinder::class)) {
 		return \MediaWiki\Utils\ExecutableFinder::findInDefaultPaths($names) ?: null;
 	}
@@ -201,24 +186,11 @@ foreach ([$wikvenYamlData, $wikvenSiteData] as $wikvenData) {
 // Push merged config into globals so the logo handling below reads final values.
 $wgSettings->apply();
 
-// Core keeps a site's address in two halves -- $wgCanonicalServer is scheme and host, a path lives
-// elsewhere -- and a site should not have to write it twice. It writes WikvenSiteUrl once and this
-// hands core the half core understands, so an absolute URL core or any extension builds names the
-// right host. The path half is wikven's to add; see SiteUrl.
+// Core keeps a site's address in two halves and a site should not have to write it twice: it
+// writes WikvenSiteUrl once, and this hands core the half core understands; see SiteUrl.
 //
-// $wgServer gets it too. Core means it as the address requests arrive on, and for a live wiki the
-// two are the same; a build is the case where they are not, and the entrypoint installs against
-// http://localhost:4000 because the installer demands a value, not because anything is served
-// there. Nothing in a build fetches from it -- every step is a maintenance script -- so what it
-// reaches is what is written into pages, and a reader was being handed the build container's
-// address. WikiSEO named it as the site's publisher on every page.
-//
-// Only where the site said. Left alone, both keep the install's localhost, which is wrong but is
-// what everything downstream already expects of a build that has not been told.
-//
-// This is where the setting is read. SiteUrl is handed the written value rather than fetching it,
-// so the same class serves this file, a maintenance script holding configuration, and a test
-// holding neither.
+// $wgServer gets it too. Nothing in a build fetches from it, so a reader was being handed the
+// build container's address.
 $wikvenSiteUrl = MediaWiki\Extension\Wikven\SiteUrl::fromWritten((string)( $wgWikvenSiteUrl ?? '' ));
 if ($wikvenSiteUrl->isKnown()) {
 	$wgCanonicalServer = $wikvenSiteUrl->canonicalServer();
@@ -226,18 +198,15 @@ if ($wikvenSiteUrl->isKnown()) {
 }
 
 // And take back the three the build works out for itself, which apply() has just handed to
-// whatever a site's file said. A site that set WikvenSourceDirectory would move where its pages are
-// read from without moving where its own config file was looked for -- SiteConfig::locate() ran
-// against the workdir long before this line -- so it would be configured from one tree and built
-// from another. SiteConfig::lint() warns about the key; this is what makes the warning true.
+// whatever a site's file said. A site that set WikvenSourceDirectory would be configured from one
+// tree and built from another, SiteConfig::locate() having run against the workdir long before.
 $wgWikvenSourceDirectory = $wikvenPaths['source'];
 $wgWikvenHtmlDirectory = $wikvenPaths['dist'];
 $wgWikvenSourceHistoryFile = $wikvenPaths['history'];
 
-// Say which setting core cannot accept, while the site's file is still the obvious suspect. Without
-// this a wrong-typed value is carried until something reads it, and what the site sees is a stack
-// trace from a part of MediaWiki it never named. This cannot catch a misspelled key: validate()
-// walks the schema's keys rather than the file's, so a name core does not define is never visited.
+// Say which setting core cannot accept, while the site's file is still the obvious suspect.
+// Without this a wrong-typed value is carried until something reads it. It cannot catch a
+// misspelled key: validate() walks the schema's keys rather than the file's.
 foreach (MediaWiki\Extension\Wikven\SiteConfig::schemaErrors($wgSettings->validate()) as $wikvenBadSetting) {
 	error_log("Wikven: WARNING in configuration: $wikvenBadSetting");
 }
@@ -247,19 +216,13 @@ $config['extensions'] = array_values(array_unique(array_filter($config['extensio
 $config['skins'] = array_values(array_unique(array_filter($config['skins'], 'is_string'), SORT_STRING));
 
 // A name in these two lists is a directory in this image, and both loops below turn it straight
-// into a path: a name carrying a path separator resolves outside the image -- into the mounted
-// source tree, say -- and is then loaded as if the image had shipped it. fetchExtensions.php
-// already refuses such a name as a WikvenRepositories key, so refuse it where the loading actually
-// happens too. SiteConfig::lint() is the other channel available and is the wrong one here: it only
-// warns, and only about the site file, while these lists are that file merged with default.yml.
-// error_log() is where this file reports the names it passes over, so a refused one lands beside
-// them.
+// into a path: one carrying a path separator resolves outside the image and is then loaded as if
+// the image had shipped it. fetchExtensions.php already refuses such a name, so refuse it where
+// the loading happens too.
 
-// Anything named below that is not on disk is a name whose settings nobody here can account for;
-// the report at the end of this file says why that silences it. Collected rather than counted,
-// because the build fails on it and has to be able to say which names: this file cannot fail on it
-// itself, since fetchExtensions.php boots this file in order to install the very names that are
-// missing at that point.
+// Anything named below that is not on disk is a name whose settings nobody here can account for.
+// Collected rather than counted, because the build fails on it and has to say which names -- and
+// this file cannot fail on it itself, fetchExtensions.php booting it to install what is missing.
 $GLOBALS['wgWikvenMissing'] = [];
 
 // Register each bundled skin; canonical name (may differ from dir) read from skin.json.
@@ -289,11 +252,8 @@ foreach ($config['skins'] ?? [] as $skin) {
 }
 $wgWikvenSkins = array_values(array_unique($wgWikvenSkins));
 
-// Which skin the site is read in. A site names it the way MediaWiki does, with DefaultSkin, and the
-// skins list says which to build -- so the two questions are asked separately, and neither answer is
-// the other's by accident. Without one, the first built skin, which is the only answer a one-skin
-// site needs. The name has to be one that was built: a default nothing renders leaves the output
-// root with no pages in it at all, which is worse than reading the site in a skin you did not name.
+// Which skin the site is read in. A site names it with DefaultSkin, and the skins list says which
+// to build. Without one, the first built skin: a default nothing renders leaves the root empty.
 $wikvenNamedSkin = $wikvenSiteData['config']['DefaultSkin'] ?? '';
 if (!is_string($wikvenNamedSkin)) {
 	$wikvenNamedSkin = '';
@@ -323,10 +283,9 @@ $wgDefaultSkin = $wgWikvenMainSkin;
 $wikvenBuildSkin = getenv('WIKVEN_BUILD_SKIN');
 if ($wikvenBuildSkin !== false && in_array($wikvenBuildSkin, $wgWikvenSkins, true)) {
 	$wgDefaultSkin = $wikvenBuildSkin;
-	// Source images are uploaded by the pass that populates the wiki, so by the time a skin
-	// renders there is nothing left to upload -- and an "Upload file" link in the rendered
-	// chrome would point at a Special: page the export does not have. Citizen's is the visible
-	// one: it moves the entry out of the toolbox (which Hider empties) into the sidebar.
+	// Source images are uploaded by the pass that populates the wiki, so by the time a skin renders
+	// there is nothing left to upload, and an "Upload file" link would point at a Special: page the
+	// export does not have. Citizen's is the visible one, in the sidebar rather than the toolbox.
 	$wgEnableUploads = false;
 	// The passes run beside each other, and SQLite takes one writer at a time -- a pass still
 	// writes to the object cache, which is a table. build.php hands each one a copy of the
@@ -363,15 +322,10 @@ foreach ($config['extensions'] ?? [] as $extension) {
 	}
 }
 
-// UniversalLanguageSelector (enabled for content i18n) would have the browser pull its webfont
-// module and font files from load.php, which a static export cannot serve. Turn its runtime
-// webfonts off; when $wgWikvenBundleWebfonts is set, maintenance/bakeWebfonts.php instead bakes
-// the same fonts into a static stylesheet (see includes/Webfonts/FontRepository.php).
-// Its input methods go the same way: focusing any text input -- the search box, most visibly --
-// has the browser fetch ext.uls.ime and jquery.ime from load.php. Nothing in an export takes
-// typed input anywhere, so there is nothing for a transliteration keyboard to type into. The flag
-// below is not what stops that fetch: Main::onSetupAfterCache() empties the list of selectors the
-// handler binds to, and says there why that cannot be done from here.
+// UniversalLanguageSelector would have the browser pull its webfont module and font files from
+// load.php, which a static export cannot serve; with $wgWikvenBundleWebfonts set, bakeWebfonts.php
+// bakes the same fonts into a static stylesheet instead. Its input methods go the same way. The
+// flag below is not what stops that fetch: Main::onSetupAfterCache() empties the selector list.
 if (in_array('UniversalLanguageSelector', $config['extensions'], true)) {
 	$GLOBALS['wgULSWebfontsEnabled'] = false;
 	$GLOBALS['wgULSIMEEnabled'] = false;
@@ -396,16 +350,8 @@ if (
 
 // Say which config names nothing defines, now that everything that could define one is queued.
 // This is the quietest way a line in a site's file is lost: $wgSettings writes the name into a
-// global, no code ever reads that global, and the build succeeds having ignored the line. Core is
-// not in a position to report it -- validate() walks the schema's keys rather than the file's, and
-// an extension's settings never reach that schema at all, ExtensionRegistry writing them straight
-// to globals -- so the queued manifests are read here instead. getQueue() is the installer's, and
-// used here because at this point in the boot it is the only complete answer to what is about to
-// load; a wrong answer costs a warning either way and never a build.
-//
-// Silent while a name in this site's lists is missing from the image, because the extensions that
-// would account for its settings are exactly the ones that are not there. fetchExtensions.php
-// boots this file to install them, and so boots it before they exist.
+// global nothing reads. Silent while a name in this site's lists is missing, fetchExtensions.php
+// booting this file to install those.
 if ($wikvenSiteFile !== null && $GLOBALS['wgWikvenMissing'] === []) {
 	// Core's names are already in hand, and most of a config file is core settings. Only what they
 	// leave over is worth opening two dozen manifests for, which is usually nothing at all -- and

--- a/maintenance/bakeWebfonts.php
+++ b/maintenance/bakeWebfonts.php
@@ -14,17 +14,14 @@ $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 require_once "$IP/maintenance/Maintenance.php";
 
 /**
- * Bake UniversalLanguageSelector webfonts into the export as a plain stylesheet:
- * @font-face plus :lang() rules for the languages the pages use, with the woff2
- * files copied alongside. It reproduces the font ULS would apply by default,
- * without shipping ULS's runtime JavaScript (which pulls fonts from load.php,
- * an endpoint a static host cannot serve).
+ * Bake UniversalLanguageSelector webfonts into the export as a plain stylesheet: @font-face plus
+ * :lang() rules for the languages the pages use, with the woff2 files copied alongside. It
+ * reproduces the font ULS would apply by default, without shipping ULS's runtime JavaScript, which
+ * pulls fonts from load.php.
  *
- * Opt-in via $wgWikvenBundleWebfonts, since it adds font payload; a no-op when
- * off or when ULS is not installed. The stylesheet is linked like site.styles.css
- * (rewriteScripts wires it in, rename's reparenting keeps the <link> correct at
- * any subpage depth), and its font url()s resolve against the stylesheet itself,
- * so they hold from every page regardless of depth or host subdirectory.
+ * Opt-in via $wgWikvenBundleWebfonts, since it adds font payload; a no-op when off or when ULS is
+ * not installed. The stylesheet is linked like site.styles.css, and its font url()s resolve against
+ * the stylesheet itself, so they hold from every page whatever its depth.
  */
 class BakeWebfonts extends Maintenance {
 	/** Output subdirectory (under the dist root) the woff2 files are copied into. */

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -74,12 +74,11 @@ class Build extends Maintenance {
 		// Materialize content translations before RunJobs so rendered translation pages get exported.
 		$this->step(BuildTranslations::class, "$own/buildTranslations.php");
 		$this->runJobs("$ip/maintenance/runJobs.php");
-		// Every category a page belongs to is known now, and not before: a page's categories are
-		// written by the links update its edit queues, which runJobs above is what runs. Asked
-		// here rather than after the passes, so a site with a fault in it is told before three
-		// skins render it.
+		// Categories are written by the links update each edit queues, which runJobs above runs, so
+		// this is the first point they are known -- and it is before the passes, so a site with a
+		// fault in it is told before three skins render it.
 		$this->assertNamedCategoriesAreEmpty();
-		// Every page the export will hold now exists, and nothing writes another revision after
+		// Every page the export will hold now exists and nothing writes another revision after
 		// this, so this is where each page can be told when it was last edited, and by whom.
 		$this->stampSourceHistory();
 		$this->hideBuildAuthors();
@@ -88,7 +87,7 @@ class Build extends Maintenance {
 		// below can be readers of it.
 		$this->freezePageTouched();
 		// The search index is built by now, by the job runJobs() holds back to the end, and every
-		// skin pass below copies it. Settle it here so the one copy they all take is already stable.
+		// pass below copies it. Settled here so the one copy they all take is stable.
 		$this->stabilizeSearchIndex();
 
 		$config = $this->getConfig();
@@ -102,15 +101,9 @@ class Build extends Maintenance {
 	/**
 	 * Say that a skin preview is experimental, once, before the work starts.
 	 *
-	 * Not experimental as in unfinished. A skin is written against several MediaWiki releases and
-	 * this renders on the one the build carries, so what it shows is that skin on that version and
-	 * nothing about the others -- which is less than a skin author needs, and more than this
-	 * project can widen. Documenting the mode at length in Configuration would promise the rest of
-	 * it, so the limit is said here, where somebody is running the mode and can weigh it, and again
-	 * in examples/skin-preview.
-	 *
-	 * From the orchestrating pass rather than from renderSkin(), which has returned above: a line
-	 * per skin would say it once per pass and be noise by the third.
+	 * Not unfinished: a skin is written against several MediaWiki releases and this renders on the
+	 * one the build carries, which is less than a skin author needs and more than this project can
+	 * widen. From the orchestrating pass, so it is said once and not per skin.
 	 */
 	private function announceSkinPreview(): void {
 		if (!BuildFor::skinPreview()) {
@@ -124,11 +117,10 @@ class Build extends Maintenance {
 	}
 
 	/**
-	 * Say what this site's Lua and this build's Lua make of each other; see Scribunto for the ways
-	 * they used to pass quietly and produce a site with braces in it.
+	 * Say what this site's Lua and this build's Lua make of each other; see Scribunto.
 	 *
-	 * Only one of the two ends the build, and it is the one the site asked for: Scribunto listed where
-	 * nothing can run it. The other is a remark about Module: files the site never asked to run.
+	 * Only one of the two ends the build, and it is the one the site asked for: Scribunto listed
+	 * where nothing can run it. The other is a remark about Module: files nobody asked to run.
 	 */
 	private function checkLuaAgainstThisBuild(): void {
 		$source = rtrim((string)$this->getConfig()->get('WikvenSourceDirectory'), '/');
@@ -149,9 +141,9 @@ class Build extends Maintenance {
 	/**
 	 * Every file under the source directory, relative to it.
 	 *
-	 * Not ImportWikitext's list, which is filtered by SourceFile::isPageFile() -- and that asks
-	 * MediaWiki for the title's content model, so with Scribunto absent a module file is not a page
-	 * file and would be missing from exactly the case worth catching.
+	 * Not ImportWikitext's list, which SourceFile::isPageFile() filters by asking MediaWiki for the
+	 * content model -- so with Scribunto absent a module file is not a page file, and would be
+	 * missing from exactly the case worth catching.
 	 *
 	 * @return string[]
 	 */
@@ -172,18 +164,15 @@ class Build extends Maintenance {
 	/**
 	 * Whether anything here can run Lua.
 	 *
-	 * Four ways, in the order Scribunto would find them. luasandbox is the engine the image carries.
-	 * Failing that, Scribunto's standalone engine runs an external lua: the one this site configured,
-	 * one on PATH, or -- and this is the case that is easy to forget -- one Scribunto ships itself,
-	 * which is what it falls back to when luaPath is null.
+	 * Four ways, in the order Scribunto would find them: luasandbox, then the standalone engine's
+	 * external lua -- this site's, one on PATH, or the one Scribunto ships and falls back to.
 	 */
 	private static function luaEngineAvailable(): bool {
 		if (extension_loaded('luasandbox')) {
 			return true;
 		}
-		// Scribunto's own setting, and this is a static with no getConfig() to ask. It stays on
-		// $GLOBALS for the second reason too: the key is absent wherever Scribunto is not loaded,
-		// which is the case the caller above is here to report.
+		// Scribunto's own setting, and this is a static with no getConfig() to ask. $GLOBALS also
+		// answers where Scribunto is not loaded at all, which is the case being reported.
 		$configured = (string)( $GLOBALS['wgScribuntoEngineConf']['luastandalone']['luaPath'] ?? '' );
 		if ($configured !== '' && is_executable($configured)) {
 			return true;
@@ -201,13 +190,9 @@ class Build extends Maintenance {
 	/**
 	 * Whether the lua binary Scribunto carries can run here.
 	 *
-	 * Existing is not enough, which is why this runs it. None of the five binaries Scribunto bundles is
-	 * arm64 -- they are Intel, Linux and Windows in 32- and 64-bit and macOS in 64 -- and
-	 * LuaStandaloneInterpreter picks among them by PHP_OS and PHP_INT_SIZE, so on arm it selects the
-	 * x86-64 one, passes its own is_executable() check on it, and only finds out when the process will
-	 * not start. The path below mirrors that choice for 64-bit Linux, which is the only platform either
-	 * wikven product runs on; executing it is what makes the mirror safe, since a wrong guess answers
-	 * no rather than promising Lua that never arrives.
+	 * Existing is not enough, which is why this runs it. None of the five binaries Scribunto
+	 * bundles is arm64, and LuaStandaloneInterpreter picks by PHP_OS and PHP_INT_SIZE, so on arm it
+	 * selects the x86-64 one and finds out when the process will not start.
 	 */
 	private static function bundledLuaRuns(): bool {
 		$lua =
@@ -224,11 +209,9 @@ class Build extends Maintenance {
 	/**
 	 * Run the queue one type at a time, in name order: the runner otherwise shuffles the types.
 	 *
-	 * The search index is held back to the end. SifterSearch enqueues a rebuild for every revision
-	 * inserted, and although a pending one absorbs the rest, each pass of the queue picks up
-	 * whichever has arrived since. A bake was running Pagefind 21 times and leaving 20 dead
-	 * generations of hashed index files in the output, since Pagefind writes into a directory rather
-	 * than replacing it. Held back, it runs once, over the finished content.
+	 * The search index is held back to the end. SifterSearch enqueues a rebuild per revision
+	 * inserted and each pass of the queue picks up whichever arrived since, so a bake was running
+	 * Pagefind 21 times.
 	 */
 	private function runJobs(string $file): void {
 		$group = $this->getServiceContainer()->getJobQueueGroup();
@@ -258,18 +241,9 @@ class Build extends Maintenance {
 	 * Date every page at the commit that last changed the file it was written from, and credit
 	 * that commit's author.
 	 *
-	 * The footer's "last edited" line reports a page's newest revision, and every revision here is
-	 * written by the build: the import stamps its own instant, and a translatable page is written
-	 * again by Translate's marker and once more per language by its render jobs. Chasing each of
-	 * those writes means guessing which one lands last; stamping the rows once the content is
-	 * final does not, and it is the same answer for all of them. What the file's mtime used to
-	 * give was the moment CI cloned the repository -- one instant for every page, a different one
-	 * for every bake of the same commit, and the one date SOURCE_DATE_EPOCH could not freeze
-	 * (#406). git has the real one, and it is what the "View history" link opens.
-	 *
-	 * A page the history says nothing about -- one generated by the build, like Licenses and
-	 * Settings, or a source file never committed -- keeps the frozen build clock, which dates it
-	 * at the commit being built. That is true of the export as a whole, if not of the page.
+	 * Every revision here is written by the build, so the "last edited" line reported whichever
+	 * landed last; the file's mtime gave the moment CI cloned the repository, the one date
+	 * SOURCE_DATE_EPOCH could not freeze (#406).
 	 */
 	private function stampSourceHistory(): void {
 		$config = $this->getConfig();
@@ -317,10 +291,9 @@ class Build extends Maintenance {
 	 * What the history says about the file a page was written from, or null for a page the build
 	 * wrote itself.
 	 *
-	 * SourceFile's naming convention answers which file that is for an imported page and for a
-	 * translated one alike: "Skins" came from "Skins.wikitext" and "Skins/ko" from
-	 * "Skins/ko.wikitext". The one page with no file of its own is the source-language page
-	 * Translate adds ("Skins/en"), which follows the page it repeats.
+	 * SourceFile's naming convention answers which file that is: "Skins" came from
+	 * "Skins.wikitext", "Skins/ko" from "Skins/ko.wikitext". The one page with no file of its own
+	 * is the source-language page Translate adds.
 	 *
 	 * @return ?array{timestamp:int,authors:string[]}
 	 */
@@ -343,20 +316,9 @@ class Build extends Maintenance {
 	/**
 	 * Stop the "last edited" lines naming the accounts the build writes under.
 	 *
-	 * The wiki is filled by maintenance scripts, so unless the source history just named a page's
-	 * author, the account on its newest revision is the build's own: "Maintenance script" for
-	 * everything the import and the page setters above wrote, and Translate's FuzzyBot for the
-	 * translated pages its jobs render. Minerva's footer bar was offering that name to every
-	 * reader as the person who last edited the page (#406). It names nobody, and the export has no
-	 * user page, contributions or account for it to lead to.
-	 *
-	 * MediaWiki's own way of saying that a revision's author is not public is the DELETED_USER bit,
-	 * and skins answer it without a name: Minerva emits no editor at all for a revision whose
-	 * RevisionRecord::getUser() is null, leaving its bar to read "Last edited <when> by an
-	 * anonymous user" -- which is what the export knows -- and with no name there is no link to a
-	 * user page the export does not have. Vector's #footer-info-lastmod never carried an author.
-	 * The pages that would report the bit itself, history and diffs, are not rendered, and page
-	 * content hangs off a separate bit (DELETED_TEXT) this leaves alone.
+	 * The wiki is filled by maintenance scripts, so Minerva was offering the build's own account to
+	 * every reader as the person who last edited the page (#406). DELETED_USER is how MediaWiki
+	 * says an author is not public, and skins answer it without a name.
 	 */
 	private function hideBuildAuthors(): void {
 		$names = [User::MAINTENANCE_SCRIPT_USER];
@@ -387,13 +349,9 @@ class Build extends Maintenance {
 	/**
 	 * Drop the cached copies of the revision rows the two steps above rewrote in place.
 	 *
-	 * RevisionStore keeps the row of a page's newest revision in the object cache for a week, keyed
-	 * on the page and revision ids alone (RevisionStore::ROW_CACHE_KEY), and an edit in place
-	 * changes neither id. The build reads most pages long before those two steps run -- the job
-	 * queue parses every one of them -- so without this the skin passes, fresh processes over the
-	 * same database-backed cache, would render each page with the date it had before it was
-	 * stamped. Nothing else in the cache is touched: the Commons thumbnail lookups it also holds
-	 * are why the build has one at all (see WikvenSettings.php).
+	 * RevisionStore caches a page's newest revision row for a week, keyed on the page and revision
+	 * ids alone, and an edit in place changes neither. Without this the skin passes would render
+	 * each page with the date it had before it was stamped.
 	 */
 	private function forgetCachedRevisionRows(): void {
 		$cache = $this->getServiceContainer()->getMainWANObjectCache();
@@ -419,18 +377,9 @@ class Build extends Maintenance {
 	/**
 	 * Freeze page_touched once content is final; wiki-page modules fold it into their version hash.
 	 *
-	 * Once, in the orchestrator, rather than once per skin pass: what it writes is content state,
-	 * the same in every pass and derived from nothing a pass did, so a three-skin bake was running
-	 * the same full-table update three times for two no-ops. It is also one of the two writes that
-	 * kept a pass from being a reader of the database -- rebuildFileCache.php puts the wiki in
-	 * read-only mode for its own duration, so a pass has no business writing around it -- and a
-	 * reader is what a pass has to be to run beside another one (#407).
-	 *
-	 * Freezing here also means the pages are rendered with the frozen value rather than with
-	 * whatever the import and the job queue left, since the passes now boot after it. That is the
-	 * point of the freeze rather than a cost of moving it: SOURCE_DATE_EPOCH differs per commit,
-	 * so a page_touched written under the frozen clock differs per commit too, and pinning it is
-	 * what keeps the module version hashes embedded in the HTML stable between bakes.
+	 * Once in the orchestrator rather than per pass: it writes content state, and it is one of the
+	 * two writes that kept a pass from being a reader (#407). The pages are then rendered with the
+	 * frozen value, which keeps the module version hashes stable.
 	 */
 	private function freezePageTouched(): void {
 		$dbw = $this->getPrimaryDB();
@@ -441,9 +390,8 @@ class Build extends Maintenance {
 			->caller(__METHOD__)
 			->execute();
 
-		// The modules read page_touched through LinkCache, not the row just written: this process
-		// has warmed it filling the wiki, and its MediaWiki: entries are kept in the object cache
-		// as well, which the passes below boot onto rather than build for themselves.
+		// The modules read page_touched through LinkCache rather than the row just written; this
+		// process warmed it filling the wiki, and the passes below boot onto its object cache.
 		$linkCache = $this->getServiceContainer()->getLinkCache();
 		$pages = $dbw->newSelectQueryBuilder()
 			->select(['page_namespace', 'page_title'])
@@ -460,16 +408,8 @@ class Build extends Maintenance {
 	 * Render every enabled skin, several passes at a time.
 	 *
 	 * The passes are independent by construction: everything they read is in the database before
-	 * the first one starts, each writes into an output directory of its own, and each is a
-	 * separate process with its own boot. So the skin phase is the half of the bake that
-	 * parallelizes, and the half that grows -- the populate phase above is O(pages) and stays
-	 * serial, while this is O(pages x skins) and gains a pass every time a skin is added (#407).
-	 *
-	 * What the passes still share is the database, and a pass is not quite a reader of it: the
-	 * object cache is a table ($wgMainCacheType = CACHE_DB), and SQLite takes one writer at a
-	 * time. Each therefore gets a copy of the database file to work on, which also keeps a pass
-	 * from reading what another one cached -- so a pass renders from the same state whether it
-	 * runs first, last or beside the others, which is what keeps the output reproducible (#411).
+	 * the first one starts, and each is a separate process writing its own output directory (#407).
+	 * What they still share is the database, hence the copy each takes below.
 	 *
 	 * @param string[] $skins
 	 */
@@ -497,8 +437,8 @@ class Build extends Maintenance {
 					continue;
 				}
 				// Whole and in one piece, now that the pass is done: three renders writing to this
-				// process's own stdout as they go would interleave into something no one could
-				// attribute a failure from, and the log is how a bake is debugged.
+				// process's own stdout as they went would interleave into something no one could
+				// attribute a failure from.
 				$this->reportPass($skin, $running[$skin], $exit);
 				$finished[$skin] = ['exit' => $exit, 'output' => $running[$skin]['output'][1]];
 				unset($running[$skin]);
@@ -540,11 +480,9 @@ class Build extends Maintenance {
 	 */
 	private function startSkinPass(array $command, string $skin, string $databaseDirectory): array {
 		// The skin, the database and the working directory are passed to the child alone, so this
-		// process's own environment and cwd stay untouched while a skin renders. run.php resolves
-		// relative to the install root, which the binary's php-cli requires, hence $GLOBALS['IP']
-		// as the child's cwd. An array argv also means the arguments never pass through a shell to
-		// be quoted for. Both variables are set even when empty, so that a pass never inherits a
-		// value another run left in this process's environment.
+		// process's own environment and cwd stay untouched. run.php resolves relative to the
+		// install root, hence $GLOBALS['IP'] as the child's cwd. Both variables are set even when
+		// empty, so a pass never inherits a value another run left behind.
 		$environment = ['WIKVEN_BUILD_SKIN' => $skin, 'WIKVEN_BUILD_DB_DIR' => $databaseDirectory] + getenv();
 		$descriptors = [0 => STDIN, 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
 		$pipes = [];
@@ -665,18 +603,12 @@ class Build extends Maintenance {
 	/**
 	 * Give each pass a copy of the database to render from.
 	 *
-	 * A pass reads the content, but it still writes: the object cache is a table of this database
-	 * ($wgMainCacheType = CACHE_DB, which is there so the Commons thumbnail lookups a bake makes
-	 * are made once). SQLite takes one writer at a time, so passes sharing the file would be
-	 * serialized by it at best and fail with SQLITE_BUSY at worst. The file is small and the
-	 * content is final by now, so a copy each is the cheap way out -- and the copies are taken
-	 * after the populate phase, so each pass inherits its lookups rather than repeating them.
-	 *
-	 * A server database has no such limit and is left alone, as is a single-pass bake.
+	 * A pass reads the content, but it still writes: the object cache is a table of this database,
+	 * and SQLite takes one writer at a time. The copies are taken after the populate phase, so
+	 * every pass inherits its cached lookups. A server database is left alone.
 	 *
 	 * @param string[] $skins
-	 * @return array<string,string> Skin to the data directory holding its copy; empty when the
-	 *   passes share the database.
+	 * @return array<string,string> Skin to the directory holding its copy; empty where they share one.
 	 */
 	private function copyDatabasePerPass(array $skins): array {
 		$config = $this->getConfig();
@@ -783,15 +715,9 @@ class Build extends Maintenance {
 	/**
 	 * Put the search bundle's entry file in an order it will come out in again next bake.
 	 *
-	 * Pagefind names each language's index in one JSON map and writes that map in whatever order it
-	 * happened to iterate, so two bakes of one source produce two spellings of the same fact: the
-	 * index hashes and page counts match, the order of the languages does not. One language has no
-	 * order to get wrong, which is why this surfaced only once translations were indexed in their
-	 * own language rather than all as the wiki's.
-	 *
-	 * Reproducibility is the build's promise (#411), not the indexer's, so the build keeps it --
-	 * exactly as StripBuildStamps drops the per-request ids MediaWiki leaves in a page. Search
-	 * explains what is safe to rewrite and why nothing reading the bundle can tell.
+	 * Pagefind names each language's index in one JSON map and writes it in whatever order it
+	 * iterated, so two bakes agree on every index and disagree on the order. Reproducibility is the
+	 * build's promise (#411), not the indexer's.
 	 */
 	private function stabilizeSearchIndex(): void {
 		// SifterSearch's own settings stay on $GLOBALS here and in the two methods below: they
@@ -803,11 +729,10 @@ class Build extends Maintenance {
 		}
 		$path = "$bundle/" . Search::INDEX_ENTRY_FILE;
 		if (!is_file($path)) {
-			// Three things used to end here together, and only two of them are fine: search off,
-			// search on with nothing to index, and search on with an index that did not get built.
-			// The job having run is what tells the third from the other two -- a Pagefind run that
-			// died leaves the site with a search box wired to a bundle that is not there, since
-			// Search::isActive() asks only whether the setting is set.
+			// Three things used to end here together and only two are fine: search off, search on
+			// with nothing to index, and search on with an index that did not get built. The job
+			// having run is what tells the third from the other two, since Search::isActive() asks
+			// only whether the setting is set.
 			if ($this->searchIndexRan) {
 				$this->fatalError(
 					"Wikven: the search index was not written ($path), though the job that builds it"
@@ -826,15 +751,8 @@ class Build extends Maintenance {
 	/**
 	 * Point this pass's search at a bundle of its own, and say where that bundle has to be written.
 	 *
-	 * A skin copy already holds its own pages, styles and scripts; the search index was the one
-	 * thing it went on reading out of the export root, and reading it there is what sent a reader
-	 * who searched back to the root copy (#399, and Search::copyBundlePath for why the bundle's
-	 * location decides that). So the copy gets its own, and every URL SifterSearch derives from it
-	 * -- a result, the results page, the form's target, the "containing" row -- lands in the copy
-	 * without anything on the client having to correct it.
-	 *
-	 * The main skin renders into the export root, where the index already is, so it needs none of
-	 * this; nor does a site whose bundle sits somewhere this cannot put a copy beside.
+	 * The search index was the one thing a skin copy went on reading out of the export root, which
+	 * sent a reader who searched back to the root copy (#399).
 	 *
 	 * @return ?string The directory the bundle must be copied to, or null where nothing is to change.
 	 */
@@ -927,9 +845,9 @@ class Build extends Maintenance {
 	/**
 	 * Stop on a category the site said a finished build must find empty.
 	 *
-	 * MediaWiki renders a page with a fault in it and files the page in a tracking category rather
-	 * than refusing; the export then publishes the page and drops the category, which is not in it.
-	 * FailOnCategories says what a category with anything in it is worth, and this is what asks.
+	 * MediaWiki files a page with a fault in it into a tracking category rather than refusing it,
+	 * and the export publishes the page and drops the category. FailOnCategories says what a
+	 * category with anything in it is worth; this is what asks.
 	 */
 	private function assertNamedCategoriesAreEmpty(): void {
 		$named = (array)$this->getConfig()->get('WikvenFailOnCategories');
@@ -955,23 +873,8 @@ class Build extends Maintenance {
 	 * The category one entry of WikvenFailOnCategories names, or null where it names none.
 	 *
 	 * An entry is a message key where this wiki has that message and a category title otherwise,
-	 * because a message is how MediaWiki holds a tracking category's name: nothing in core says
-	 * "Pages with template loops", it says template-loop-category, and a wiki reading in another
-	 * language answers that key with its own name. Naming the key is therefore the only way the
-	 * default list can name core's faults without deciding what language the sites using it read
-	 * in, and a site writing a category of its own still writes the name.
-	 *
-	 * The two cannot collide in practice -- a category name is a page title and a message key is
-	 * not one a wiki would title a category -- and where they somehow do, the message wins and
-	 * says so by resolving to the name it holds.
-	 *
-	 * Null is for a message a wiki has edited to "-", which is MediaWiki's own way of switching a
-	 * tracking category off: a category nothing can be filed into is not one to look in.
-	 *
-	 * A key belonging to an extension this site does not load has no message either, and falls to
-	 * the category reading, where it names a category nothing files into and is found empty. That
-	 * is what lets the default carry every bundled extension's faults while a site loads none of
-	 * them, and it costs one query each for the ones it does not have.
+	 * because a message is how MediaWiki holds a tracking category's name. Null is a message edited
+	 * to "-", which switches the category off.
 	 */
 	private function categoryNamed(string $entry): ?Title {
 		$message = wfMessage($entry)->inContentLanguage();
@@ -1045,10 +948,8 @@ class Build extends Maintenance {
 	 * Stop on a name in the site's extensions or skins list that nothing here provides.
 	 *
 	 * WikvenSettings collects these rather than failing on them, because fetchExtensions.php boots
-	 * it to install the very components that are missing while it runs. By here they are installed,
-	 * so a name still unaccounted for is one nothing will account for -- and a build that carries on
-	 * publishes a site missing whatever the author asked that name for, with one line in a log of
-	 * thousands to say so. A typo in a skin name is the ordinary case.
+	 * it to install the very components that are missing. By here they are installed, so a name
+	 * still unaccounted for would publish a site missing whatever the author asked for.
 	 */
 	private function assertEverythingListedIsHere(): void {
 		$missing = $this->getConfig()->get('WikvenMissing');
@@ -1105,11 +1006,8 @@ class Build extends Maintenance {
 		$child->setArg(0, $directory);
 		$child->setOption('extensions', implode(',', $extensions));
 		// No --skip-dupes. It skips a file whose *content* matches one already imported, whatever
-		// the two are called, so a logo shipped twice under two names left the second name with no
-		// File: page and every page embedding it red-linking, reported as one skipped line and a
-		// successful build. Nothing is lost by dropping it: a name already taken is skipped by the
-		// importer with or without it, and two source files cannot share a name here anyway --
-		// collisions() above has already stopped the build if they do.
+		// the two are called, so a logo shipped twice under two names left the second with no File:
+		// page. collisions() above already stops the build on two source files sharing a name.
 		//
 		// Subdirectories, because pages are read from them; sources() above walked the same way.
 		$child->setOption('search-recursively', true);
@@ -1128,11 +1026,8 @@ class Build extends Maintenance {
 	/**
 	 * Every source image now has a File: page, or the build stops naming the ones that do not.
 	 *
-	 * The importer answers "I skipped that one" with the same success it answers "I imported them
-	 * all" with, and it has more than one reason to skip: a duplicate under another name, a title
-	 * core would not make from the file's own name, a name already taken. Whichever it was, the
-	 * page embedding the image is left with a red link and the build says nothing, so the check is
-	 * on the outcome rather than on the reasons -- the pages that were supposed to be here.
+	 * The importer answers "I skipped that one" with the same success as "I imported them all".
+	 * Whichever reason it had, the page is left with a red link, so the check is on the outcome.
 	 *
 	 * @param string[] $sources Absolute paths, as ImageImport::sources() returns them.
 	 */
@@ -1238,12 +1133,9 @@ class Build extends Maintenance {
 
 	/**
 	 * Generate a Settings page: the reader's own display choices, which a static export keeps in
-	 * the browser rather than in a user account. It stands in for Special:MobileOptions, which is
-	 * MobileFrontend's and which no bake writes, and it is a page rather than a panel so every
-	 * skin can link to it.
-	 *
-	 * The controls themselves are drawn by ext.Wikven.appearance into the placeholders below;
-	 * wikitext cannot carry a radio, and the choices mean nothing without the script anyway.
+	 * the browser rather than in a user account. It stands in for Special:MobileOptions, and it is
+	 * a page rather than a panel so every skin can link to it. The controls are drawn by
+	 * ext.Wikven.appearance into the placeholders below.
 	 */
 	private function setSettingsPage(): void {
 		$config = $this->getConfig();
@@ -1257,10 +1149,8 @@ class Build extends Maintenance {
 		}
 
 		// Special:MobileOptions is an empty form its own script fills, so this page is the same
-		// empty form: Adder queues the modules, and MediaWiki draws the controls it would have
-		// drawn there. Wikitext carries no <form>, and that stylesheet's layout rules all name
-		// one, so fillMinervaMenu.php puts a real form inside this. The skin list is wikven's own,
-		// and follows in a section of its own.
+		// empty form. Wikitext carries no <form> and that stylesheet's layout rules all name one,
+		// so fillMinervaMenu.php puts a real form inside this.
 		$text = "<div id=\"wikven-settings-form\"></div>\n";
 		if (count((array)$config->get('WikvenSkins')) > 1) {
 			$text .= $this->settingsSection(
@@ -1295,44 +1185,9 @@ class Build extends Maintenance {
 	/**
 	 * Give the site a page saying what it redistributes, and link it from every page.
 	 *
-	 * A built site is not only the author's words. buildScripts bakes MediaWiki's own module
-	 * closure into modules-static.js and buildStyles writes each skin's and extension's CSS beside
-	 * it, so every page the export serves carries other people's code, under other people's
-	 * licenses. Something has to say so, and it has to be reachable: a page only a reader who goes
-	 * looking would find is not an acknowledgement, which is why the footer links this one.
-	 *
-	 * One page, and not the two it is tempting to write. A site's own introduction is the site's to
-	 * write and the build has nothing to add to it; what the site redistributes is not an
-	 * introduction, and is the one thing here the build knows and the author cannot. So the
-	 * introduction is left alone and this is what gets generated.
-	 *
-	 * The whole page is written here rather than assembled from generated templates. Templates
-	 * were the earlier shape and their cost fell on every site rather than on this one: a template
-	 * the build writes unconditionally is a title in the site's own Template namespace that the
-	 * site can no longer use, and no site should carry a reserved name so that this page can be
-	 * built out of parts.
-	 *
-	 * What it lists is what the published site carries and nothing else. MediaWiki, because
-	 * buildScripts bakes its module closure into modules-static.js; the extensions and skins,
-	 * because buildStyles writes their CSS and their scripts go into the same bundle. PHP, the
-	 * database and the tools that made the build are not in it: a static site does not ship them,
-	 * and a licenses page that named them would be claiming a redistribution that never happened.
-	 *
-	 * A source page of the configured name is used as written, as every generated page's is: a site
-	 * that writes this one itself has taken the question on deliberately. Set the name empty and no
-	 * page is written and the footer entry goes with it, which is a site saying it will acknowledge
-	 * this its own way.
-	 *
-	 * It is written once per language the site is built in, at "<Page>/<lang>", because a notice
-	 * nobody can read is not one either: every string on it is a message, wikven's own and core's
-	 * Special:Version ones, so each language costs a render and nothing else. The footer's
-	 * Special:MyLanguage link then lands on the reader's own copy.
-	 *
-	 * The languages are the ones the source tree has translations in, not every language MediaWiki
-	 * knows. Nothing could reach the rest: resolveTranslationLinks settles each link by the
-	 * language of the page carrying it, and a reader is only ever on a page in a language the site
-	 * has content in, so a copy in any other language would be a file no link in the export points
-	 * at -- several hundred of them, once per skin, in the search index.
+	 * Every page carries other people's code: buildScripts bakes MediaWiki's module closure into
+	 * modules-static.js, and buildStyles writes each skin's CSS. The page lists what the export
+	 * carries and nothing else -- not PHP or the tools that made the build.
 	 */
 	private function setLicensesPage(): void {
 		$title = LicensesPage::title();
@@ -1413,22 +1268,9 @@ class Build extends Maintenance {
 	 * What the build ran on: MediaWiki, PHP and the database, with their versions, and the server
 	 * besides where a standalone binary is what ran it.
 	 *
-	 * Of the three fixed rows only one is redistributed, and it is the one that carries the most:
-	 * every page of the export loads modules-static.js, which is MediaWiki's module closure, so
-	 * core goes out with every site whatever else it installs -- and it is the component the
-	 * registry below cannot answer for, since it is not an entry in it. So MediaWiki's license is
-	 * named. PHP and the database ran the build and stayed behind; a license beside them would read
-	 * as a claim that the site ships them, and it ships neither. The lead-in says so, because an
-	 * empty cell on its own would read as a component that declared nothing. runtimeSoftware()
-	 * says why the rows it adds are named with theirs.
-	 *
-	 * They are here at all because "what built this" is worth knowing and an export has no
-	 * Special:Version to ask.
-	 *
-	 * MediaWiki's license is read from core's own composer.json rather than written here, the same
-	 * way each extension's is read from its extension.json: this file should not be the second
-	 * place that fact is kept. Unreadable leaves the cell empty, because a guess on a licenses page
-	 * is worse than a gap.
+	 * Only MediaWiki is redistributed -- every page loads modules-static.js, its module closure --
+	 * and the registry below cannot answer for it, so its license is named here. PHP and the
+	 * database ran the build and stayed behind.
 	 */
 	private function coreTable(?string $lang): string {
 		$db = $this->getServiceContainer()->getConnectionProvider()->getReplicaDatabase();
@@ -1459,19 +1301,11 @@ class Build extends Maintenance {
 
 	/**
 	 * The server a standalone-binary build ran on, as further rows for the table above, or none
-	 * where it ran on something else: the Docker image, or a wiki of your own with the extension
-	 * installed.
+	 * where it ran on something else.
 	 *
-	 * Named with their licenses where PHP and the database are not, and the difference is who
-	 * handed them to you. PHP came inside the base image you pulled and stayed behind; FrankenPHP
-	 * and Caddy are the executable you downloaded, compiled in and redistributed by wikven, so
-	 * their terms are yours to know. What the site publishes is unchanged either way -- it carries
-	 * neither -- which is what the lead-in above says.
-	 *
-	 * The names and versions come from the binary itself: caddy/wikven.go reads them out of the Go
-	 * build that assembled it and passes them in, so they cannot claim a version other than the one
-	 * linked. The licenses are written here because a Go build records none, which makes this their
-	 * one place rather than their second.
+	 * Named with their licenses where PHP and the database are not: FrankenPHP and Caddy are
+	 * compiled into the executable wikven redistributes. Their licenses are written here because a
+	 * Go build records none.
 	 *
 	 * @return list<array{string, string, string}>
 	 */
@@ -1557,11 +1391,9 @@ class Build extends Maintenance {
 	 * A wikitext table of components with versions, project links and licenses, under the given
 	 * messages.
 	 *
-	 * The license is the one the component declares in its own extension.json, which is the only
-	 * place that fact is kept and the reason a page acknowledging it need not be written by hand.
-	 * Special:Version links each one to the license text it ships; an export has no such page, so
-	 * the identifier stands on its own, and a component declaring none leaves the cell empty rather
-	 * than being guessed at.
+	 * The license is the one the component declares in its own extension.json. Special:Version
+	 * links each to the license text it ships; an export has no such page, so the identifier
+	 * stands alone, and a component declaring none leaves the cell empty.
 	 */
 	private function componentTable(
 		string $headingKey,

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -199,9 +199,8 @@ class BuildScripts extends Maintenance {
 	 * The lazy modules any rendered page needs, from the same pass over the same HTML.
 	 *
 	 * Top-level pages only, as collectPageModules() reads them: a translation is rendered from the
-	 * source page's wikitext, so a collapsible on one is a collapsible on the other, and the source
-	 * page is not in a subdirectory. Scanning deeper would also reach the per-skin copies, which
-	 * this skin's bundle has no business reading.
+	 * source page's wikitext, so a collapsible on one is a collapsible on the other. Scanning
+	 * deeper would also reach the per-skin copies.
 	 *
 	 * @return string[]
 	 */

--- a/maintenance/buildSitemap.php
+++ b/maintenance/buildSitemap.php
@@ -13,21 +13,12 @@ require_once "$IP/maintenance/Maintenance.php";
 /**
  * Write sitemap.xml, naming every page this build exported.
  *
- * A sitemap is how a crawler is told a page exists without a link to it, which for a freshly
- * published site is most of them. The protocol wants absolute URLs -- "must begin with the
- * protocol" -- so this writes nothing at all until the site has said where it will be published;
- * see SiteUrl. A sitemap naming pages a crawler cannot resolve is worse than no sitemap.
+ * A sitemap is how a crawler is told a page exists without a link to it. The protocol wants
+ * absolute URLs, so this writes nothing until the site has said where it will be published.
  *
- * The pages come from the output directory rather than from the database, because those are two
- * different sets. Core's own maintenance/generateSitemap.php reads the database, and run against a
- * wikven build it names MediaWiki:Mainpage, Help:Setup and the rest -- pages that exist as rows and
- * were never exported, so every one of them is a 404 offered to a crawler as a page. What the site
- * serves is what is on disk.
- *
- * There is no <lastmod>. Everything a build could put there is either wrong or harmful: the wiki's
- * own timestamps are frozen by freezePageTouched, and the wall clock would make two bakes of one
- * source differ, which is the promise #411 checks. Both <lastmod> and <changefreq> are optional and
- * a crawler treats them as hints; an honest omission beats a field that lies every bake.
+ * The pages come from the output directory rather than the database, those being two different
+ * sets: core's generateSitemap.php names MediaWiki:Mainpage and the rest, rows that were never
+ * exported. There is no <lastmod> either -- the wall clock would make two bakes differ (#411).
  */
 class BuildSitemap extends Maintenance {
 	/** The conventional name: what a crawler looks for, and what a webmaster tool is pointed at. */
@@ -104,14 +95,9 @@ class BuildSitemap extends Maintenance {
 	/**
 	 * Whether a rendered page is one a crawler may index, read from the page itself.
 	 *
-	 * A sitemap is an invitation to index, so naming a page that answers "noindex" asks a crawler
-	 * to do what the page refuses -- the same contradiction the skin-preview copies are kept out
-	 * of, and the reason a site that sets DefaultRobotPolicy to noindex gets no sitemap rather
-	 * than one listing everything it just told crawlers to skip.
-	 *
-	 * The page is asked rather than the configuration, because the configuration is only one of
-	 * the things that decides: __NOINDEX__ settles it a page at a time, and what MediaWiki wrote
-	 * into the file is the answer both of them end at.
+	 * A sitemap is an invitation to index, so naming a page that answers "noindex" asks a crawler to
+	 * do what the page refuses. The page is asked rather than the configuration, __NOINDEX__
+	 * settling it a page at a time.
 	 */
 	private static function invitesIndexing(string $path): bool {
 		$html = (string)file_get_contents($path);

--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -77,14 +77,9 @@ class BuildTranslations extends Maintenance {
 		// the shared message index caught up, silently producing no <Page>/<lang> page for it.
 		$this->drainJobs();
 		// Deferring the renders is not enough on its own, because the drains above have already done
-		// some: saving a unit page queues a RenderTranslationPageJob for its page, and the drain
-		// inside the next page's prepare() runs it. Those renders asked #ifexist whether units that
-		// did not exist yet existed -- a prevnext label finds its target's translated title that way
-		// -- and Title::newFromText() keeps the instance it answered with, whose "no such page" is
-		// memoized for the life of the process. Creating the page afterwards does not undo it: the
-		// units are made with Title::makeTitle(), which never touches that cache. So every later
-		// render in this process, including the search index's, would go on being told the title is
-		// untranslated and fall back to the English page name (#460, #464).
+		// some: saving a unit page queues a RenderTranslationPageJob, which the next prepare() runs.
+		// Those renders asked #ifexist whether units that did not exist yet existed, and
+		// Title::newFromText() memoizes "no such page" for the life of the process (#460, #464).
 		Title::clearCaches();
 		foreach ($prepared as $title) {
 			$this->render($title);

--- a/maintenance/checkTranslations.php
+++ b/maintenance/checkTranslations.php
@@ -143,12 +143,10 @@ class CheckTranslations extends Maintenance {
 				}
 			}
 
-			// Named for a language but carrying none of the source's unit markers, so read as a page
-			// in its own right. That is usually what it is -- "API/id" is about identifiers, not
-			// Indonesian -- and nothing here can tell the two apart, so this is said and not counted:
-			// it gates nothing and is not a translation falling behind either. The language code goes
-			// in as detail rather than as lang, because this finding is not about translating into
-			// that language and an --comment-languages=auto run should not write in it.
+			// Named for a language but carrying none of the source's unit markers, so read as a page in its
+			// own right. That is usually what it is -- "API/id" is about identifiers, not Indonesian. The
+			// language code goes in as detail rather than as lang, an --comment-languages=auto run having no
+			// reason to write in it.
 			foreach (TranslationSource::pagesNamedForALanguage($baseFile, $isKnownLanguage) as $lang => $page) {
 				$reportPage = $prefix . substr($page, strlen($source) + 1);
 				$this->findings[] = [
@@ -212,9 +210,8 @@ class CheckTranslations extends Maintenance {
 	 * The paths --comment-paths named, or null when it named none and the comment is about the
 	 * whole tree.
 	 *
-	 * The file is written by whatever knows what the change touches -- the action asks the forge
-	 * for the list -- so a run that cannot read it says so and comments about everything, which
-	 * is the behaviour this option narrows rather than a state worth failing a check over.
+	 * The file is written by whatever knows what the change touches, so a run that cannot read it
+	 * says so and comments about everything -- the behaviour this option narrows.
 	 *
 	 * @return list<string>|null
 	 */
@@ -242,8 +239,7 @@ class CheckTranslations extends Maintenance {
 	 *
 	 * English leads because it is the one language the workflow can count on a reader of the change
 	 * having in common with it. What follows is for the contributor: "auto" reads it off the
-	 * findings, so someone who sent a Korean translation is answered in Korean without the workflow
-	 * naming a language it cannot know in advance.
+	 * findings.
 	 *
 	 * @return list<string>
 	 */

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -111,10 +111,9 @@ class FetchExtensions extends Maintenance {
 				);
 			}
 
-			// Written last: a tree stamped before its fetch finished would be taken for a good one
-			// by the next build, which is the state this is here to catch. The commit goes in with
-			// it, because a reference is not a pin: the tag or branch it names can be moved, and
-			// this is what the next build compares the remote against.
+			// Written last: a tree stamped before its fetch finished would be taken for a good one by the
+			// next build, which is the state this is here to catch. The commit goes in with it, because a
+			// reference is not a pin: the tag it names can be moved.
 			$commit = isset($spec['repository'])
 				? self::gitOutput(['-C', $dest, 'rev-parse', 'HEAD'])
 				: null;
@@ -165,11 +164,9 @@ class FetchExtensions extends Maintenance {
 	/**
 	 * Whether an existing $dest has to go before the fetch, saying either way what it decided.
 	 *
-	 * Three answers, and the quiet one is the common one. A tree fetched from this same source
-	 * is the fetch already made. A tree with no pin in it was not fetched by wikven -- it is
-	 * bundled in the image, or somebody put it there -- and is left alone, which is what this
-	 * check has always done. A tree fetched from a different source is the one worth acting on:
-	 * a pin moved under a build that would otherwise keep the old code and say nothing.
+	 * A tree fetched from this same source is the fetch already made; one with no pin was not
+	 * fetched by wikven. One fetched from a different source is a pin that moved under a build
+	 * that would otherwise keep the old code.
 	 */
 	private function isStale(array $spec, string $dest, string $pin, string $name, string $kind): bool {
 		$stamp = FetchPin::inside($dest);
@@ -202,11 +199,8 @@ class FetchExtensions extends Maintenance {
 	/**
 	 * The commit the declared reference points at now, where that is not the one on disk.
 	 *
-	 * Only for a spec that names a reference: a commit is already the whole answer, a tarball
-	 * has no reference to move, and a tree that recorded no commit was not fetched by git. The
-	 * ask is one `git ls-remote`, made only where the tree is already there -- a build that has
-	 * to clone anyway never makes it -- and a remote that will not answer leaves what is on disk
-	 * alone rather than failing a build over a question nobody asked.
+	 * Only for a spec that names a reference: a commit is already the whole answer, and a tarball
+	 * has none to move. One `git ls-remote`, and a remote that will not answer leaves disk alone.
 	 *
 	 * @return string|null The commit to fetch, or null where there is nothing to do.
 	 */
@@ -441,16 +435,9 @@ class FetchExtensions extends Maintenance {
 	/**
 	 * How to call git, with the User-Agent it should send in front of the subcommand.
 	 *
-	 * A clone or a fetch over HTTPS is wikven reaching somebody else's server, and git signs it
-	 * with nothing but its own version: the operator on the other end sees a git, like every
-	 * other git, with no way to tell whose build it is or where to go about it. http.userAgent
-	 * replaces that string, so git's own goes back in front of wikven's rather than being taken
-	 * away -- there are proxies that carry git traffic only while the User-Agent still looks
-	 * like a git client's, and none of them are visible from here.
-	 *
-	 * A git that will not say what version it is keeps the string it had; naming a version this
-	 * never read would be worse than saying nothing. (composer, which some extensions need
-	 * afterwards, signs its own requests and offers no way to add to them.)
+	 * A clone over HTTPS is wikven reaching somebody else's server, and git signs it with nothing
+	 * but its own version. http.userAgent puts git's back in front of wikven's rather than
+	 * replacing it: some proxies carry git traffic only while it looks like a git client's.
 	 *
 	 * @return string[] argv up to but not including the subcommand.
 	 */
@@ -477,10 +464,8 @@ class FetchExtensions extends Maintenance {
 	/**
 	 * What `git $arguments` printed, or null where it could not be run or did not succeed.
 	 *
-	 * Located rather than spawned by name, as SourceHistory does: proc_open() warns of its own
-	 * when the command is not there, and a host without git is an answer this can give. An array
-	 * argv never reaches a shell, so a repository URL needs no quoting; git's own complaints go
-	 * nowhere, since every caller here has something to say for itself when the answer is null.
+	 * Located rather than spawned by name, as SourceHistory does: proc_open() warns of its own when
+	 * the command is not there, and a host without git is an answer this can give.
 	 *
 	 * @param string[] $arguments
 	 */

--- a/maintenance/fillMinervaMenu.php
+++ b/maintenance/fillMinervaMenu.php
@@ -18,13 +18,11 @@ require_once "$IP/maintenance/Maintenance.php";
  * Put the site's navigation in Minerva's main menu.
  *
  * Minerva builds that menu from its own Menu\Definitions and reads MediaWiki:Sidebar only to
- * override the href of its two hardcoded entries, so a site's own navigation never reaches it:
- * its Definitions class is final, its builder is constructed inside the skin, and it registers no
- * menu hook. Nothing in PHP can add an entry, so the entries are written into the rendered pages
- * instead, in the same pass that rewrites their scripts and styles.
+ * override the href of its two hardcoded entries, so a site's own navigation never reaches it: the
+ * Definitions class is final, its builder is constructed inside the skin, and it registers no menu
+ * hook. So the entries are written into the rendered pages instead.
  *
- * Runs before rename.php, so hrefs written as "./Page.html" are reparented for subpages with
- * every other link on the page.
+ * Runs before rename.php, so hrefs written as "./Page.html" are reparented with every other link.
  */
 class FillMinervaMenu extends Maintenance {
 	/** The list Minerva renders its own discovery entries into; ours follow it. */

--- a/maintenance/resolveTranslationLinks.php
+++ b/maintenance/resolveTranslationLinks.php
@@ -16,14 +16,12 @@ require_once "$IP/maintenance/Maintenance.php";
  * Resolve Translate's Special:MyLanguage/ links in the exported HTML.
  *
  * Translation pages are parsed in the source-page context, so the page language is not known at
- * render time; the exported path is (a translation is at "<Page>/<lang>.html"). This runs after
- * Rename, over the final tree: it reads each file's language from its path, then rewrites every
- * "Special:MyLanguage/Target" link to the target's translation in that language when it exists, or
- * the source target otherwise, keeping the link's existing relative prefix.
+ * render time; the exported path is. This runs after Rename, over the final tree: it reads each
+ * file's language from its path, then rewrites every "Special:MyLanguage/Target" link to the
+ * target's translation in that language when it exists.
  *
- * "The final tree" is this pass's own pages and no one else's: the walk goes through SkinOutput,
- * which keeps the main skin's out of the other skins' output below it. Deciding a link in
- * dist/citizen/Foo/ko.html by whether dist/Foo/ko.html exists is how that goes wrong.
+ * "The final tree" is this pass's own pages, the walk going through SkinOutput: a link in
+ * dist/citizen/Foo/ko.html must not be decided by whether dist/Foo/ko.html exists.
  */
 class ResolveTranslationLinks extends Maintenance {
 	public function __construct() {

--- a/maintenance/retranslateChrome.php
+++ b/maintenance/retranslateChrome.php
@@ -69,14 +69,8 @@ class RetranslateChrome extends Maintenance {
 	 * The licenses page's own language copies, which the walk above cannot reach.
 	 *
 	 * That walk finds translations by their source files, and these have none: build.php writes
-	 * them, message by message, in each language the site is built in. They are pages in that
-	 * language all the same -- the Declarer hook answers for them -- so the chrome around them has
-	 * to follow, or a Korean page keeps an English menu and footer.
-	 *
-	 * Only the copies the build wrote: a page the source tree provided, under that title or under
-	 * one of its language subpages, is the site's or Translate's, and is handled above. LicensesPage
-	 * is asked which those are, the same as the Declarer hook asks it, so the chrome a copy wears
-	 * and the language it declares cannot end up disagreeing.
+	 * them message by message. They are pages in that language all the same, so the chrome has to
+	 * follow. Only the copies the build wrote.
 	 *
 	 * @param string $source
 	 * @param string $contentLang

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -151,12 +151,8 @@ class RewriteScripts extends Maintenance {
 	 * Leave Citizen with the search its no-JS fallback gives it, or with none at all.
 	 *
 	 * Citizen's own search is a command palette backed by the REST API, which an export has no
-	 * server for. Underneath it the skin renders an ordinary search form, meant for readers without
-	 * JavaScript, and that one works: SifterSearch's ext.sifter.retarget points it at the static
-	 * results page. commandPalette.js deletes that form the moment it finds its trigger by id, so
-	 * dropping the id is what leaves the working search standing. Where the form leads nowhere --
-	 * no SifterSearch, or no results page for it to be retargeted at, Citizen having no typeahead
-	 * to carry the submit instead -- the whole box goes, as Vector's does above.
+	 * server for. Underneath it the skin renders an ordinary search form that works, and
+	 * commandPalette.js deletes it the moment it finds its trigger by id.
 	 */
 	private function citizenSearch(string $html, bool $searchWorks): string {
 		if ($searchWorks) {

--- a/maintenance/stampTranslations.php
+++ b/maintenance/stampTranslations.php
@@ -16,12 +16,11 @@ require_once "$IP/maintenance/Maintenance.php";
  * Rewrite one translation's marker stamps (@hash) to the current source unit hashes.
  *
  * A stamp is not a fact the tool can work out: it records that whoever wrote the translation wrote
- * it against this version of the source. Translate keeps that record in the database when a
- * translator saves through the wiki; a translation that arrives as a committed file never passes
- * through there, so this command writes it instead -- and only the person who did the reading can
- * say it is true. So it takes the translation they read, one file, and has no sweep: a sweep would
- * be that assertion made about pages nobody opened, which is how a stale translation comes to call
- * itself current.
+ * it against this version of the source. Translate keeps that record when a translator saves
+ * through the wiki, and a file arriving as a commit never passes through there.
+ *
+ * So this takes one file and has no sweep: a sweep would be that assertion made about pages nobody
+ * opened.
  */
 class StampTranslations extends Maintenance {
 	public function __construct() {

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -53,12 +53,10 @@ class StoreImages extends Maintenance {
 		foreach (glob("$htmlDir/*.html") as $file) {
 			$html = file_get_contents($file);
 
-			// Stored first, and only then hotlinked. Each pass reads what the one before it wrote,
-			// and both can now write the published base into a page. A site published under a path
-			// holding the upload path -- "https://example.org/images/" -- would have the second
-			// pass match the first one's answers and hunt for files nobody referenced; the
-			// repository's host is not a base anyone publishes under, so this way round nothing
-			// either writes can be mistaken for a reference by the other.
+			// Stored first, and only then hotlinked. Each pass reads what the one before it wrote, and both
+			// can now write the published base into a page. A site published under a path holding the upload
+			// path would have the second pass match the first one's answers; the repository's host is not a
+			// base anyone publishes under.
 			$html = $references->rewrite(
 				$html,
 				function (string $path) use (&$map, $uploadDir, $htmlDir, $assetDirectory): ?string {

--- a/tests/bake/Checks.php
+++ b/tests/bake/Checks.php
@@ -187,10 +187,9 @@ class Checks {
 
 	/** @return string[] */
 	private static function bakeWarnings(Site $site): array {
-		// A bake with something to say about the site's own configuration says it and carries on, so
-		// a warning is only ever seen by whoever reads the log. The site's .wikven.yaml is the
-		// configuration wikven recommends; a warning about it is a mistake either in that file or in
-		// the code that reports on it, and both are worth stopping for.
+		// A bake with something to say about the site's own configuration says it and carries on, so a
+		// warning is only ever seen by whoever reads the log. The site's .wikven.yaml is the
+		// configuration wikven recommends, so a warning about it is a mistake worth stopping for.
 		$warnings = [];
 		foreach ($site->logs as $log) {
 			foreach (explode("\n", $site->read($log)) as $line) {
@@ -275,19 +274,10 @@ class Checks {
 
 	/** @return string[] */
 	private static function noindex(Site $site): array {
-		// A page that stops being indexed is invisible by construction: nothing 404s, nothing reads
-		// wrong, and the only place it shows is a crawler's view of the site weeks later.
-		// __NOINDEX__ is a behaviour switch, so a page that writes the word while telling a reader
-		// to use it takes it -- Deploying noindexed itself, in both languages, and left the sitemap,
-		// with every gate here green (#655). It is written through <nowiki> now.
-		//
-		// Read off the rendered pages rather than the sources, because the source is where the word
-		// legitimately appears, and named rather than counted, because a count passes one page
-		// swapping for another and the swap is what nobody would read.
-		//
-		// The sitemap is the other half of the same fact and the build derives it separately, so the
-		// two have to agree with the list and with each other. That half also catches a page leaving
-		// the sitemap for a reason that has nothing to do with noindex.
+		// A page that stops being indexed is invisible by construction: nothing 404s, and the only place
+		// it shows is a crawler's view of the site weeks later. __NOINDEX__ is a behaviour switch, so a
+		// page telling a reader to use it took it -- Deploying noindexed itself, in both languages, with
+		// every gate here green (#655).
 		$expected = (array)$site->expect['noindex_pages'];
 		$copies = (array)$site->expect['skin_copies'];
 
@@ -362,12 +352,9 @@ class Checks {
 
 	/** @return string[] */
 	private static function ogImage(Site $site): array {
-		// The card a shared link shows has to be an absolute URL -- read by something that never saw
-		// the page -- AND has to name a file this build actually wrote. Both halves are asserted,
-		// because either alone passes while the card is broken: WikiSEO builds the URL under
-		// MediaWiki's upload path, which the export does not serve, and storeImages moves it to the
-		// published file. Get one half of that wrong and the tag is either a relative URL no crawler
-		// can resolve or an absolute one pointing at nothing.
+		// The card a shared link shows has to be an absolute URL -- read by something that never saw the
+		// page -- AND has to name a file this build actually wrote. Either half alone passes while the
+		// card is broken: WikiSEO builds the URL under the upload path, and storeImages moves the file.
 		$missing = [];
 		$relative = [];
 		$seen = 0;
@@ -406,19 +393,10 @@ class Checks {
 
 	/** @return string[] */
 	private static function hotlinkHost(Site $site): array {
-		// A picture this site borrows from a repository is downloaded and republished, and what says
-		// the export stopped depending on that repository is that nothing in it still names the
-		// host. The documentation site embeds one, so this has something to be about.
-		//
-		// A reference the rewrite does not match is the failure nobody hears about: the build
-		// reports the files it could not fetch, and a reference it never saw is not one of them. A
-		// schema.org block spells the same URL "https:\/\/upload.wikimedia.org\/...", and for a
-		// while that spelling went through untouched while the og:image beside it was rewritten.
-		// Searched as raw text for that reason -- either spelling holds the host verbatim.
-		//
-		// Every file rather than the pages alone, and skipping the ones that are not text, which is
-		// the reading `grep -rI` gave this before it was a check: a picture is named from a
-		// stylesheet and from a script bundle as readily as from a page.
+		// A picture this site borrows from a repository is downloaded and republished, and what says the
+		// export stopped depending on it is that nothing still names the host. A reference the rewrite
+		// does not match is the failure nobody hears about: a schema.org block spells the same URL
+		// "https:\/\/upload.wikimedia.org\/...", which went through untouched for a while.
 		$guilty = [];
 		foreach ($site->filesEndingIn('') as $path) {
 			$text = $site->read($path);
@@ -472,17 +450,9 @@ class Checks {
 	/** @return string[] */
 	private static function buildHost(Site $site): array {
 		// Nothing a reader is handed may name the machine that built it. The build installs against
-		// http://localhost:4000 and every step is a maintenance script, so any address that reaches
-		// the output through $wgServer is the container's, not the site's. Two places had one, green
-		// across every other check: WikiSEO named it as the site's author and publisher in the
-		// JSON-LD of every page, and mw.config shipped it as wgServer in the module bundle,
-		// disagreeing with the wgServerName beside it.
-		//
-		// Scoped to the head, because "http://localhost:8080" is also a correct sentence:
-		// docs/Deploying.wikitext tells a reader to open the preview there, and wikitext autolinks
-		// it, so the body legitimately holds an anchor to a local address. The head is machine-read
-		// metadata about the site and can hold no such sentence. The generated bundles are searched
-		// whole; they hold no prose either.
+		// http://localhost:4000, so any address reaching the output through $wgServer is the
+		// container's; two places had one, green across every other check. Scoped to the head, because
+		// docs/Deploying.wikitext tells a reader to open the preview at a local address.
 		$bad = [];
 		foreach ($site->filesEndingIn('') as $path) {
 			$isHtml = str_ends_with($path, '.html');
@@ -594,9 +564,7 @@ class Checks {
 	private static function pagefindLanguages(Site $site): array {
 		// Each page is indexed in the language it is written in, so Pagefind builds one index per
 		// language and a reader searching from a translated page is answered out of that language's
-		// index (#400). A single index means every translation was stamped with the wiki's content
-		// language and stemmed by English rules, which is what this site looked like until
-		// SifterSearch indexed per page rather than per wiki.
+		// index (#400). A single index meant every translation was stemmed by English rules.
 		$metas = $site->glob($site->path('pagefind', '*.pf_meta'));
 		if (!$metas) {
 			return [$site->path('pagefind') . ' holds no search index at all'];
@@ -632,15 +600,9 @@ class Checks {
 	/** @return string[] */
 	private static function pagefindSourceLanguage(Site $site): array {
 		// Marking a page for translation gives it a translation page in the source language too, so
-		// "Installation" and "Installation/en" hold the same English text under two titles and
-		// English was counted twice for every translated page (#454). Only the source page is
-		// indexed now, and what says so is the absence of any "/en.html" from the English index -- a
-		// count would not, since the pages indexed are not the source files: the build generates
-		// Licenses and Settings, which have no files, and the search results page has a file but is
-		// not indexed. Those two cancelled out the day this was written, so a count read off the
-		// source tree would have passed by luck and broken on the next page added.
-		//
-		// This reads Pagefind's fragments, which are gzipped JSON carrying the page's url.
+		// English was counted twice (#454). What says only the source page is indexed now is the
+		// absence of any "/en.html" from the English index; a count would not, the pages indexed not
+		// being the source files.
 		$language = (string)$site->expect['source_language'];
 		$pattern = '~"url":"[^"]*/' . preg_quote($language, '~') . '\.html"~';
 		foreach ($site->glob($site->path('pagefind', 'fragment', "{$language}_*")) as $fragment) {
@@ -666,10 +628,8 @@ class Checks {
 	/** @return string[] */
 	private static function sortableTable(Site $site): array {
 		// A sortable table needs jquery.tablesorter, and core does not queue it while rendering:
-		// mediawiki.page.ready looks for table.sortable in the browser and fetches the module from
-		// load.php, which an export does not have (#483). The build makes that decision instead, so
-		// what this checks is that it made it -- the module has to be in the bundle, and the page
-		// that asked for it has to still be there to ask.
+		// mediawiki.page.ready looks for table.sortable in the browser and fetches it from load.php,
+		// which an export does not have (#483). The build makes that decision instead.
 		$page = $site->path((string)$site->expect['sortable_page']);
 		if (!is_file($page) || !preg_match('~class="[^"]*\bsortable\b~', $site->read($page))) {
 			return ["$page no longer has a sortable table for this to be about"];
@@ -686,14 +646,9 @@ class Checks {
 
 	/** @return string[] */
 	private static function skinModules(Site $site): array {
-		// A skin the site never asked for has no business in the script every reader downloads. The
-		// installer used to enable every skin it found on disk, and MonoBook and Timeless rode into
-		// each bundle and onto the licenses page as skins this site publishes (#637). Read out of
-		// the startup manifest, which is the registry the bundle is built from, and so is where a
-		// skin nobody asked for shows up first. Each copy checked, not just the root: a reader of
-		// one skin downloads that copy's bundle and no other.
-		// Exact, rather than a list of names not to find: a check that only knows the two that went
-		// wrong would pass the next one.
+		// A skin the site never asked for has no business in the script every reader downloads: the
+		// installer used to enable every skin on disk, and MonoBook and Timeless rode into each
+		// bundle (#637). Read out of the startup manifest, which is what the bundle is built from.
 		$expected = (array)$site->expect['skin_modules'];
 		sort($expected, SORT_STRING);
 		$manifests = [
@@ -724,12 +679,8 @@ class Checks {
 	/** @return string[] */
 	private static function luaModules(Site $site): array {
 		// A Lua module runs at build time and its answer is baked into the page that invoked it
-		// (#465). Module:Example answers with the title of the page it ran on, so this says both
-		// that Scribunto rendered at all -- without it the invocation is left in the page as
-		// "{{#invoke:Example|thisPage}}", which is what used to happen quietly -- and that the
-		// module saw which page it was on, per language.
-		// Named per page rather than derived, because the file name has underscores where the title
-		// the module answers with has spaces.
+		// (#465). Module:Example answers with the title of the page it ran on, so this says both that
+		// Scribunto rendered at all and that the module saw which page it was on, per language.
 		$problems = [];
 		$pages = (array)$site->expect['lua_pages'];
 		ksort($pages);
@@ -779,11 +730,9 @@ class Checks {
 
 	/** @return string[] */
 	private static function headLinks(Site $site): array {
-		// Every address a page names for itself has to be one the export actually has (#394 again,
-		// one layer out). A canonical url and an hreflang alternate are whole urls, so nothing in
-		// the export resolves them and nothing else would notice one naming a page that was never
-		// written -- and a single alternate pointing at a 404 is enough for a search engine to throw
-		// away the whole set it belongs to.
+		// Every address a page names for itself has to be one the export actually has (#394 again, one
+		// layer out). A canonical url and an hreflang alternate are whole urls, so nothing in the export
+		// resolves them -- and one alternate pointing at a 404 loses the whole set it belongs to.
 		$hrefs = [];
 		foreach ($site->htmlFiles() as $page) {
 			$tags = [];
@@ -913,10 +862,9 @@ class Checks {
 
 	/** @return string[] */
 	private static function prevnextRows(Site $site): array {
-		// Every page the sidebar names gets a navigation row, and the two ends of the sequence get
-		// one link rather than two. The order lives in MediaWiki:Sidebar and Module:Sequence reads
-		// it (#455); before that it was restated in each call, and what went wrong twice was exactly
-		// this -- a page in the sidebar with no row, and the last page with none either.
+		// Every page the sidebar names gets a navigation row, and the two ends of the sequence get one
+		// link rather than two. The order lives in MediaWiki:Sidebar and Module:Sequence reads it
+		// (#455); before that it was restated in each call, and both ends went wrong.
 		$missing = [];
 		foreach (self::sidebarPages($site) as $page) {
 			$path = $site->path(str_replace(' ', '_', $page) . '.html');
@@ -937,15 +885,9 @@ class Checks {
 
 	/** @return string[] */
 	private static function prevnextLabel(Site $site): array {
-		// A prevnext link is labelled with the target page's own title, so on a translated page it
-		// must carry the translated one. The label is not in the calling page's source: the call
-		// sits outside the translate tags and passes a page name, and the template reads the title
-		// from the target's own title unit, which is the whole point -- a label restated in the
-		// caller would be a second copy of a string that is already translated once.
-		// One page is the fixture, and the expectation is read from the source rather than written
-		// into the expectations file: any Korean at all would pass a string pinned there. Which page
-		// follows it is read from the sidebar for the same reason the row itself is -- naming it
-		// would make this a check of a particular order rather than of the label.
+		// A prevnext link is labelled with the target page's own title, so on a translated page it must
+		// carry the translated one. The label is not in the calling page's source: the call sits outside
+		// the translate tags, and the template reads the target's own title unit.
 		$page = (string)$site->expect['prevnext_page'];
 		$language = (string)$site->expect['prevnext_language'];
 		$order = self::sidebarPages($site);

--- a/tests/bake/assert-bake.php
+++ b/tests/bake/assert-bake.php
@@ -8,18 +8,15 @@
  *
  * The checks themselves live in Checks.php and know nothing about where they are run. This file
  * reads the site's expectations, decides which checks have the input they asked for, runs them all,
- * and prints one line per check plus whatever each had to say. It exits 1 if any of them found a
- * problem.
+ * and prints one line per check plus whatever each had to say. It exits 1 if any found a problem.
  *
  * Every check runs even after one fails, which the shell step this replaces could not do: it ran
- * under `set -e`, so the first failure hid the rest and a broken bake took as many pushes to
- * understand as it had problems.
+ * under `set -e`, so the first failure hid the rest.
  *
- * --github additionally emits a ::error:: workflow command per problem, so the annotations that
- * used to be written into the assertions are now the runner's business rather than theirs.
+ * --github additionally emits a ::error:: workflow command per problem, so the annotations are the
+ * runner's business rather than each check's.
  *
- * Plain PHP, and no MediaWiki: a finished bake is a directory of files, so reading one needs
- * neither a wiki nor a second language in the tree to run it.
+ * Plain PHP, and no MediaWiki: a finished bake is a directory of files.
  */
 
 namespace MediaWiki\Extension\Wikven\Bake;

--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -381,9 +381,8 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 	 * they can read.
 	 *
 	 * resolveTranslationLinks.php runs on exactly this condition and settles the link by the
-	 * language of the page holding it. Without the prefix a Korean reader on Licenses/ko.html
-	 * would follow the footer to the English page -- and this link is the site's only guaranteed
-	 * route there, so there is no second way in.
+	 * language of the page holding it. Without the prefix a Korean reader on Licenses/ko.html would
+	 * follow the footer to the English page.
 	 */
 	public function testATranslatedSiteLinksTheReaderToTheirOwnLanguage() {
 		$licenses = Title::newFromText('Licenses');
@@ -405,13 +404,9 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * Every page carries a link to what the site redistributes.
 	 *
-	 * The built site ships MediaWiki's own JavaScript and each skin's CSS, and the page saying so
-	 * is no use if only a reader who goes looking finds it.
-	 *
 	 * Which of the two hrefs is written depends on whether Translate is installed beside this
-	 * suite, and the jobs disagree: the coverage run has it and the phpunit runs do not. So what is
-	 * asserted here is that the link is present and leads to the page; the exact spelling of each
-	 * route is pinned by the two cases above, which pass the flag in rather than reading it.
+	 * suite, and the jobs disagree, so what is asserted here is that the link leads to the page.
+	 * The two cases above pin each spelling.
 	 */
 	public function testTheFooterSaysWhereToFindWhatTheSiteRedistributes() {
 		$this->overrideConfigValue('WikvenLicensesPage', 'Licenses');

--- a/tests/phpunit/integration/AssetLocalizerTest.php
+++ b/tests/phpunit/integration/AssetLocalizerTest.php
@@ -14,9 +14,8 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 	 * The ResourceLoader service, with $GLOBALS['IP'] then pointed at a fixture install root.
 	 *
 	 * AssetLocalizer resolves a direct asset path against $IP, so these tests have to move it. The
-	 * service container reads the real install the first time it builds the ResourceLoader, to
-	 * register core's own modules, and errors out on a fixture root that has none of them -- so
-	 * build it first, while $IP is still the real one.
+	 * container reads the real install the first time it builds the ResourceLoader, and errors out
+	 * on a fixture root -- so build it first, while $IP is still the real one.
 	 */
 	private function resourceLoaderRootedAt(string $mwRoot): ResourceLoader {
 		$rl = $this->getServiceContainer()->getResourceLoader();
@@ -25,12 +24,10 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
-	 * Direct skin/resource/extension asset url()s in dumped CSS are the most
-	 * regex-fragile part of the static export: if they stop matching, the output
-	 * silently points at paths that only exist inside a live MediaWiki. Assert
-	 * that every reference form the build emits is rewritten to a local copy,
-	 * that look-alike paths which must NOT match are left untouched, and that the
-	 * referenced bytes are actually copied out.
+	 * Direct skin/resource/extension asset url()s in dumped CSS are the most regex-fragile part of
+	 * the static export: if they stop matching, the output silently points at paths that only exist
+	 * inside a live MediaWiki. Assert that every reference form the build emits is rewritten, that
+	 * look-alike paths are left untouched, and that the bytes are copied out.
 	 */
 	public function testLocalizeAssetsRewritesDirectAssetPaths() {
 		$mwRoot = $this->getNewTempDirectory();
@@ -133,9 +130,8 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 
 	/**
 	 * A real icon SVG carries attributes, so the inlined URI has spaces between them. CSSMin leaves
-	 * those bare because it quotes the url() it builds itself; the one emitted here is unquoted (a
-	 * quote inside a JS bundle's CSS string would need escaping), and a bare space makes the whole
-	 * declaration invalid -- the browser drops it and the icon renders blank.
+	 * those bare because it quotes the url() it builds itself; the one emitted here is unquoted,
+	 * and a bare space makes the whole declaration invalid.
 	 */
 	public function testLocalizeAssetsEncodesSpacesInInlinedAssets() {
 		$mwRoot = $this->getNewTempDirectory();

--- a/tests/phpunit/integration/HiderTest.php
+++ b/tests/phpunit/integration/HiderTest.php
@@ -111,9 +111,8 @@ class HiderTest extends MediaWikiIntegrationTestCase {
 	 * A skin preview keeps every affordance this class would take away.
 	 *
 	 * The whole of Hider is an argument about what a static host can answer for, and a skin author
-	 * baking pages to look at their skin is not asking that question: the personal menu, the
-	 * toolbox, the talk tab and the section edit links are the skin's work, and the work is the
-	 * thing being looked at.
+	 * baking pages to look at their skin is not asking that: the menus, the tabs and the edit links
+	 * are the skin's work, and that work is the subject.
 	 */
 	public function testASkinPreviewIsLeftTheChromeTheSkinDrew() {
 		$this->overrideConfigValue('WikvenBuildFor', BuildFor::SKIN_PREVIEW);

--- a/tests/phpunit/integration/Hooks/DeclarerTest.php
+++ b/tests/phpunit/integration/Hooks/DeclarerTest.php
@@ -17,9 +17,8 @@ class DeclarerTest extends MediaWikiIntegrationTestCase {
 	 * The rule: a language copy the build wrote is in that language, and nothing else is touched.
 	 *
 	 * A page MediaWiki is not told about is in the content language, which is what sent a Korean
-	 * page out as English (#561). The pages that need telling are the ones build.php writes under
-	 * the licenses page, and they are the only ones this may answer for: everything below is
-	 * either one of those or something with an owner of its own.
+	 * page out as English (#561). The pages that need telling are the ones build.php writes, and
+	 * they are the only ones this may answer for.
 	 *
 	 * @dataProvider provideTitles
 	 */

--- a/tests/phpunit/integration/Hooks/IndexerTest.php
+++ b/tests/phpunit/integration/Hooks/IndexerTest.php
@@ -57,11 +57,9 @@ class IndexerTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * Built the way MediaWiki builds it, the handler asks Translate rather than a stand-in. Neither
 	 * answer may cost a page its place: where Translate is absent the lookup says so and stops, and
-	 * where it is installed, a page nobody marked for translation is not a translation page. A wiki
-	 * without content translation must not be a wiki that loses pages.
+	 * where it is installed, a page nobody marked for translation is not a translation page.
 	 *
-	 * Both answers are reached, because the jobs differ in what they install: the quibble jobs bring
-	 * Translate along (quibble.yml names it), the phpunit jobs install MediaWiki alone.
+	 * Both answers are reached, because the jobs differ in what they install.
 	 */
 	public function testTheHandlerAsBuiltLeavesAnUnmarkedPageAlone() {
 		$index = true;

--- a/tests/phpunit/integration/LicensesPageTest.php
+++ b/tests/phpunit/integration/LicensesPageTest.php
@@ -31,9 +31,8 @@ class LicensesPageTest extends MediaWikiIntegrationTestCase {
 	 * A copy the site provided itself is the site's, and re-rendering it is not the build's to do.
 	 *
 	 * This is the page the Declarer hook keeps its hands off (#561): English prose about Korean
-	 * licensing terms, sitting at the title a Korean copy would have had. Re-rendering it in ko
-	 * would wrap Korean chrome around English prose and leave the html lang saying en, because the
-	 * hook still -- rightly -- calls the page English.
+	 * licensing terms, at the title a Korean copy would have had. Re-rendering it in ko would wrap
+	 * Korean chrome around English prose.
 	 */
 	public function testASourceCopyIsNotTheBuildsToRecache() {
 		$source = $this->sourceTreeTranslatedIntoKorean();

--- a/tests/phpunit/integration/MainHeadLinksTest.php
+++ b/tests/phpunit/integration/MainHeadLinksTest.php
@@ -122,8 +122,8 @@ class MainHeadLinksTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * A language the source tree is translated into is not by itself a licenses page in that
 	 * language. build.php writes a copy only for a language it can translate the page's own
-	 * messages into, and an alternate naming a page the export does not have is a link to a 404 --
-	 * in the head of every other page in the set, which is a set a search engine throws away whole.
+	 * messages into, and an alternate naming a page the export does not have is a set a search
+	 * engine throws away whole.
 	 */
 	public function testALicensesCopyTheBuildDidNotWriteIsNotNamed() {
 		$this->licensedSiteTranslatedIntoKorean();

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -178,12 +178,9 @@ class MainTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * A Special:MyLanguage link is written canonically, not in this wiki's own words for it.
 	 *
-	 * The link is not a link to a file -- no export holds that special page -- but the marker
-	 * resolveTranslationLinks.php reads to send a reader to their own copy of the target, and a
-	 * marker matched by one spelling has to be written in one. On a wiki whose content language is
-	 * not English the namespace is that language's word for it, so the marker written from the
-	 * wiki's own naming would be "특수:MyLanguage/..." and that pass would walk past it, leaving
-	 * every translated page pointing at a file the site does not have.
+	 * The link is not a link to a file but the marker resolveTranslationLinks.php reads, and a
+	 * marker matched by one spelling has to be written in one -- otherwise a Korean wiki writes
+	 * "특수:MyLanguage/..." and that pass walks past it.
 	 */
 	public function testSpecialMyLanguageIsMarkedCanonicallyInAnotherContentLanguage() {
 		$this->setContentLang('ko');
@@ -219,10 +216,9 @@ class MainTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
-	 * The "View source" tab points at the page's source file in the repository, and in Citizen it
-	 * brings an icon: the skin renders the page actions as icon buttons and stops rendering their
-	 * labels below desktop width, so a tab it has no icon for is a blank box there. It maps icons
-	 * onto the keys core uses, and this key is Wikven's own.
+	 * The "View source" tab points at the page's source file, and in Citizen it brings an icon: the
+	 * skin renders the page actions as icon buttons and drops their labels below desktop width, so
+	 * a tab it has no icon for is a blank box. Its icon map is keyed by core's names.
 	 */
 	public function testViewSourceTabCarriesCitizensIcon() {
 		$dir = $this->getNewTempDirectory();
@@ -264,8 +260,7 @@ class MainTest extends MediaWikiIntegrationTestCase {
 	 *
 	 * The row of page actions is the skin's layout, and a skin author baking pages to look at it
 	 * has not asked for an extra tab in it. Everything this class does to make the output work as
-	 * files -- rewriting a link to "./X.html" above all -- is untouched, so there is still a
-	 * preview to look at.
+	 * files is untouched, so there is still a preview to look at.
 	 */
 	public function testASkinPreviewGetsNoTabOfOurOwn() {
 		$dir = $this->getNewTempDirectory();

--- a/tests/phpunit/integration/ModuleRendererTest.php
+++ b/tests/phpunit/integration/ModuleRendererTest.php
@@ -143,9 +143,8 @@ class ModuleRendererTest extends MediaWikiIntegrationTestCase {
 	 * The one place the two paths are meant to differ, pinned on purpose.
 	 *
 	 * A module that throws is caught by makeModuleResponse(), which logs it and leaves an "error"
-	 * load state. respond() then writes the exception text and its backtrace into the response --
-	 * so the build used to dump a CSS or JS asset with a stack trace inside it and carry on.
-	 * render() stops instead.
+	 * load state. respond() writes the exception text and its backtrace into the response, so the
+	 * build used to dump an asset with a stack trace inside it. render() stops instead.
 	 */
 	public function testRenderThrowsOnAModuleThatCannotBeBuilt() {
 		$rl = $this->getServiceContainer()->getResourceLoader();

--- a/tests/phpunit/integration/RetryingForeignRepoTest.php
+++ b/tests/phpunit/integration/RetryingForeignRepoTest.php
@@ -71,12 +71,10 @@ class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * A successful response carrying headers, answered the way MWHttpRequest answers them.
 	 *
-	 * getResponseHeader() is documented case-insensitive and the real class implements it that
-	 * way, lowercasing the name it is asked for. MockHttpTrait's fake lowercases the name it was
-	 * *given* and compares that to the name asked for, so it answers a lowercase ask and nothing
-	 * else -- and core asks for "Last-Modified". Every header a test hands it therefore reads back
-	 * as absent, which is not a fake of MWHttpRequest but of a different class. This is one, for
-	 * the one method that differs; the rest of the response is still the trait's.
+	 * getResponseHeader() is documented case-insensitive and the real class lowercases the name it
+	 * is asked for. MockHttpTrait's fake lowercases the name it was *given*, so it answers a
+	 * lowercase ask and nothing else -- and core asks for "Last-Modified". This is a fake for that
+	 * one method.
 	 *
 	 * @param string $body The response body.
 	 * @param array<string,string> $headers The response headers, in any case.
@@ -157,9 +155,8 @@ class RetryingForeignRepoTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * Every lookup this repository makes says which tool made it and where to go about it.
 	 *
-	 * Core would sign them "MediaWiki/" and its version, which names the library rather than
-	 * the thing that asked, and Commons is the server a bake asks most: one page with ten
-	 * images is ten lookups. UserAgent holds the string; this is the wiring that carries it.
+	 * Core would sign them "MediaWiki/" and its version, which names the library rather than the
+	 * thing that asked, and Commons is the server a bake asks most.
 	 */
 	public function testALookupSaysWhichToolIsAskingAndWhereToGoAboutIt() {
 		$agents = [];

--- a/tests/phpunit/integration/TranslationSourceTest.php
+++ b/tests/phpunit/integration/TranslationSourceTest.php
@@ -114,10 +114,9 @@ class TranslationSourceTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
-	 * Hundreds of language codes are also ordinary English words -- "id", "no", "is", "it", "as",
-	 * "be" -- so a name alone had a translatable page's "API/id" subpage read as an Indonesian
-	 * translation, and the page then went missing from the built site with nothing said about it.
-	 * The unit markers are what settle it: a page written to stand on its own has no reason to
+	 * Hundreds of language codes are also ordinary English words -- "id", "no", "is", "it" -- so a
+	 * name alone had a translatable page's "API/id" subpage read as an Indonesian translation, and
+	 * the page went missing with nothing said. A page written to stand on its own has no reason to
 	 * carry a source page's unit numbers.
 	 */
 	public function testASubpageNamedForALanguageIsAPageOfItsOwnWithoutMarkers() {

--- a/tests/phpunit/unit/ContainedPathTest.php
+++ b/tests/phpunit/unit/ContainedPathTest.php
@@ -69,11 +69,9 @@ class ContainedPathTest extends MediaWikiUnitTestCase {
 
 	/**
 	 * A link is followed rather than refused, deliberately. Neither directory this bounds holds
-	 * anything the author of a path put there -- MediaWiki writes a file's contents into the upload
-	 * directory rather than a link to them, and the install root is the build's own -- while
-	 * refusing links here would have silently dropped the assets of a MediaWiki whose skins/ and
-	 * extensions/ are symlinked, which is how people develop against one. What a source tree can
-	 * bring is refused by ImageImport, where the file can be named.
+	 * anything the author of a path put there, while refusing links here would have silently
+	 * dropped the assets of a MediaWiki whose skins/ and extensions/ are symlinked, which is how
+	 * people develop against one. What a source tree can bring is refused by ImageImport.
 	 */
 	public function testALinkIsThisDirectoryToAnswerFor() {
 		$this->assertSame("$this->root/link/secret.txt", ContainedPath::under($this->root, '/link/secret.txt'));

--- a/tests/phpunit/unit/OutputNameTest.php
+++ b/tests/phpunit/unit/OutputNameTest.php
@@ -130,10 +130,8 @@ class OutputNameTest extends MediaWikiUnitTestCase {
 	 * A prefixed name handed in whole names the file its namespace and dbkey name apart.
 	 *
 	 * The Special:MyLanguage marker is built that way: the target's prefixed name rides inside the
-	 * marker's own dbkey (Hooks\Adder::licensesHref, and any link through GetLocalURL), and
-	 * resolveTranslationLinks.php then looks for the file that name spells. So the two ways of
-	 * spelling one title have to land on one file, which is only true while the namespace is
-	 * escaped exactly as the rest of the name is.
+	 * marker's own dbkey, and resolveTranslationLinks.php then looks for the file that name spells.
+	 * So the two spellings of one title have to land on one file.
 	 *
 	 * @dataProvider provideBothSchemes
 	 */

--- a/tests/phpunit/unit/TranslationAdviceTest.php
+++ b/tests/phpunit/unit/TranslationAdviceTest.php
@@ -13,8 +13,8 @@ class TranslationAdviceTest extends MediaWikiUnitTestCase {
 	 * The advice with the real English messages behind it, so what is asserted below is the wording
 	 * a contributor actually reads, and a key nobody added to i18n/en.json fails the test.
 	 *
-	 * A language other than English is answered with the same text under a tag, standing in for a
-	 * translation of the messages: enough to see that each language gets its own rendering.
+	 * A language other than English is answered with the same text under a tag, enough to see that
+	 * each language gets its own rendering.
 	 */
 	private function advice(): TranslationAdvice {
 		$messages = json_decode(file_get_contents(__DIR__ . '/../../../i18n/en.json'), true);

--- a/tests/phpunit/unit/UploadReferenceTest.php
+++ b/tests/phpunit/unit/UploadReferenceTest.php
@@ -38,10 +38,10 @@ class UploadReferenceTest extends MediaWikiUnitTestCase {
 	}
 
 	/**
-	 * The defect this class exists for. MediaWiki hands a head tag File::getFullUrl(), which is the
-	 * body's URL expanded against $wgServer, so a scheme and host arriving here is MediaWiki saying
-	 * this will be read away from the page. Answered with a path beside the page it means nothing:
-	 * a crawler that never saw the page has nothing to resolve it against.
+	 * The defect this class exists for. MediaWiki hands a head tag File::getFullUrl(), so a scheme
+	 * and host arriving here is MediaWiki saying this will be read away from the page. Answered
+	 * with a path beside the page it means nothing: a crawler that never saw the page has nothing
+	 * to resolve it against.
 	 */
 	public function testAWholeReferenceIsAnsweredWhole() {
 		$this->assertSame(


### PR DESCRIPTION
Measured against MediaWiki core and its bundled extensions, this tree's comments carried three to five times the prose of any of them. The `token_get_all` counts below are of prose only — `@param` and its neighbours, with the indented lines under them, are the signature written a second time and are left out.

| | words of prose per line of code |
| --- | ---: |
| **wikven** `includes` + `maintenance` + `tests` | **5.57** |
| MediaWiki core `includes` | 2.10 |
| MediaWiki core `maintenance` | 1.10 |
| Translate | 1.13 |
| Cite | 2.41 |

## The comments were not too many; they were too long

Inline notes ran 7.3 blocks per 100 lines of code, against 5.2 in core's `includes` and 9.8 in Cite — the middle of the range. What was out was the length distribution, and it was out wholesale rather than in a tail:

| | median | p90 | max |
| --- | ---: | ---: | ---: |
| class docblock, before | 14 | 196 | 473 |
| class docblock, core | 15 | 46 | 960 |
| inline note, before | 25 | 56 | 218 |
| inline note, core | 8 | 25 | 380 |

The medians were already fine. Everything above them was an essay: a class header that argues a position for two paragraphs before saying what the class is, an inline note that explains a decision in five sentences where one carries it. A reader looking for the sentence that says why a line is there had to read all of it to find it.

## What was done

Every comment now fits a ceiling for its kind — 150 words for a file header, 90 for a class, 60 for a method or an inline note — at roughly twice core's ninetieth percentile, so a hard-won constraint still gets its paragraph. The tree comes to 4.11 words a line.

Nothing was deleted wholesale. Each comment keeps the fact a reader cannot work out from the code — the upstream behaviour that forced the shape, the issue number, the failure that was actually seen — and gives up the argument around it, which is in the issue or pull request that decided it.

Before and after, on `includes/BuildFor.php`:

```diff
  * Who this build is for: a site being published, or a skin being looked at.
  *
- * Wikven has opinions about the chrome around a page, and they are a reader's opinions: a static
- * export has no account to log into, no watchlist to add to, no talk page to post on and no server
- * to search with, so the menus offering those are emptied, the tabs are replaced with links to the
- * source files, and a footer link to the repository goes in. That is right for a published site,
- * where every affordance left standing is one that has to work.
- *
- * It is wrong for the other thing a bake is useful for. A skin author who points wikven at a
- * handful of pages to see their skin rendered wants to see *their skin* -- the personal menu it
- * draws, the tabs it lays out, the toolbox it styles -- and what they get instead is wikven's
- * reading of it, with most of that taken away. The skin is the subject, and the tool has been
- * editing the subject.
- *
- * So the chrome layer can be turned off, and this is the switch. What it does not touch is
- * everything that makes the output a working set of files: links are still rewritten to "./X.html",
- * stylesheets and scripts are still baked to local copies, the canonical link still points at the
- * main skin's copy. Those are not opinions about how a page should look; without them there is no
- * preview to look at.
- *
- * Two per-skin fixes also stay on, because they are of the same kind: Citizen's service worker,
- * which registers against a load.php the export does not have, and its search shortcuts, which
- * reach for modules the export does not ship. Both exist to stop the page asking for something
- * that is not there, which is as true of a preview as of a site.
+ * For a site, wikven empties the menus for login, watchlist, talk and search and turns the tabs
+ * into links to the source files. That is wrong for a skin preview, where the skin is the subject,
+ * so this switch turns the chrome layer off. Link rewriting, local asset copies and the two
+ * Citizen fixes stay on either way.
  */
```

## No code changed

Two checks say so, over all 78 files:

- every file's token stream with comments removed is identical to the one before;
- every file holds the same comments it did, kind for kind, and each function's comment is a rewrite of its own rather than another's.

`mago format --check`, `mago lint` and `composer phpcs` are clean.

A second pull request adds the CI check that holds these ceilings; it needs this one merged first, since it fails on `main` as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_