### PR TITLE
build(deps): let dependabot see the tofu provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,7 +81,6 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: terraform
-    # The github provider that applies this repository's own settings, and the lock file beside it.
     directory: /.tf
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,3 +80,15 @@ updates:
       gomod:
         patterns:
           - "*"
+  - package-ecosystem: terraform
+    # The github provider that applies this repository's own settings, and the lock file beside it.
+    directory: /.tf
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      terraform:
+        patterns:
+          - "*"


### PR DESCRIPTION
`.tf/main.tf` pins `integrations/github` at `~> 6.0` and keeps a `.terraform.lock.hcl` beside it. Nothing watched either, so the one thing that applies this repository's own settings was the one dependency nobody was bumping.

A `terraform` entry covers both: dependabot reads `.tf` files and the lock file in the same format OpenTofu uses. Same shape as every other entry — weekly, five open at a time, a seven-day cooldown, one group so the provider and its lock move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_