### PR TITLE
ci: link the tagged repository bumps to what changed too

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -31,24 +31,24 @@ jobs:
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # The bundled extensions are pinned to commits, and a gitcommit source carries no changelog,
-      # so the pull request updatecli writes for them names the new commit and stops there: what
-      # moved is a click away only for a reader willing to build the compare url by hand. The range
-      # needs the pin being replaced, which no upstream source can know and only this repository
-      # holds, so it is worked out here -- the pins on main against the pins updatecli pushed --
-      # and appended to the body updatecli wrote.
+      # A pin this repository moves by hand does not say what moved. A gitcommit source names the
+      # new commit and stops; the notes updatecli embeds for a tagged source cover one release
+      # against the one before it, not the span a bump crosses when it skips a version. Either way
+      # the compare url is left for the reader to build, and building it needs the pin being
+      # replaced -- which no upstream source knows and only this repository holds. So it is worked
+      # out here, the pins on main against the pins updatecli pushed, and appended to the body
+      # updatecli wrote.
       #
-      # No mirror url is written down below. The Dockerfile fetches each tarball from codeload, and
-      # the site's config names the repository on the line above the commit, so every link is read
-      # off the same line as the pin it describes and cannot come to name a repository the build
-      # does not fetch from. The other manifests need none of this: their sources are GitHub
-      # releases, which bring their own notes and their own compare link.
-      - name: Link each bumped extension to what changed
+      # No mirror url is written down below. The Dockerfile fetches each tarball from codeload and
+      # the site's config names the repository a line above the pin, so every link is read off the
+      # same line as the pin it describes and cannot come to name a repository the build does not
+      # fetch from. The manifests left out bump a version string with no repository beside it.
+      - name: Link each bumped pin to what changed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          # updatecli names the branch after the manifest's pipelineid.
-          BRANCH: updatecli_main_mediawiki-extensions
+          # updatecli names each branch after its manifest's pipelineid.
+          BRANCHES: updatecli_main_mediawiki-extensions updatecli_main_wikven-repositories
           # The block is written between these, and a later run strips what they hold before
           # writing again, so a pull request updatecli keeps open collects one block and not one
           # per week.
@@ -57,12 +57,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! gh api "repos/$REPOSITORY/branches/$BRANCH" >/dev/null 2>&1; then
-            echo "wikven: updatecli pushed no extension bump; nothing to link."
-            exit 0
-          fi
-
-          # "<name> <owner/repo> <commit>", one per extension pinned by a commit.
+          # "<name> <owner/repo> <pin>", one line per repository pinned by a commit or a tag.
           pins() {
             tree=$1
             sed -n 's/^ARG \([A-Z_]*_VERSION\)=\([0-9a-f]\{40\}\)$/\1=\2/p' "$tree/Dockerfile" |
@@ -76,7 +71,7 @@ jobs:
             awk '
               /^    [A-Za-z]/ { name = $1; sub(/:$/, "", name); repo = "" }
               /^      repository:/ { repo = $2 }
-              /^      commit:/ && repo != "" {
+              /^      (commit|reference):/ && repo != "" {
                 slug = repo
                 sub(/^https:\/\/github\.com\//, "", slug)
                 sub(/\.git$/, "", slug)
@@ -86,38 +81,52 @@ jobs:
           }
 
           work=$(mktemp -d)
-          after=$work/after
-          mkdir -p "$after/docs"
-          for file in Dockerfile docs/.wikven.yaml; do
-            gh api "repos/$REPOSITORY/contents/$file?ref=$BRANCH" \
-              -H "Accept: application/vnd.github.raw" > "$after/$file"
-          done
-
           pins . | sort > "$work/before.pins"
-          pins "$after" | sort > "$work/after.pins"
-          links=$(join -j 1 -o 0,1.2,1.3,2.3 "$work/before.pins" "$work/after.pins" |
-            while read -r name slug old new; do
-              [ "$old" != "$new" ] || continue
-              printf '* [%s](https://github.com/%s/compare/%s...%s)\n' "$name" "$slug" "$old" "$new"
-            done)
 
-          if [ -z "$links" ]; then
-            echo "wikven: the branch pins what main pins; nothing to link."
-            exit 0
-          fi
+          link() {
+            branch=$1
 
-          number=$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --state open \
-            --json number --jq '.[0].number // empty')
-          if [ -z "$number" ]; then
-            echo "wikven: no open pull request for $BRANCH; leaving the links unwritten."
-            exit 0
-          fi
+            if ! gh api "repos/$REPOSITORY/branches/$branch" >/dev/null 2>&1; then
+              echo "wikven: updatecli pushed no $branch; nothing to link."
+              return 0
+            fi
 
-          gh pr view "$number" --repo "$REPOSITORY" --json body --jq .body \
-            | awk -v opening="$OPEN" -v closing="$CLOSE" '
-                $0 == opening { skip = 1 } !skip { print } $0 == closing { skip = 0 }
-              ' > "$work/body"
-          { printf '%s\n' "$OPEN"; echo; echo "What changed upstream:"; echo
-            printf '%s\n' "$links"; echo; printf '%s\n' "$CLOSE"; } >> "$work/body"
-          gh pr edit "$number" --repo "$REPOSITORY" --body-file "$work/body"
-          echo "wikven: linked $(printf '%s\n' "$links" | wc -l) bumped extension(s) on #$number."
+            after=$work/$branch
+            mkdir -p "$after/docs"
+            for file in Dockerfile docs/.wikven.yaml; do
+              gh api "repos/$REPOSITORY/contents/$file?ref=$branch" \
+                -H "Accept: application/vnd.github.raw" > "$after/$file"
+            done
+
+            pins "$after" | sort > "$work/$branch.pins"
+            links=$(join -j 1 -o 0,1.2,1.3,2.3 "$work/before.pins" "$work/$branch.pins" |
+              while read -r name slug old new; do
+                [ "$old" != "$new" ] || continue
+                printf '* [%s](https://github.com/%s/compare/%s...%s)\n' "$name" "$slug" "$old" "$new"
+              done)
+
+            if [ -z "$links" ]; then
+              echo "wikven: $branch pins what main pins; nothing to link."
+              return 0
+            fi
+
+            number=$(gh pr list --repo "$REPOSITORY" --head "$branch" --state open \
+              --json number --jq '.[0].number // empty')
+            if [ -z "$number" ]; then
+              echo "wikven: no open pull request for $branch; leaving the links unwritten."
+              return 0
+            fi
+
+            gh pr view "$number" --repo "$REPOSITORY" --json body --jq .body \
+              | awk -v opening="$OPEN" -v closing="$CLOSE" '
+                  $0 == opening { skip = 1 } !skip { print } $0 == closing { skip = 0 }
+                ' > "$work/$branch.body"
+            { printf '%s\n' "$OPEN"; echo; echo "What changed upstream:"; echo
+              printf '%s\n' "$links"; echo; printf '%s\n' "$CLOSE"; } >> "$work/$branch.body"
+            gh pr edit "$number" --repo "$REPOSITORY" --body-file "$work/$branch.body"
+            echo "wikven: linked $(printf '%s\n' "$links" | wc -l) bumped pin(s) on #$number."
+          }
+
+          for branch in $BRANCHES; do
+            link "$branch"
+          done


### PR DESCRIPTION
The step that appends "What changed upstream" to an updatecli pull request ran over `updatecli_main_mediawiki-extensions` alone. The reasoning written above it was that a tagged source brings its own notes and its own compare link, so the other manifests need none of this.

The notes are there, but the compare link inside them is per release. #685 bumps Citizen v3.21.0 → v3.22.0 and the range happens to match; a bump that skips a version does not, and the link for the range actually crossed is nowhere in the body. TabberNeue is pinned the same way.

So the same treatment now covers `updatecli_main_wikven-repositories`:

* the pin reader takes a `reference:` the way it already takes a `commit:`, off the same line as the `repository:` above it, so a tag link cannot come to name a repository the build does not clone;
* the branch-specific half of the step became a function, and the step runs it over both branches. A branch updatecli did not push, a branch that pins what `main` pins, and a branch with no open pull request are each skipped as before, now per branch rather than for the step.

What #685 would have collected:

```
<!-- wikven: what changed upstream -->

What changed upstream:

* [Citizen](https://github.com/StarCitizenTools/mediawiki-skins-Citizen/compare/v3.21.0...v3.22.0)

<!-- /wikven -->
```

That is from a local run of the step with `gh` stubbed: the extensions branch absent, the repositories branch carrying `docs/.wikven.yaml` as #685 wrote it, and an open pull request already holding a stale block. The stale block is stripped and replaced, which is what keeps a weekly run from stacking one block per week.

The manifests still left out — biome, mago, SifterSearch, Translate's runtime dependencies — bump a version string with no repository written beside it, so a link for them would have to be a url hardcoded in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_