### PR TITLE
docs: cut the Dockerfile comments down to the decisions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,32 @@
-# Base images are digest-pinned and version-tagged so Dependabot's bumps read as version numbers
-# rather than digests. Dependabot keeps them current. The pin fixes the base images alone: apk below
-# still resolves against the current Alpine index at build time, so the image is not reproducible.
+# Digest-pinned and version-tagged, so dependabot's bumps read as versions. The pin fixes the base
+# images alone: apk below resolves against the current Alpine index, so the image is not reproducible.
 FROM composer:2.10.3@sha256:d8f6343d3fae98107426bc49163ccad46ef85aabd4a27d80a74401fab4aba332 AS composer
 
-# The alpine variant, because nothing here serves over HTTP: `build` runs a maintenance script and
-# `serve` runs PHP's own server, so the Apache the default variant carries is never started. Same
-# PHP extensions, 873MB against 1.5GB. A bump onto a new release branch has to take the bundled
-# extensions with it, and their branch is `branch` in updatecli/updatecli.d/mediawiki-extensions.yaml.
+# The alpine variant: nothing here serves over HTTP, so the default variant's Apache never starts.
+# Same extensions, 873MB against 1.5GB. A bump onto a new release branch has to take the bundled
+# extensions with it; their branch is in updatecli/updatecli.d/mediawiki-extensions.yaml.
 FROM mediawiki:1.46.0-fpm-alpine@sha256:b0e9413c015268322cfb67908e5f92121372c7407f09f97a4ce8938a4351e4ad
 
-# composer to install third-party extensions/skins at bake time (git/tar/gzip/unzip present).
-# rsvg-convert renders SVG thumbnails, and alpine splits ImageMagick's delegates out, so its
-# convert reads only the PNG family until these are added. Together they cover every type
-# FileExtensions allows: png and gif are built in, svg goes through rsvg, and these two are the
-# rest. The formats still absent (TIFF, PDF, HEIC, camera RAW) are ones uploads reject anyway.
+# composer installs third-party extensions at bake time. rsvg-convert renders SVG thumbnails, and
+# alpine splits ImageMagick's delegates out, so its convert reads only the PNG family without these.
+# Together they cover every type FileExtensions allows; the rest (TIFF, PDF, HEIC, RAW) is refused.
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 
-# Bundled extensions come from stable external sources; fetch them before copying wikven's own
-# code so edits to that code do not bust the (slow) download/clone layers.
+# Fetched before wikven's own code is copied in, so an edit there does not bust the slow layers.
 
-# Every fetch below asks curl to try again, because "stable source" describes the bytes and not the
-# service in front of them: GitHub served 500s for archive and git traffic for hours on 2026-08-17,
-# and codeload has answered 429 under load. One attempt turns somebody else's bad minute into a
-# failed build with nothing wrong in it. --retry-all-errors is needed as well as --retry because
-# curl counts a connection reset as a non-transient error and would otherwise not repeat it.
+# "Stable source" describes the bytes, not the service in front of them: GitHub served 500s for
+# hours on 2026-08-17, and codeload answers 429 under load. --retry-all-errors as well as --retry,
+# because curl counts a connection reset as non-transient and would not repeat it.
 ARG CURL_RETRY="--retry 5 --retry-delay 2 --retry-all-errors"
 
-# And to say who is asking. curl signs a request with its own version and nothing else, which
-# tells the operator on the other end which library made it and not which project: these three
-# downloads are the image build reaching GitHub and Gerrit, and the same rule applies to them as
-# to the fetching a bake does, which carries UserAgent::string(). No version here, because the
-# release this image is cut from is not known until wikven's own code is copied in, well after
-# these run.
+# And who is asking: curl signs with its own version, naming the library rather than the project.
+# No wikven version -- the release this is cut from is not known until its code is copied in.
 ARG CURL_AGENT="Wikven image build (+https://github.com/chaotic-ground/wikven)"
 
-# SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
-# per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
-#
-# Downloaded before extracting rather than piped, for the reason the block below already gives: a
-# retried transfer restarts, and tar reading a restarted stream has already been fed the first
-# attempt's bytes.
+# SifterSearch's release tarball carries the per-arch Pagefind binary a clone omits. Downloaded
+# before extracting rather than piped: a retried transfer restarts, and tar reading one has already
+# been fed the first attempt's bytes.
 ARG TARGETARCH
 ARG SIFTERSEARCH_VERSION=v0.8.0
 RUN arch="$TARGETARCH" \
@@ -50,30 +36,25 @@ RUN arch="$TARGETARCH" \
  && tar -xzf /tmp/siftersearch.tar.gz -C /var/www/html/extensions/ \
  && rm /tmp/siftersearch.tar.gz
 
-# Content i18n (opt-in by listing Translate in a site's .wikven.yaml): it renders translated
-# pages and the <languages/> bar; UniversalLanguageSelector is its hard load-time dependency. Both track this
-# image's MediaWiki branch. Translate pulls its runtime Composer deps (spyc) into its own vendor/,
-# which its load_composer_autoloader then loads.
+# Content i18n, opt-in by listing Translate in a site's .wikven.yaml; UniversalLanguageSelector is
+# its load-time dependency. Both track this image's MediaWiki branch. Translate pulls spyc into its
+# own vendor/, which its load_composer_autoloader loads.
 ENV COMPOSER_ALLOW_SUPERUSER=1
-# Commits, not the branch tip: REL1_46 takes translatewiki updates weekly, so a branch pin builds a
-# different Translate from the same wikven commit a week later. Bumped by updatecli, which reads the
-# branch these follow from its own manifest, so that branch moves there when this image's does.
+# Commits, not the branch tip: REL1_46 takes translatewiki updates weekly, so a branch pin would
+# build a different Translate from the same wikven commit a week later. updatecli moves them.
 ARG TRANSLATE_VERSION=afbd690fcf71a21dbd3939f50f97e0cff88a840d
 ARG ULS_VERSION=f914eba81f7f7196140febbfce3ed6e17d65ba22
-# Translate asks for its two runtime deps by range, so an unpinned install takes whatever Packagist
-# serves that day. Core's own answer to this is exact versions and no lock file, so: exact versions,
-# passed as temporary constraints rather than written into Translate's manifest. Bumped by updatecli.
+# Translate asks for both by range, so an unpinned install takes whatever Packagist serves that day.
+# Exact versions, as temporary constraints rather than written into Translate's manifest.
 ARG SPYC_VERSION=0.6.3
 ARG COMPOSER_INSTALLERS_VERSION=v2.3.0
-# Composer refuses to resolve at all when any package in the tree carries a security advisory,
-# including a require-dev one that --no-dev then never installs. Translate's dev requirements pin
-# a phpcs release that has one, which broke every build reaching this layer without a warm cache.
-# The audit still reports on what is installed; only the hard stop is off.
-# Fetched as tarballs: a clone carries a .git nothing here reads, and transfers several times the
-# bytes for it. Downloaded before extracting rather than piped, so a failed fetch fails the build
-# instead of feeding tar an empty stream.
-# The php check ahead of the update fails the build if Translate's runtime requirements ever stop
-# matching what the ARGs pin, so a new upstream dependency cannot slip in unpinned.
+# Composer refuses to resolve at all while anything in the tree carries an advisory, including a
+# require-dev one --no-dev never installs -- which Translate's pinned phpcs has. The audit still
+# reports; only the hard stop is off.
+#
+# Tarballs rather than clones, which carry a .git nothing here reads. The php check ahead of the
+# update fails the build if Translate's runtime requirements stop matching the ARGs above, so a new
+# dependency cannot slip in unpinned.
 RUN composer config --global policy.advisories.block false \
  && ext=/var/www/html/extensions \
  && curl -fsSL $CURL_RETRY -A "$CURL_AGENT" -o /tmp/uls.tar.gz \
@@ -91,15 +72,14 @@ RUN composer config --global policy.advisories.block false \
       --with "mustangostang/spyc:$SPYC_VERSION" \
       --with "composer/installers:$COMPOSER_INSTALLERS_VERSION"
 
-# SiteUrl builds every absolute URL a published site writes about itself on Guzzle's PSR-7 Uri,
-# which arrives here as core's dependency rather than wikven's: MediaWiki requires
-# guzzlehttp/guzzle, and that requires guzzlehttp/psr7. Nothing declares it on wikven's behalf, so
-# a release that drops guzzle would otherwise be found by a site whose sitemap had gone missing.
+# SiteUrl builds every absolute URL on Guzzle's PSR-7 Uri, which is here as core's dependency
+# rather than wikven's. Nothing declares it on wikven's behalf, so a release that dropped guzzle
+# would otherwise be found by a site whose sitemap had gone missing.
 RUN php -r 'require "/var/www/html/vendor/autoload.php"; if (!class_exists("GuzzleHttp\\Psr7\\Uri") || !class_exists("GuzzleHttp\\Psr7\\UriResolver")) { fwrite(STDERR, "MediaWiki no longer vendors guzzlehttp/psr7; SiteUrl needs it\n"); exit(1); }'
 
 COPY ./ /var/www/html/extensions/Wikven
 COPY includes/WikvenSettings.php /var/www/html/
 COPY bin/entrypoint /usr/local/bin/entrypoint
-# Entry point is wikven's run script; the arg is the subcommand (default "build"; "serve" previews).
+# The arg is the subcommand: "build" bakes a site, "serve" previews one.
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 CMD ["build"]

--- a/binary.Dockerfile
+++ b/binary.Dockerfile
@@ -1,19 +1,15 @@
-# Build a standalone FrankenPHP binary that embeds MediaWiki + Wikven, so the
-# static-site build runs without Docker. Built in CI per target architecture and
-# attached to the GitHub release; see .github/workflows/binary.yml.
+# A standalone FrankenPHP binary embedding MediaWiki and Wikven, so a bake runs without Docker.
+# Built per architecture by .github/workflows/binary.yml and attached to the release.
 #
-# Usage (the wikven image must be built first, e.g. `docker build -t wikven .`):
+# Usage (build the wikven image first, e.g. `docker build -t wikven .`):
 #   docker build -f binary.Dockerfile --target export -o type=local,dest=out .
-#   # -> out/wikven, a single static executable. Run it with:
-#   #    WIKVEN_WORKDIR=. ./wikven build
+#   # -> out/wikven. Run it with: WIKVEN_WORKDIR=. ./wikven build
 #   # On a GitHub API rate limit, add: --secret id=github-token,env=GITHUB_TOKEN
 
-# Stage 1: the app tree to embed = the wikven image + the binary entry point,
-# minus what the build never needs (keeping all locales, so the binary is not
-# English-only).
+# Stage 1: the tree to embed -- the wikven image, less what a bake never reads. Locales stay, so
+# the binary is not English-only.
 FROM wikven AS app
-# The binary's own entry points, beside the app tree they drive: one per subcommand, plus the
-# prelude they share.
+# One entry point per subcommand, plus the prelude they share.
 COPY bin/build.php bin/prepare.php bin/translate.php /var/www/html/
 RUN find /var/www/html -type d -name tests -prune -exec rm -rf {} + \
  && rm -rf \
@@ -23,42 +19,32 @@ RUN find /var/www/html -type d -name tests -prune -exec rm -rf {} + \
       /var/www/html/cache/* \
       /var/www/html/images/*
 
-# Stage 2: compile a static PHP + FrankenPHP and embed the app. curl is omitted:
-# its HTTP/3 (ngtcp2/nghttp3) static libs fail to link, and it is unneeded
-# (MediaWiki/Guzzle uses PHP stream wrappers over openssl).
-# Digest-pinned, version-tagged so Dependabot's bumps read as versions. The pin fixes the toolchain
-# but not the build: build-static.sh fetches a nightly static-php-cli, which picks the library versions.
+# Stage 2: a static PHP + FrankenPHP with the app embedded. curl is left out -- its HTTP/3 static
+# libs fail to link and nothing needs it, Guzzle going through PHP's stream wrappers. Pinned like
+# the base above, though build-static.sh fetches a nightly static-php-cli that picks the libraries.
 FROM dunglas/frankenphp:static-builder-musl-1.12.7@sha256:5b7c8d9c3da7fc672154796039365f4e25ae9ff77a1cafb783c6db313863655d AS builder
 WORKDIR /go/src/app
 COPY --from=app /var/www/html ./dist/app
-# A small Caddy module registers the `build`, `serve` and `translate` subcommands,
-# so the binary can be run as `./wikven build` instead of `./wikven php-cli
-# build.php`.
+# A small Caddy module registers the build, serve and translate subcommands, so the binary is run
+# as `./wikven build` rather than `./wikven php-cli build.php`.
 #
-# Setting this replaces FrankenPHP's default module list rather than adding to it, so the line is
-# also the list of what the binary does not carry. Vulcain, a REST push gateway, is left out of it:
-# nothing in a bake or in `wikven serve` reaches one, and it is AGPL-3.0, so linking it meant
-# redistributing AGPL code for a capability nobody using this binary can call. binary.yml asserts
-# it is gone from the build, because a list like this is easy to restore by copying FrankenPHP's
-# defaults back over it.
-#
-# Mercure, the other AGPL-3.0 default, is not attempted and cannot be dropped this way: frankenphp's
-# own Caddy package imports it (`go mod why` gives frankenphp/caddy -> mercure), so it is linked
-# whatever this list says and every FrankenPHP binary carries it. The licenses page names it.
-#
-# cbrotli stays: it is what `wikven serve` compresses with.
+# This replaces FrankenPHP's default module list rather than adding to it, so it is also the list of
+# what the binary leaves out. Vulcain is out because nothing here reaches a REST push gateway and it
+# is AGPL-3.0; binary.yml asserts it is gone.
+# Mercure, the other AGPL default, cannot be dropped -- frankenphp's own Caddy package imports it --
+# so every FrankenPHP binary carries it and the licenses page names it. cbrotli is what
+# `wikven serve` compresses with.
 COPY caddy /go/wikven-caddy
 ENV SPC_CMD_VAR_FRANKENPHP_XCADDY_MODULES="--with github.com/dunglas/caddy-cbrotli --with github.com/chaotic-ground/wikven/caddy=/go/wikven-caddy"
 ENV PHP_VERSION=8.3
 ENV PHP_EXTENSIONS="gd,intl,pdo_sqlite,sqlite3,mbstring,dom,xml,simplexml,xmlreader,xmlwriter,fileinfo,iconv,ctype,filter,tokenizer,phar,session,calendar,opcache,openssl,sodium,zlib,bcmath,exif"
 ENV PHP_EXTENSION_LIBS="libpng,libjpeg,freetype,libwebp"
-# static-php-cli resolves most sources through api.github.com, which is 60 requests/hour per IP when
-# anonymous and shared with every other runner on that IP. The token raises it to 1000/hour per repo.
+# static-php-cli resolves sources through api.github.com: 60 requests an hour per IP anonymously,
+# shared with every runner on it. The token raises that to 1000.
 RUN --mount=type=secret,id=github-token \
     GITHUB_TOKEN="$(cat /run/secrets/github-token 2>/dev/null || true)" \
     EMBED=dist/app ./build-static.sh
 
-# Stage 3: expose just the binary (named per arch by build-static.sh) for
-# `docker build --target export -o`.
+# Stage 3: just the binary, named per arch by build-static.sh, for `--target export -o`.
 FROM scratch AS export
 COPY --from=builder /go/src/app/dist/frankenphp-linux-* /wikven


### PR DESCRIPTION
Same measurement as #678 and #680, on the two files that pass had no opinion about.

| | before | after | upstream |
| --- | ---: | ---: | ---: |
| `Dockerfile` | 763 words / 18.6 a line | **458 / 11.2** | frankenphp 0.75 |
| `binary.Dockerfile` | 396 / 18.0 | **276 / 12.6** | its static builder 0.30, docker-library/php fpm 1.25 |

The gap to upstream stays wide and that part is earned: those files are recipes, and these two are a list of workarounds — a composer advisory block, spyc pinned by hand, a retry policy with a date in it, a guard on a dependency core never promised, two AGPL modules that part company. None of that is recoverable from the instruction it sits above, so all of it stays.

What went is the second telling. `# The alpine variant, because nothing here serves over HTTP: `build` runs a maintenance script and `serve` runs PHP's own server, so the Apache the default variant carries is never started` says the same thing twice; the first clause is the whole of it. The download-before-extract reason was written out in full in two places, and is now in the one that meets it first.

Nothing else changed: with comments stripped, both files are byte-identical to `main`.

The comment budget in `tests/comments/` does not reach here — it reads PHP through the tokenizer, and a Dockerfile would need its own parser. If this shape is worth holding, that is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_