### PR TITLE
build: keep the tooling out of the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,16 +1,52 @@
 # What COPY ./ must not put in the image -- and, through binary.Dockerfile's COPY --from=app, in
 # the standalone binary either. Everything here is a thing that builds or checks wikven rather than
 # a thing wikven runs, and a site built with the image reads none of it.
-.git
-.github
+#
+# One .dockerignore filters the context of every build that uses it, so caddy/ is deliberately
+# absent: binary.Dockerfile copies it out of this same context to link into the binary.
 .claude
+.dockerignore
+.git
+.gitignore
+.github
+.phan
+.rumdl_cache
 .tf
 .venv
-.rumdl_cache
-docs
-examples
-tests
-node_modules
-vendor
+actions
 dist
 dist-again
+docs
+examples
+node_modules
+out
+playwright-report
+pw-root
+test-results
+tests
+updatecli
+vendor
+
+# The tooling's own configuration, which lives in the root and so is not covered by a directory
+# above. Nothing in a bake opens any of it: the one composer.json a build reads is MediaWiki's, by
+# absolute path. wikven's own stays -- it is what says this directory is a package -- but its lock
+# file is a development artifact.
+.biome.json
+.codecov.yml
+.phpcs.xml
+.release-please-config.json
+.release-please-manifest.json
+.rumdl.toml
+.taplo.toml
+.typos.toml
+.yamllint.yml
+Dockerfile
+binary.Dockerfile
+composer.lock
+grumphp.yml
+mago.toml
+package-lock.json
+package.json
+playwright.config.js
+pyproject.toml
+uv.lock


### PR DESCRIPTION
`.dockerignore` opens by saying what it is for — "everything here is a thing that builds or checks wikven rather than a thing wikven runs" — and then lists only directories. So every configuration file in the root travelled with `COPY ./` into the image, and through `binary.Dockerfile`'s `COPY --from=app` into the standalone binary as well.

Eighteen files and three directories: `.biome.json`, `.codecov.yml`, `.phpcs.xml`, `.release-please-*.json`, `.rumdl.toml`, `.taplo.toml`, `.typos.toml`, `.yamllint.yml`, `Dockerfile`, `binary.Dockerfile`, `grumphp.yml`, `mago.toml`, `package.json`, `package-lock.json`, `playwright.config.js`, `pyproject.toml`, `uv.lock`, plus `actions/`, `updatecli/` and `.phan/`. The local-only build artefacts (`out`, `pw-root`, `playwright-report`, `test-results`, `composer.lock`) go too — git ignores them, so they reach a context only from somebody's own checkout.

What the context carries afterwards is the product and nothing else:

```
CHANGELOG.md  LICENSE  README.md  Wikven.i18n.magic.php  bin  caddy
composer.json  default.yml  extension.json  i18n  includes  maintenance  resources
```

## Two judgement calls, both written into the file

`composer.json` stays. It is the file that says this directory is a package, and nothing at runtime reads it — the only `composer.json` a bake opens is MediaWiki's, at `MW_INSTALL_PATH`. Its lock file is a development artefact and goes.

`caddy/` is listed nowhere, deliberately, and the header now says why: one `.dockerignore` filters the context of *every* build that uses it, and `binary.Dockerfile` copies `caddy` out of that same context to link into the binary. Excluding it would break the binary build. It therefore still reaches the image, where nothing reads it; getting it out would mean deleting it after the copy, which trades a stowaway for a layer.

## Checked

Every entry was tested against what actually reads it: nothing under `includes/`, `maintenance/`, `bin/` or the composite actions opens any of the excluded files. `binary.yml` already watches `.dockerignore`, so the binary build runs on this pull request — which is the check that matters, since it is the build whose context is easiest to break this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_