### PR TITLE
fix: let the downloaded tarball go when the fetch does not

### DIFF
--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -9,6 +9,7 @@ use MediaWiki\Settings\Source\Format\JsonFormat;
 use MediaWiki\Settings\Source\Format\YamlFormat;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Wikimedia\FileBackend\FSFile\TempFSFileFactory;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 	? getenv('MW_INSTALL_PATH')
@@ -282,12 +283,17 @@ class FetchExtensions extends Maintenance {
 
 	private function fetchTarball(string $url, string $dest, string $name, string $kind, ?string $sha256 = null): void {
 		$this->output("Wikven: downloading $kind '$name' from $url\n");
-		$tmp = tempnam(sys_get_temp_dir(), 'wikven');
+		// Core's, so the download goes when this returns and when it does not: half of the ways out
+		// of here are a fatalError, and each one used to leave the tarball in the temp directory.
+		$download = ( new TempFSFileFactory() )->newTempFSFile('wikven');
+		if ($download === null) {
+			$this->fatalError("Wikven: could not make a temporary file to download $kind '$name' into.");
+		}
+		$tmp = $download->getPath();
 		$this->download($url, $tmp, "download $kind '$name'");
 		if ($sha256 !== null) {
 			if (!TarballChecksum::matches($sha256, $tmp)) {
 				$actual = is_file($tmp) ? hash_file('sha256', $tmp) : 'nothing';
-				unlink($tmp);
 				$this->fatalError(
 					"Wikven: $kind '$name' tarball sha256 mismatch (expected $sha256, got $actual)."
 				);
@@ -298,7 +304,6 @@ class FetchExtensions extends Maintenance {
 			$this->fatalError("Wikven: could not create '$dest'.");
 		}
 		$this->run(['tar', '-xzf', $tmp, '-C', $dest, '--strip-components=1'], "extract $kind '$name'");
-		unlink($tmp);
 	}
 
 	private function fetchGit(array $spec, string $dest, string $name, string $kind): void {


### PR DESCRIPTION
`fetchTarball()` made its temp file with `tempnam()` and unlinked it in the two places the function ends well. Half the ways out of it are a `fatalError()` — a destination directory that cannot be made, a `tar` that fails — and each of those left the downloaded tarball in the temp directory. Only the sha256 mismatch remembered to clean up, and it had to say so in its own line.

Core has exactly this. `TempFSFileFactory::newTempFSFile()` returns a file that purges itself when it falls out of scope, and `autocollect()`s besides, so it goes on a shutdown that skipped every destructor. Both `unlink()` calls go with it, and the paths that never had one are covered without gaining one.

```diff
-		$tmp = tempnam(sys_get_temp_dir(), 'wikven');
+		$download = ( new TempFSFileFactory() )->newTempFSFile('wikven');
+		if ($download === null) { ... }
+		$tmp = $download->getPath();
```

## The rest of the survey

This came out of reading core's `includes/Utils/` and `includes/libs/` against what this repository writes by hand. Most of it was already answered:

* `ExecutableFinder`, `CSSMin`, `RemexHtml`, `ExtensionRegistry`, `HttpRequestFactory` and the YAML settings source are in use already.
* `Wikimedia\Composer\ComposerInstalled` reads `installed.json` but reports name, version, licenses and authors — not `install-path`, which is the only thing `ComposerInstall::locations()` asks it.
* `MediaWiki\Utils\GitInfo` reads `.git` without spawning anything, but the one call it could serve — `rev-parse HEAD` in `fetchExtensions` — runs immediately after that same function cloned with git, so it gains nothing and parses refs itself where `rev-parse` asks git.
* `UrlUtils` could take `SiteUrl` off `GuzzleHttp\Psr7`, which is worth something: guzzle is in core's `vendor/` by circumstance rather than promise, which is why the Dockerfile carries a check that it is still there. But `parse()` leaves the host in the case it was written and keeps a `:443`, and `SiteUrl` would have to normalise both by hand — which is what guzzle is doing for it now. Left alone.
* `MimeAnalyzer` and `FileContentsHasher` are built for questions bigger than the ones asked here (five extensions mapped to a data: URI, one tarball hashed once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_