### PR TITLE
chore: measure coverage over the code a test can reach

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,17 +5,27 @@ fixes:
 
 comment: false
 
+# What PHPUnit cannot load, it cannot cover, and counting those lines only moves the number away
+# from what it is for: whether the code under test is tested.
 ignore:
+  # Including a maintenance script runs it -- the last line of every one is RUN_MAINTENANCE_IF_MAIN
+  # -- so a test that loaded one would build a site rather than assert anything. These are half the
+  # tree's lines and every one of them counted as a miss. tests/bake and the Playwright suite do run
+  # them, for real, and report no coverage; what belongs under a unit test is moved into a class in
+  # includes/ instead, which is where most of what these scripts once held has already gone.
+  - "maintenance"
   # A settings script, not library code: LocalSettings.php require_once's it and its first line calls
-  # wfLoadExtension(), so PHPUnit cannot include it and nothing it holds is ever covered. The same
-  # reason maintenance/ is left out of the patch target below.
+  # wfLoadExtension(), so PHPUnit cannot include it and nothing it holds is ever covered.
   - "includes/WikvenSettings.php"
 
 coverage:
   status:
-    # maintenance/ is half the tree's lines with no unit tests; its diffs can never meet a patch target.
+    # Now that the number counts only what tests can reach, it is worth holding: a change may not
+    # take the whole tree down by more than a point.
+    project:
+      default:
+        target: auto
+        threshold: 1%
     patch:
       default:
         target: 70%
-        paths:
-          - includes/


### PR DESCRIPTION
The badge says 42%. `includes/` is at 88%. The difference is `maintenance/`: 2,306 lines, 0 of them hit, more than half of everything the report counts.

None of those lines can ever be hit. The last line of every maintenance script is `RUN_MAINTENANCE_IF_MAIN`, so including one runs it — a test that loaded `build.php` would build a site instead of asserting anything. They are exercised, by `tests/bake` and by the Playwright suite, and neither reports coverage; and what belongs under a unit test has been moved into a class in `includes/` all along, which is why `BuildPaths`, `SkinPass` and `BuildConcurrency` exist.

So the report now counts `includes/`, and the number means what it is supposed to mean.

| | before | after |
| --- | --- | --- |
| lines counted | 4,426 | 2,120 |
| coverage | 42.31% | 88.35% |

With the number worth reading, a `project` status holds it: a change may not take the tree down by more than a point. `patch` keeps its 70% and no longer needs the `paths` filter — `includes/` is all that is left.

Neither status is a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_