### PR TITLE
refactor: run git from one place

### DIFF
--- a/includes/Git.php
+++ b/includes/Git.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use MediaWiki\Utils\ExecutableFinder;
+
+/**
+ * What git said, for a build that carries on without it.
+ *
+ * Located rather than spawned by name: proc_open() warns of its own accord when the command is
+ * missing, and a host with no git is an answer here rather than an error. Loadable by path,
+ * because fetchExtensions runs before wikven's autoloader.
+ */
+class Git {
+	/**
+	 * Run git and return what it printed, or null.
+	 *
+	 * Null covers every way of not getting an answer, git's own refusals among them, so stderr is
+	 * discarded and the exit status is what reports those.
+	 *
+	 * @param string[] $arguments git's own, "-C <dir>" included where a directory is wanted.
+	 * @return string|null Standard output as it came, trailing newline and all.
+	 */
+	public static function output(array $arguments): ?string {
+		$binary = ExecutableFinder::findInDefaultPaths(['git']) ?: null;
+		if ($binary === null) {
+			return null;
+		}
+
+		$descriptors = [
+			0 => ['file', '/dev/null', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['file', '/dev/null', 'w']
+		];
+		$pipes = [];
+		// An array argv never reaches a shell, so no argument needs quoting.
+		$process = proc_open(array_merge([$binary], $arguments), $descriptors, $pipes);
+		if ($process === false) {
+			return null;
+		}
+		$output = stream_get_contents($pipes[1]);
+		fclose($pipes[1]);
+
+		return proc_close($process) === 0 && $output !== false ? $output : null;
+	}
+}

--- a/includes/SourceHistory.php
+++ b/includes/SourceHistory.php
@@ -2,8 +2,6 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use MediaWiki\Utils\ExecutableFinder;
-
 /**
  * When each source file last changed, and who changed it, as git tells it.
  *
@@ -154,28 +152,6 @@ class SourceHistory {
 	 * @param string[] $arguments
 	 */
 	private static function git(string $directory, array $arguments): ?string {
-		// Located rather than spawned by name: proc_open() raises a PHP warning of its own when the
-		// command is not there, and a host without git is one of the answers this method gives.
-		$binary = ExecutableFinder::findInDefaultPaths(['git']) ?: null;
-		if ($binary === null) {
-			return null;
-		}
-
-		// An array argv never reaches a shell, so a directory name needs no quoting. git's own
-		// complaints (no repository here, nothing committed yet) are the expected outcome rather
-		// than something to print, and the exit status already reports them.
-		$descriptors = [
-			0 => ['file', '/dev/null', 'r'],
-			1 => ['pipe', 'w'],
-			2 => ['file', '/dev/null', 'w']
-		];
-		$pipes = [];
-		$process = proc_open(array_merge([$binary, '-C', $directory], $arguments), $descriptors, $pipes);
-		if ($process === false) {
-			return null;
-		}
-		$output = stream_get_contents($pipes[1]);
-		fclose($pipes[1]);
-		return proc_close($process) === 0 && $output !== false ? $output : null;
+		return Git::output(array_merge(['-C', $directory], $arguments));
 	}
 }

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -7,7 +7,6 @@ use Maintenance;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Settings\Source\Format\JsonFormat;
 use MediaWiki\Settings\Source\Format\YamlFormat;
-use MediaWiki\Utils\ExecutableFinder;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
@@ -22,6 +21,7 @@ require_once "$IP/maintenance/Maintenance.php";
 require_once __DIR__ . '/../includes/Attempts.php';
 require_once __DIR__ . '/../includes/ComposerInstall.php';
 require_once __DIR__ . '/../includes/FetchPin.php';
+require_once __DIR__ . '/../includes/Git.php';
 require_once __DIR__ . '/../includes/TarballChecksum.php';
 require_once __DIR__ . '/../includes/UserAgent.php';
 
@@ -455,31 +455,14 @@ class FetchExtensions extends Maintenance {
 	}
 
 	/**
-	 * What `git $arguments` printed, or null where it could not be run or did not succeed.
-	 *
-	 * Located rather than spawned by name, as SourceHistory does: a host without git is an answer
-	 * this can give.
+	 * What `git $arguments` printed, trimmed, or null where it could not be run or did not succeed.
 	 *
 	 * @param string[] $arguments
 	 */
 	private static function gitOutput(array $arguments): ?string {
-		$binary = ExecutableFinder::findInDefaultPaths(['git']) ?: null;
-		if ($binary === null) {
-			return null;
-		}
-		$descriptors = [
-			0 => ['file', '/dev/null', 'r'],
-			1 => ['pipe', 'w'],
-			2 => ['file', '/dev/null', 'w']
-		];
-		$pipes = [];
-		$process = proc_open(array_merge([$binary], $arguments), $descriptors, $pipes);
-		if ($process === false) {
-			return null;
-		}
-		$output = (string)stream_get_contents($pipes[1]);
-		fclose($pipes[1]);
-		return proc_close($process) === 0 ? trim($output) : null;
+		$output = Git::output($arguments);
+
+		return $output === null ? null : trim($output);
 	}
 
 	/**

--- a/tests/phpunit/integration/GitTest.php
+++ b/tests/phpunit/integration/GitTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\Git;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * What git says, and the three ways of getting no answer.
+ *
+ * @covers \MediaWiki\Extension\Wikven\Git
+ */
+class GitTest extends MediaWikiIntegrationTestCase {
+	public function testWhatGitPrintsComesBack() {
+		$output = Git::output(['--version']);
+		if ($output === null) {
+			// The host has no git, which is one of the answers this gives; the tests below are it.
+			$this->markTestSkipped('git is not installed here');
+		}
+
+		$this->assertStringStartsWith('git version', $output);
+	}
+
+	public function testADirectoryThatIsNotACheckoutIsNoAnswer() {
+		// git exits non-zero and says so on the stderr this discards.
+		$this->assertNull(Git::output(['-C', $this->getNewTempDirectory(), 'rev-parse', 'HEAD']));
+	}
+
+	public function testASubcommandGitDoesNotHaveIsNoAnswer() {
+		$this->assertNull(Git::output(['wikven-no-such-subcommand']));
+	}
+}


### PR DESCRIPTION
`SourceHistory::git()` and `FetchExtensions::gitOutput()` were the same twenty lines twice: find git with `ExecutableFinder` rather than spawn it by name, open it on a descriptor set that sends stdin to `/dev/null` and throws stderr away, read stdout, and treat a non-zero exit as no answer. Both even carried the same comment explaining why git is located and not named.

They had already drifted. On a pipe that cannot be read, one returned `null` and the other `""` — so the two disagreed about what "git said nothing" means, and nothing would have caught it.

`includes/Git.php` holds it once. It is dependency-free beyond core and loadable by path, which `fetchExtensions.php` needs: that script runs before wikven's autoloader and already requires five files that way. Each caller keeps its own thin wrapper, so their contracts do not change — `SourceHistory` still takes a directory and passes it as git's `-C`, and `fetchExtensions` still trims.

## Only two of the three

`build.php`'s `proc_open` stays. It starts several skin passes at once, sets a working directory and an environment for each, keeps their pipes non-blocking and multiplexes them with `stream_select` — process supervision, not "ask a command what it has to say". Folding it in would mean an abstraction wide enough to cover both and useful for neither.

## What it is worth

Barely a line: 47 removed, 49 added. The change is that there is one copy of how this repository runs git instead of two, and the `""`/`null` disagreement is gone.

## Checked

`SourceHistory` reads `docs/` through git the same as before, byte for byte — timestamps and author lists compared against `HEAD`'s version over four files. `fetchExtensions`' three call sites all test their result against `null` already, so returning `null` where the old code would have returned `""` is what they were written for. `mago format --check`, `mago lint`, `composer phpcs`, `composer test` and the comment budget are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_