### PR TITLE
test: walk the branches the output side never took

### DIFF
--- a/includes/Output/ModuleRenderer.php
+++ b/includes/Output/ModuleRenderer.php
@@ -72,11 +72,9 @@ class ModuleRenderer {
 					LogLevel::ALERT,
 					LogLevel::EMERGENCY
 				];
-				if (isset($context['exception']) && in_array((string)$level, $levels, true)) {
-					$exception = $context['exception'];
-					$this->failures[] = $exception instanceof Throwable
-						? get_class($exception) . ': ' . $exception->getMessage()
-						: (string)$message;
+				$exception = $context['exception'] ?? null;
+				if ($exception instanceof Throwable && in_array((string)$level, $levels, true)) {
+					$this->failures[] = get_class($exception) . ': ' . $exception->getMessage();
 				}
 				$this->inner->log($level, $message, $context);
 			}

--- a/tests/phpunit/integration/Webfonts/FontCopierTest.php
+++ b/tests/phpunit/integration/Webfonts/FontCopierTest.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\Wikven\Tests\Integration\Webfonts;
 
 use MediaWiki\Extension\Wikven\Webfonts\FontCopier;
 use MediaWikiIntegrationTestCase;
+use Wikimedia\AtEase\AtEase;
 
 /**
  * FontCopier makes the output directories with wfMkdirParents, so this is an integration test.
@@ -92,5 +93,46 @@ class FontCopierTest extends MediaWikiIntegrationTestCase {
 	/** A stylesheet naming no files asks for nothing, and nothing is what is missing. */
 	public function testAskingForNoFilesIsNotAFailure() {
 		$this->assertSame([], FontCopier::copy($this->source(), $this->destination(), []));
+	}
+
+	/**
+	 * The output tree is made as the copy goes, so a path the directory cannot be made at -- here a
+	 * file already standing where the directory would go -- is one more font that did not arrive.
+	 */
+	public function testAFontWhoseDirectoryCannotBeMadeIsReported() {
+		$this->repositoryHolds('Alef/Alef-Regular.woff2');
+		mkdir("{$this->destination()}", 0777, true);
+		file_put_contents("{$this->destination()}/Alef", 'a file, where the directory has to go');
+
+		$missing = $this->copyQuietly(['Alef/Alef-Regular.woff2']);
+
+		$this->assertSame(['Alef/Alef-Regular.woff2'], $missing);
+	}
+
+	/** And so is a copy that cannot be written, whatever the reason the write failed. */
+	public function testAFontThatCannotBeWrittenIsReported() {
+		$this->repositoryHolds('Alef/Alef-Regular.woff2');
+		// A directory standing where the file goes: copy() refuses it, as it would a read-only tree.
+		mkdir("{$this->destination()}/Alef/Alef-Regular.woff2", 0777, true);
+
+		$missing = $this->copyQuietly(['Alef/Alef-Regular.woff2']);
+
+		$this->assertSame(['Alef/Alef-Regular.woff2'], $missing);
+	}
+
+	/**
+	 * A failed mkdir or copy warns on its way to the return value this class is about, and PHPUnit
+	 * turns a warning into a failed test.
+	 *
+	 * @param string[] $files
+	 * @return string[]
+	 */
+	private function copyQuietly(array $files): array {
+		AtEase::suppressWarnings();
+		try {
+			return FontCopier::copy($this->source(), $this->destination(), $files);
+		} finally {
+			AtEase::restoreWarnings();
+		}
 	}
 }

--- a/tests/phpunit/unit/HtmlElementRemoverTest.php
+++ b/tests/phpunit/unit/HtmlElementRemoverTest.php
@@ -75,4 +75,19 @@ class HtmlElementRemoverTest extends MediaWikiUnitTestCase {
 		$html = '<body><div class="other">x</div></body>';
 		$this->assertSame($html, HtmlElementRemover::remove($html, $this->byId()));
 	}
+
+	/**
+	 * A matched void or self-closed element ends where its own tag does. Opening a span at one and
+	 * waiting for an end tag that never comes would swallow the rest of the document.
+	 */
+	public function testAMatchedVoidElementIsRemovedOnItsOwn() {
+		$this->assertSame(
+			'<body><p>keep</p></body>',
+			HtmlElementRemover::remove('<body><input id="removable" type="search"><p>keep</p></body>', $this->byId())
+		);
+		$this->assertSame(
+			'<body><p>keep</p></body>',
+			HtmlElementRemover::remove('<body><svg id="removable"/><p>keep</p></body>', $this->byId())
+		);
+	}
 }

--- a/tests/phpunit/unit/HtmlListInserterTest.php
+++ b/tests/phpunit/unit/HtmlListInserterTest.php
@@ -41,4 +41,32 @@ class HtmlListInserterTest extends MediaWikiUnitTestCase {
 
 		$this->assertSame($page, HtmlListInserter::after($page, 'p-navigation', '<ul></ul>'));
 	}
+
+	/**
+	 * inside() fills an element rather than following one: Minerva renders its menu as an empty
+	 * <ul> that the build writes the entries into.
+	 */
+	public function testInsideFillsTheElementAsked() {
+		$page = '<div id="mw-mf-page-left"><ul id="p-navigation"></ul></div>';
+
+		$out = HtmlListInserter::inside($page, 'p-navigation', '<li>Home</li>', 'ul');
+
+		$this->assertSame(
+			'<div id="mw-mf-page-left"><ul id="p-navigation"><li>Home</li></ul></div>',
+			$out
+		);
+	}
+
+	public function testInsideLeavesThePageAloneWhenTheElementIsMissing() {
+		$page = '<div id="mw-mf-page-left"><ul id="p-navigation"></ul></div>';
+
+		$this->assertSame($page, HtmlListInserter::inside($page, 'p-nowhere', '<li>Home</li>', 'ul'));
+	}
+
+	/** An element that never closes would otherwise take the markup to the end of the document. */
+	public function testInsideLeavesThePageAloneWhenTheElementNeverCloses() {
+		$page = '<div id="mw-mf-page-left"><ul id="p-navigation">';
+
+		$this->assertSame($page, HtmlListInserter::inside($page, 'p-navigation', '<li>Home</li>', 'ul'));
+	}
 }

--- a/tests/phpunit/unit/PngTest.php
+++ b/tests/phpunit/unit/PngTest.php
@@ -137,4 +137,19 @@ class PngTest extends MediaWikiUnitTestCase {
 			'trailing bytes' => ['bytes past IEND', $signature . $ihdr . $iend . 'extra']
 		];
 	}
+
+	/**
+	 * A text chunk whose payload carries no NUL has no keyword to read, so it says nothing about a
+	 * clock and stays. ImageMagick writes none, but the format allows it and a keyword is what the
+	 * decision is made on.
+	 */
+	public function testATextChunkWithoutAKeywordIsKept() {
+		$png =
+			self::SIGNATURE
+			. $this->chunk('IHDR', str_repeat("\x01", 13))
+			. $this->chunk('tEXt', 'no keyword here')
+			. $this->chunk('IEND');
+
+		$this->assertSame($png, Png::withoutTimestamps($png));
+	}
 }

--- a/tests/phpunit/unit/RelativeUrlTest.php
+++ b/tests/phpunit/unit/RelativeUrlTest.php
@@ -340,4 +340,16 @@ class RelativeUrlTest extends MediaWikiUnitTestCase {
 			return true;
 		}));
 	}
+
+	/** A srcset written in prose is text rather than markup, and text names nothing to rebase. */
+	public function testASrcsetInProseIsLeftAlone() {
+		$html = '<p>An &lt;img&gt; takes srcset="./img-a.png 2x" as its list of sources.</p>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
+
+	/** An empty href names the page it is on, which no depth moves. */
+	public function testAnEmptyPrintFooterHrefIsLeftAlone() {
+		$html = '<div class="printfooter"><a href="">Retrieved from here</a></div>';
+		$this->assertSame($html, RelativeUrl::reparent($html, 1));
+	}
 }

--- a/tests/phpunit/unit/Webfonts/FontRepositoryTest.php
+++ b/tests/phpunit/unit/Webfonts/FontRepositoryTest.php
@@ -103,4 +103,21 @@ class FontRepositoryTest extends MediaWikiUnitTestCase {
 		$built = ( new FontRepository($this->repository()) )->build(['am'], '../fonts/uls');
 		$this->assertStringContainsString("url('../fonts/uls/AbyssinicaSIL/AbyssinicaSIL-R.woff2')", $built['css']);
 	}
+
+	/**
+	 * A build reads whatever the installed ULS generated. An entry that is not a map, or one naming
+	 * no woff2, declares no font rather than a rule pointing at a file the copy will not find.
+	 */
+	public function testAFontEntryThatDeclaresNoFileIsSkipped() {
+		$repository = $this->repository();
+		$repository['languages']['aa'] = ['NotAMap'];
+		$repository['languages']['ab'] = ['NoFile'];
+		$repository['fonts']['NotAMap'] = 'AbyssinicaSIL/AbyssinicaSIL-R.woff2';
+		$repository['fonts']['NoFile'] = ['fontweight' => 'bold'];
+
+		$built = ( new FontRepository($repository) )->build(['aa', 'ab'], 'fonts/uls/');
+
+		$this->assertStringNotContainsString('@font-face', $built['css']);
+		$this->assertSame([], $built['files']);
+	}
 }


### PR DESCRIPTION
Seven classes on the output side each had a `return` no test reached. Every one of them is the answer to a page or a font arriving broken, so they are worth a test rather than a shrug.

| | the line nothing walked |
| --- | --- |
| `HtmlListInserter::inside` | the whole method — the element is missing, or never closes |
| `Png` | a `tEXt` chunk with no NUL, so no keyword to judge |
| `HtmlElementRemover` | a matched element that is void: it ends at its own tag |
| `RelativeUrl` | a `srcset` written in prose; an empty printfooter `href` |
| `FontRepository` | a repository entry that is not a map, or names no woff2 |
| `FontCopier` | the directory could not be made; the copy could not be written |

`FontCopier`'s two go through a helper that silences the warning `wfMkdirParents` and `copy()` raise on their way to the return value, which PHPUnit would otherwise fail the test on.

## One line removed instead

`ModuleRenderer` collects a module's failure out of what ResourceLoader logs, and fell back to the log message when `context['exception']` held something other than a `Throwable`. `outputErrorAndLog()` is the only place that logs one and it always attaches a real exception, so the fallback answered a case core does not produce. The collector now reads the exception first and does nothing without one.

`includes/` goes from 87.7% to 88.6% locally, and these seven files to 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_