### PR TITLE
test: put the skin switcher and the hooks under test

### DIFF
--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Wikven\Tests\Integration;
 use MediaWiki\Extension\Wikven\Build\BuildFor;
 use MediaWiki\Extension\Wikven\Hooks\Adder;
 use MediaWiki\Output\OutputPage;
+use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Request\FauxRequest;
 use MediaWiki\Skin\Skin;
 use MediaWiki\Title\Title;
@@ -451,5 +452,43 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 		$skin->method('getSkinName')->willReturn($name);
 		$skin->method('getTitle')->willReturn(Title::makeTitle(NS_MAIN, 'Installation'));
 		return $skin;
+	}
+
+	/**
+	 * Timeless draws a personal-tools dropdown and a "Page tools" sidebar that a static export has
+	 * nothing to put in, and its own stylesheet loads after this, so the rule has to shout.
+	 */
+	public function testTimelessLosesTheToolsAStaticSiteCannotFill() {
+		$this->overrideConfigValue('WikvenSkins', ['timeless']);
+		$styles = [];
+		$out = $this->outputPage();
+		$out->method('addInlineStyle')->willReturnCallback(static function ($style) use (&$styles) {
+			$styles[] = $style;
+		});
+
+		$this->adder()->onBeforePageDisplay($out, $this->skin('timeless'));
+
+		$this->assertNotEmpty(array_filter($styles, static function (string $style): bool {
+			return str_contains($style, '#user-tools') && str_contains($style, '#page-tools');
+		}));
+	}
+
+	/**
+	 * The settings page stands in for Special:MobileOptions, whose controls are MobileFrontend's:
+	 * without it installed there is nothing to ask for, and the page is left as any other.
+	 */
+	public function testTheSettingsPageAsksForNothingWithoutMobileFrontend() {
+		if (ExtensionRegistry::getInstance()->isLoaded('MobileFrontend')) {
+			$this->markTestSkipped('with MobileFrontend installed the page does ask for its controls');
+		}
+		$this->overrideConfigValues([
+			'WikvenSkins' => ['minerva'],
+			'WikvenSettingsPage' => 'Settings'
+		]);
+		$out = $this->outputPage();
+		$out->method('getTitle')->willReturn(Title::makeTitle(NS_MAIN, 'Settings'));
+		$out->expects($this->never())->method('addJsConfigVars');
+
+		$this->adder()->onBeforePageDisplay($out, $this->skin('minerva'));
 	}
 }

--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -491,4 +491,55 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 
 		$this->adder()->onBeforePageDisplay($out, $this->skin('minerva'));
 	}
+
+	/** The text size a reader picks has to hold on the pages they then read. */
+	public function testMinervaCarriesTheTextSizeMobileFrontendSets() {
+		$this->markTestSkippedIfExtensionNotLoaded('MobileFrontend');
+		$this->overrideConfigValue('WikvenSkins', ['minerva']);
+		$classes = [];
+		$styles = [];
+		$out = $this->outputPage();
+		$out->method('addHtmlClasses')->willReturnCallback(static function ($class) use (&$classes) {
+			$classes[] = $class;
+		});
+		$out->method('addModuleStyles')->willReturnCallback(static function ($style) use (&$styles) {
+			$styles = array_merge($styles, (array)$style);
+		});
+
+		$this->adder()->onBeforePageDisplay($out, $this->skin('minerva'));
+
+		$this->assertContains('mf-font-size-clientpref-regular', $classes);
+		$this->assertContains('mobile.init.styles', $styles);
+	}
+
+	/** The settings page stands in for Special:MobileOptions, so it asks for what that page asks for. */
+	public function testTheSettingsPageAsksForWhatSpecialMobileOptionsAsksFor() {
+		$this->markTestSkippedIfExtensionNotLoaded('MobileFrontend');
+		$this->overrideConfigValues([
+			'WikvenSkins' => ['minerva'],
+			'WikvenSettingsPage' => 'Settings'
+		]);
+		$vars = [];
+		$modules = [];
+		$styles = [];
+		$out = $this->outputPage();
+		$out->method('getTitle')->willReturn(Title::makeTitle(NS_MAIN, 'Settings'));
+		$out->method('addJsConfigVars')->willReturnCallback(static function ($set) use (&$vars) {
+			$vars = array_merge($vars, (array)$set);
+		});
+		$out->method('addModules')->willReturnCallback(static function ($module) use (&$modules) {
+			$modules = array_merge($modules, (array)$module);
+		});
+		$out->method('addModuleStyles')->willReturnCallback(static function ($style) use (&$styles) {
+			$styles = array_merge($styles, (array)$style);
+		});
+
+		$this->adder()->onBeforePageDisplay($out, $this->skin('minerva'));
+
+		$this->assertArrayHasKey('wgMFEnableFontChanger', $vars);
+		$this->assertContains('mobile.special.mobileoptions.styles', $styles);
+		$this->assertContains('mobile.special.mobileoptions.scripts', $modules);
+		// Asked for at run time by that script, so buildScripts.php cannot see it coming.
+		$this->assertContains('oojs-ui-widgets', $modules);
+	}
 }

--- a/tests/phpunit/integration/SkinListTest.php
+++ b/tests/phpunit/integration/SkinListTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\Build\SkinList;
+use MediaWiki\Skin\Skin;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * The switcher's entries: one per enabled skin, each pointing at that skin's copy of the page.
+ *
+ * @covers \MediaWiki\Extension\Wikven\Build\SkinList
+ */
+class SkinListTest extends MediaWikiIntegrationTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		$this->overrideConfigValues([
+			'WikvenSkins' => ['vector-2022', 'citizen', 'minerva'],
+			'WikvenMainSkin' => 'vector-2022'
+		]);
+	}
+
+	/**
+	 * A skin whose name and title are the page being rendered, as a hook hands one over. Its
+	 * messages are the wiki's, except that "fancy" is a skin declaring a name of its own.
+	 */
+	private function skin(string $name, ?Title $title): Skin {
+		$skin = $this->createMock(Skin::class);
+		$skin->method('getSkinName')->willReturn($name);
+		$skin->method('getTitle')->willReturn($title);
+		$skin->method('msg')->willReturnCallback(static function (string $key, ...$parameters) {
+			return $key === 'skinname-fancy'
+				? wfMessage('rawmessage', 'Fancy Skin')
+				: wfMessage($key, ...$parameters);
+		});
+		return $skin;
+	}
+
+	/**
+	 * The main skin is written at the root and every other one in a directory of its own, so a
+	 * page rendered in the main skin reaches the others by going down and they reach it by going up.
+	 */
+	public function testEachSkinPointsAtItsOwnCopyOfThePage() {
+		$entries = SkinList::entries($this->skin('vector-2022', Title::makeTitle(NS_HELP, 'Searching')));
+
+		$this->assertSame(
+			['t-wikven-skin-vector-2022', 't-wikven-skin-citizen', 't-wikven-skin-minerva'],
+			array_column($entries, 'id')
+		);
+		$this->assertSame(
+			[null, './citizen/Help:Searching.html', './minerva/Help:Searching.html'],
+			array_column($entries, 'href')
+		);
+		$this->assertSame([true, false, false], array_column($entries, 'active'));
+	}
+
+	/** A page rendered in a skin of its own is one directory down, so every link starts by leaving it. */
+	public function testAPageInASkinDirectoryReachesTheOthersFromAboveIt() {
+		$entries = SkinList::forPage($this->skin('citizen', null), 'Installation.html', 'citizen');
+
+		$this->assertSame(
+			['../Installation.html', null, '../minerva/Installation.html'],
+			array_column($entries, 'href')
+		);
+		$this->assertSame([false, true, false], array_column($entries, 'active'));
+	}
+
+	/** Nothing to switch between: one skin is the whole site, and a menu of one is chrome. */
+	public function testASiteWithOneSkinHasNoSwitcher() {
+		$this->overrideConfigValue('WikvenSkins', ['vector-2022']);
+
+		$this->assertSame([], SkinList::forPage($this->skin('vector-2022', null), 'Index.html', 'vector-2022'));
+	}
+
+	/**
+	 * A special page and a link with no page behind it cannot be exported, so neither has a copy
+	 * in another skin to point at.
+	 */
+	public function testAPageThatCannotExistHasNoEntries() {
+		$this->assertSame([], SkinList::entries($this->skin('vector-2022', null)));
+		$this->assertSame(
+			[],
+			SkinList::entries($this->skin('vector-2022', Title::makeTitle(NS_SPECIAL, 'Search')))
+		);
+	}
+
+	/**
+	 * The label is what a reader picks a skin by: the name the skin declares for itself, and
+	 * failing that its directory name spelled as a name rather than as a slug.
+	 */
+	public function testASkinIsLabelledWithTheNameItDeclares() {
+		$this->overrideConfigValue('WikvenSkins', ['vector-2022', 'fancy', 'no-such-skin']);
+
+		$labels = array_column(
+			SkinList::forPage($this->skin('vector-2022', null), 'Index.html', 'vector-2022'),
+			'text'
+		);
+
+		$this->assertSame('Fancy Skin', $labels[1]);
+		$this->assertSame('No Such Skin', $labels[2]);
+	}
+}

--- a/tests/phpunit/integration/VersionerTest.php
+++ b/tests/phpunit/integration/VersionerTest.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
+use MediaWiki\Extension\Wikven\Hooks\Versioner;
 use MediaWiki\Extension\Wikven\Version;
 use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Registration\ExtensionRegistry;
@@ -45,5 +46,22 @@ class VersionerTest extends MediaWikiIntegrationTestCase {
 				Title::newFromText('Versioner test'),
 				ParserOptions::newFromAnon()
 			);
+	}
+
+	/** Every registered variable comes through the hook; another extension's is left to it. */
+	public function testAVariableThatIsNotOursIsLeftAlone() {
+		$value = 'untouched';
+		$cache = [];
+		$frame = false;
+
+		( new Versioner() )->onParserGetVariableValueSwitch(
+			$this->getServiceContainer()->getParserFactory()->getInstance(),
+			$cache,
+			'currentversion',
+			$value,
+			$frame
+		);
+
+		$this->assertSame('untouched', $value);
 	}
 }

--- a/tests/phpunit/unit/ReporterTest.php
+++ b/tests/phpunit/unit/ReporterTest.php
@@ -75,4 +75,19 @@ class ReporterTest extends MediaWikiUnitTestCase {
 
 		$this->assertSame([], $installed);
 	}
+
+	/**
+	 * The hook reads the run it is in rather than being told about it, and the run it is in here is
+	 * PHPUnit's -- which owns the handler, so nothing is installed over it.
+	 */
+	public function testTheHookLeavesAPhpunitRunAlone() {
+		$previous = set_exception_handler(null);
+		set_exception_handler($previous);
+
+		( new Reporter() )->onSetupAfterCache();
+
+		$installed = set_exception_handler(null);
+		set_exception_handler($installed);
+		$this->assertSame($previous, $installed);
+	}
 }

--- a/tests/phpunit/unit/RetrierTest.php
+++ b/tests/phpunit/unit/RetrierTest.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven\Tests\Unit;
 
+use MediaWiki\Config\HashConfig;
 use MediaWiki\Extension\Wikven\Fetching\RetryingForeignRepo;
 use MediaWiki\Extension\Wikven\Hooks\Retrier;
 use MediaWiki\FileRepo\ForeignAPIRepo;
@@ -72,5 +73,35 @@ class RetrierTest extends MediaWikiUnitTestCase {
 
 	public function testNoRepositoryAtAllIsHarmless() {
 		$this->assertSame([], Retrier::retrying([]));
+	}
+
+	/**
+	 * The hook is where this reaches core: the read goes through the service and the write cannot,
+	 * because what core assembles the repositories from is the global.
+	 */
+	public function testTheHookWritesTheRepositoriesBackToTheGlobal() {
+		$before = $GLOBALS['wgForeignFileRepos'] ?? null;
+		try {
+			$GLOBALS['wgForeignFileRepos'] = [];
+			$retrier = new Retrier(new HashConfig(['ForeignFileRepos' => [$this->instantCommons()]]));
+
+			$retrier->onSetupAfterCache();
+
+			$this->assertSame(RetryingForeignRepo::class, $GLOBALS['wgForeignFileRepos'][0]['class']);
+		} finally {
+			if ($before === null) {
+				unset($GLOBALS['wgForeignFileRepos']);
+			} else {
+				$GLOBALS['wgForeignFileRepos'] = $before;
+			}
+		}
+	}
+
+	/** $wgForeignFileRepos is a site's own setting, and a value that is not a repository is passed by. */
+	public function testAnEntryThatIsNotARepositoryIsLeftWhereItIs() {
+		$repos = Retrier::retrying(['nonsense', $this->instantCommons()]);
+
+		$this->assertSame('nonsense', $repos[0]);
+		$this->assertSame(RetryingForeignRepo::class, $repos[1]['class']);
 	}
 }


### PR DESCRIPTION
`SkinList` had no test at all — twenty-four lines that write every link in the switcher a reader picks a skin with, and the one place the rule "the main skin lives at the root, the others in a directory each" is spelled out. It now has one: where each entry points from the root and from a skin directory, that the current skin's own entry has no href, that a one-skin site has no switcher, that a page which cannot exist has no entries, and that a skin is labelled with the name it declares before its directory name.

The hook classes had their pure functions tested and their hooks not:

| | the line nothing walked |
| --- | --- |
| `Retrier` | the hook itself — the read goes through the service, the write has to go to the global |
| `Retrier` | an entry in `$wgForeignFileRepos` that is not a repository |
| `Reporter` | the hook, which under PHPUnit must leave the handler MediaWiki owns alone |
| `Versioner` | another extension's variable arriving at our hook |
| `Adder` | Timeless losing the tools a static site cannot fill |
| `Adder` | the settings page with no MobileFrontend to ask for controls |
| `Adder` | the text size Minerva carries, and what the settings page asks for, *with* MobileFrontend |

The last two skip where MobileFrontend is not installed, which today is every job. #711 puts it in the coverage job; with it, `Adder` reads 99.1% instead of 87.0%. Either PR is useful without the other — these tests skip until the extension arrives, and the extension covers nothing until these tests exist.

`includes/` goes from 87.7% to 89.3% locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn