### PR TITLE
test: walk the branches that read the world outside

### DIFF
--- a/includes/Search.php
+++ b/includes/Search.php
@@ -65,14 +65,11 @@ class Search {
 		$path = rtrim($bundlePath, '/');
 		$cut = strrpos($path, '/');
 		if ($cut === false) {
+			// "/" alone, which the trim leaves empty: a bundle at the site root has no directory
+			// of its own to reproduce.
 			return null;
 		}
-		$segment = substr($path, $cut + 1);
-		if ($segment === '') {
-			// "/" alone: a bundle at the site root has no directory of its own to reproduce.
-			return null;
-		}
-		return substr($path, 0, $cut + 1) . $directory . '/' . $segment . '/';
+		return substr($path, 0, $cut + 1) . $directory . '/' . substr($path, $cut + 1) . '/';
 	}
 
 	/** The file in the bundle that names each language's index, and the key holding that map. */

--- a/tests/phpunit/integration/SourceAuthorsTest.php
+++ b/tests/phpunit/integration/SourceAuthorsTest.php
@@ -3,6 +3,9 @@
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
 use MediaWiki\Extension\Wikven\Source\SourceAuthors;
+use MediaWiki\Status\Status;
+use MediaWiki\User\User;
+use MediaWiki\User\UserFactory;
 use MediaWikiIntegrationTestCase;
 
 /**
@@ -52,5 +55,22 @@ class SourceAuthorsTest extends MediaWikiIntegrationTestCase {
 		[$authors, $build] = $this->authors();
 
 		$this->assertSame($build, $authors->accountFor([]));
+	}
+
+	/**
+	 * A name MediaWiki will take can still fail to save, and a build that wrote revisions against
+	 * the account it did not get would attribute them to a user id that is not there.
+	 */
+	public function testAnAccountThatCannotBeSavedLeavesThePageUnattributed() {
+		$build = $this->getTestUser()->getUser();
+		$refused = $this->createMock(User::class);
+		$refused->method('isRegistered')->willReturn(false);
+		$refused->method('addToDatabase')->willReturn(Status::newFatal('userexists'));
+		$factory = $this->createMock(UserFactory::class);
+		$factory->method('newFromName')->willReturn($refused);
+
+		$authors = new SourceAuthors($factory, $build);
+
+		$this->assertSame($build, $authors->accountFor(['Leslie']));
 	}
 }

--- a/tests/phpunit/integration/SourceFileTest.php
+++ b/tests/phpunit/integration/SourceFileTest.php
@@ -66,4 +66,40 @@ class SourceFileTest extends MediaWikiIntegrationTestCase {
 		$this->assertTrue(SourceFile::exists('Getting Started'), 'imported page');
 		$this->assertFalse(SourceFile::exists('Version'), 'generated page');
 	}
+
+	/**
+	 * The "$1" in an edit or history URL is a path in someone's repository, so the slash and the
+	 * namespace colon stay as they are and everything else is encoded.
+	 *
+	 * @dataProvider provideTitlesAsParameters
+	 */
+	public function testTitleToParam(string $titleText, string $expected) {
+		$this->assertSame($expected, SourceFile::titleToParam($titleText));
+	}
+
+	public static function provideTitlesAsParameters() {
+		return [
+			'a space' => ['Getting Started', 'Getting%20Started.wikitext'],
+			'a subpage' => ['Manual/Config', 'Manual/Config.wikitext'],
+			'a namespace' => ['Help:Search', 'Help:Search.wikitext'],
+			'a title with its own content model' => ['MediaWiki:Common.css', 'MediaWiki:Common.css'],
+			'a character a URL cannot carry' => ['Q&A', 'Q%26A.wikitext']
+		];
+	}
+
+	/** A wiki running the extension outside a build has no source directory to look in. */
+	public function testNothingExistsWithoutASourceDirectory() {
+		$this->overrideConfigValue('WikvenSourceDirectory', '');
+
+		$this->assertFalse(SourceFile::exists('Getting Started'));
+	}
+
+	/**
+	 * A title core will not parse resolves no content model, so it is treated as one that has none
+	 * of its own and gets the marker.
+	 */
+	public function testATitleCoreWillNotParseGetsTheMarker() {
+		$this->assertSame('<.wikitext', SourceFile::titleToFilename('<'));
+		$this->assertFalse(SourceFile::isPageFile('<'));
+	}
 }

--- a/tests/phpunit/integration/SourceHistoryTest.php
+++ b/tests/phpunit/integration/SourceHistoryTest.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
+use MediaWiki\Extension\Wikven\Fetching\Git;
 use MediaWiki\Extension\Wikven\Source\SourceHistory;
 use MediaWikiIntegrationTestCase;
 
@@ -47,5 +48,48 @@ class SourceHistoryTest extends MediaWikiIntegrationTestCase {
 		// What a wiki running the extension outside a build has.
 		$this->assertNull(SourceHistory::forSource('')->timestamp(self::ABSENT));
 		$this->assertNull(SourceHistory::forSource('/nonexistent/wikven-source')->timestamp(self::ABSENT));
+	}
+
+	/**
+	 * The other half of forSource(): with no log dumped beside it, a checkout answers for itself.
+	 * This is the one place the log arguments and the parser meet what git actually writes.
+	 */
+	public function testACheckoutAnswersForItself() {
+		if (Git::output(['--version']) === null) {
+			$this->markTestSkipped('git is not installed here');
+		}
+		$directory = $this->getNewTempDirectory();
+		file_put_contents("$directory/index.wikitext", "Hello\n");
+		$this->commit($directory, 'index.wikitext', 'Leslie', 'leslie@example.org', 1_786_288_328);
+
+		$history = SourceHistory::forSource($directory);
+
+		$this->assertSame(1_786_288_328, $history->timestamp('index.wikitext'));
+		$this->assertSame('Leslie', $history->authors('index.wikitext')[0]);
+	}
+
+	/** Make $directory a checkout holding one commit, written at $at by $author. */
+	private function commit(string $directory, string $file, string $author, string $email, int $at): void {
+		// git takes the author date from the command line and the committer date, which the log
+		// format reads, from the environment alone.
+		$stamp = gmdate('Y-m-d\TH:i:sP', $at);
+		putenv("GIT_AUTHOR_DATE=$stamp");
+		putenv("GIT_COMMITTER_DATE=$stamp");
+		try {
+			$runs = [
+				['init'],
+				['add', $file],
+				['-c', "user.name=$author", '-c', "user.email=$email", 'commit', '-m', "Write $file"]
+			];
+			foreach ($runs as $arguments) {
+				$this->assertNotNull(
+					Git::output(array_merge(['-C', $directory], $arguments)),
+					'git ' . implode(' ', $arguments)
+				);
+			}
+		} finally {
+			putenv('GIT_AUTHOR_DATE');
+			putenv('GIT_COMMITTER_DATE');
+		}
 	}
 }

--- a/tests/phpunit/unit/ComposerInstallTest.php
+++ b/tests/phpunit/unit/ComposerInstallTest.php
@@ -242,4 +242,38 @@ class ComposerInstallTest extends MediaWikiUnitTestCase {
 		}
 		rmdir($path);
 	}
+
+	/** composer's record is not this build's file, so anything but a list of packages is no answer. */
+	public function testARecordThatIsNotAListOfPackagesIsNoAnswer() {
+		$tree = $this->makeTree();
+		mkdir("{$tree['ip']}/vendor/composer", 0777, true);
+		file_put_contents("{$tree['ip']}/vendor/composer/installed.json", 'not json at all');
+
+		$this->assertSame([], ComposerInstall::locations($tree['ip']));
+	}
+
+	/**
+	 * Only a package under extensions/ or skins/ has a name to suggest; one that landed anywhere
+	 * else declared no component type, so the report names where it went and stops there.
+	 */
+	public function testAPackageOutsideBothComponentDirectoriesIsAnsweredWithoutASuggestion() {
+		$tree = $this->makeTree(['resources/Helper'], [
+			['name' => 'example/helper', 'version' => '1.0.0', 'install-path' => '../../resources/Helper']
+		]);
+
+		$problem = ComposerInstall::misplaced(
+			$tree['ip'],
+			[
+				'package' => 'example/helper',
+				'name' => 'Helper',
+				'kind' => 'extension',
+				'dest' => "{$tree['ip']}/extensions/Helper"
+			],
+			ComposerInstall::locations($tree['ip'])
+		);
+
+		$this->assertNotNull($problem);
+		$this->assertStringContainsString('installed into resources/Helper', $problem);
+		$this->assertStringNotContainsString('instead', $problem);
+	}
 }

--- a/tests/phpunit/unit/ImageImportTest.php
+++ b/tests/phpunit/unit/ImageImportTest.php
@@ -248,4 +248,22 @@ class ImageImportTest extends MediaWikiUnitTestCase {
 		sort($names);
 		return $names;
 	}
+
+	/** A link with nothing on the far side is neither a directory to walk nor a file to upload. */
+	public function testADanglingSymlinkIsPassedOver() {
+		touch($this->directory . '/keep.png');
+		symlink($this->outside . '/gone.png', $this->directory . '/dangling.png');
+
+		$this->assertSame(
+			['keep.png'],
+			$this->basenames(ImageImport::sources($this->directory, self::EXTENSIONS))
+		);
+	}
+
+	/** A source directory that is not there resolves to nothing, so nothing is inside it. */
+	public function testEverySourceIsOutsideADirectoryThatDoesNotExist() {
+		$sources = [$this->directory . '/logo.png'];
+
+		$this->assertSame($sources, ImageImport::outside($this->directory . '/gone', $sources));
+	}
 }

--- a/tests/phpunit/unit/SiteConfigTest.php
+++ b/tests/phpunit/unit/SiteConfigTest.php
@@ -335,4 +335,36 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 		}
 		parent::tearDown();
 	}
+
+	/** With no map to read there are no settings to judge, so the lint stops rather than guess. */
+	public function testAConfigThatIsNotAMapEndsTheLint() {
+		$warnings = SiteConfig::lint(['extensions' => 'Foo', 'config' => 'WikvenSiteUrl=https://example.org']);
+
+		$this->assertSame(["'extensions' must be a list.", "'config' must be a map."], $warnings);
+	}
+
+	/**
+	 * An address a crawler cannot fetch is worse in a sitemap than no sitemap, so the value is named
+	 * back to whoever wrote it.
+	 *
+	 * @dataProvider provideUnusableSiteUrls
+	 * @param mixed $value
+	 * @param string $named
+	 */
+	public function testASiteUrlNothingCanFetchIsNamedAndIgnored($value, string $named) {
+		$warnings = SiteConfig::lint(['config' => ['WikvenSiteUrl' => $value]]);
+
+		$this->assertSame(
+			["'WikvenSiteUrl' is $named; expected an http or https URL. Ignoring it."],
+			$warnings
+		);
+	}
+
+	public static function provideUnusableSiteUrls(): array {
+		return [
+			'a scheme no reader follows' => ['ftp://example.org/wiki', "'ftp://example.org/wiki'"],
+			'a host with no scheme' => ['example.org', "'example.org'"],
+			'not a string at all' => [true, 'bool']
+		];
+	}
 }

--- a/tests/phpunit/unit/UserAgentTest.php
+++ b/tests/phpunit/unit/UserAgentTest.php
@@ -4,11 +4,21 @@ namespace MediaWiki\Extension\Wikven\Tests\Unit;
 
 use MediaWiki\Extension\Wikven\Fetching\UserAgent;
 use MediaWikiUnitTestCase;
+use ReflectionProperty;
 
 /**
  * @covers \MediaWiki\Extension\Wikven\Fetching\UserAgent
  */
 class UserAgentTest extends MediaWikiUnitTestCase {
+	/**
+	 * The string is built once and kept. Whoever asked first in this process built it, so clearing
+	 * it is what puts each test back on the manifest read rather than on that answer.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		( new ReflectionProperty(UserAgent::class, 'tool') )->setValue(null, null);
+	}
+
 	/** The version a release moves, read from the same file the class reads. */
 	private function version(): string {
 		$manifest = json_decode(file_get_contents(__DIR__ . '/../../../extension.json'), true);


### PR DESCRIPTION
These classes answer for a machine rather than for a string, so the lines no test reached are the ones a build hits on a bad day.

| | the line nothing walked |
| --- | --- |
| `ComposerInstall` | a record that is not JSON; a package under neither `extensions/` nor `skins/` |
| `ImageImport` | a link with nothing on the far side; a source directory that is not there |
| `SourceFile` | `titleToParam` entirely; no source directory at all; a title core will not parse |
| `SourceAuthors` | a name MediaWiki takes and then will not save |
| `SourceHistory` | the git path — until now every test read a dumped log |
| `SiteConfig` | a `config` that is not a map; a `WikvenSiteUrl` nothing can fetch |
| `UserAgent` | the version read, which the process-wide cache had already answered for |

`SourceHistory` gains the only test in the tree that makes a real checkout: it commits one file at a fixed date and asks for it back, which is where the `git log` arguments and the parser meet what git actually writes. It skips itself where git is not installed, as `GitTest` does.

`UserAgent` builds its string once and keeps it, so by the time its test ran something else in the process had usually built it — the assertions passed against an answer computed before the test started. Clearing the cache in `setUp` puts each test back on the code it is testing.

## One branch removed instead

`Search::copyBundlePath` refused a bundle path whose last segment came out empty. It cannot: the path has its trailing slashes trimmed first, so a lone `/` becomes the empty string and is refused a line earlier, which the existing "the site root" case already proves. The check goes and its comment moves to the branch that does the work.

`Git`'s two remaining lines are "git is not installed" and "the fork failed"; neither is reachable from a test on a host where the suite can run at all.

`includes/` goes from 87.7% to 88.7% locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_