### PR TITLE
test: read the source tree the way the build reads it

### DIFF
--- a/tests/phpunit/integration/TranslationAdviceTest.php
+++ b/tests/phpunit/integration/TranslationAdviceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\PageTranslation\TranslationAdvice;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * The advice with the wiki's own messages behind it, which is how checkTranslations.php builds it.
+ * The unit test drives the same class with a message function of its own.
+ *
+ * @covers \MediaWiki\Extension\Wikven\PageTranslation\TranslationAdvice
+ */
+class TranslationAdviceTest extends MediaWikiIntegrationTestCase {
+	/** A key nobody added to i18n/ renders as its own name in braces, and that is what would ship. */
+	public function testEveryMessageTheAdviceAsksForIsOneTheExtensionDeclares() {
+		$comment = TranslationAdvice::usingMessages()->comment([
+			['kind' => 'stale', 'file' => 'docs/Pages/ko.wikitext', 'unit' => '3', 'lang' => 'ko'],
+			['kind' => 'parse', 'file' => 'docs/Pages.wikitext', 'detail' => 'pt-shake-position']
+		]);
+
+		$this->assertNotNull($comment);
+		$this->assertStringNotContainsString('⧼', $comment);
+		$this->assertStringContainsString(TranslationAdvice::MARKER, $comment);
+		$this->assertStringContainsString('docs/Pages/ko.wikitext', $comment);
+	}
+
+	/** The all-clear goes through the same messages, and it is what most runs post. */
+	public function testTheAllClearIsRenderedFromMessagesToo() {
+		$body = TranslationAdvice::usingMessages()->allClear();
+
+		$this->assertStringNotContainsString('⧼', $body);
+		$this->assertStringContainsString(TranslationAdvice::MARKER, $body);
+	}
+}

--- a/tests/phpunit/unit/StalenessComputerTest.php
+++ b/tests/phpunit/unit/StalenessComputerTest.php
@@ -489,4 +489,28 @@ class StalenessComputerTest extends MediaWikiUnitTestCase {
 			]
 		];
 	}
+
+	/** A translation with no markers has no units, whatever else is written in it. */
+	public function testATranslationWithoutMarkersHasNoUnits() {
+		$this->assertSame([], StalenessComputer::translationUnits("Hello.\n\nNo markers here."));
+	}
+
+	/** Re-running the scaffold on a translation that already has every unit changes nothing. */
+	public function testAScaffoldWithNothingToAddLeavesTheTranslationAsItIs() {
+		$source = "<!--T:1-->\nHello.\n\n<!--T:2-->\nGoodbye.";
+		$existing = "<!--T:1-->\n안녕하세요.\n\n<!--T:2-->\n안녕히 가세요.";
+
+		$this->assertSame($existing, StalenessComputer::scaffold($source, $existing));
+		$this->assertSame('', StalenessComputer::scaffold('No units at all.'));
+	}
+
+	/** Restamping reads the spans a page quotes verbatim, and a page with no comments has none. */
+	public function testATranslationWithoutAnyCommentIsRestampedUntouched() {
+		$translation = 'Nothing here is a marker, not even <nowiki>this</nowiki>.';
+
+		$this->assertSame(
+			$translation,
+			StalenessComputer::restamp("<!--T:1-->\nHello.", $translation)
+		);
+	}
 }

--- a/tests/phpunit/unit/TranslationAdviceTest.php
+++ b/tests/phpunit/unit/TranslationAdviceTest.php
@@ -242,4 +242,16 @@ class TranslationAdviceTest extends MediaWikiUnitTestCase {
 		$this->assertStringNotContainsString("\n---\n", $body);
 		$this->assertSame(1, substr_count($body, 'text of wikven-translations-title'));
 	}
+
+	/**
+	 * A finding about a file that is not a page -- the config, a script -- has no translations
+	 * under it, so it belongs to the change that names it and to nothing else.
+	 */
+	public function testAFindingAboutSomethingOtherThanAPageIsNotClaimedByAnotherChange() {
+		$advice = $this->advice()->about(['docs/index.wikitext']);
+
+		$this->assertNull($advice->comment([
+			['kind' => 'parse', 'file' => 'docs/.wikven.yaml', 'detail' => 'pt-shake-position']
+		]));
+	}
 }

--- a/tests/phpunit/unit/TranslationSourceTest.php
+++ b/tests/phpunit/unit/TranslationSourceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
+use MediaWikiUnitTestCase;
+
+/**
+ * The parts that read the source tree rather than the wiki: which files are translations, and of
+ * what. The tag extraction they go through works without a service container, and the maintenance
+ * scripts that call them run before there is one.
+ *
+ * @covers \MediaWiki\Extension\Wikven\PageTranslation\TranslationSource
+ */
+class TranslationSourceTest extends MediaWikiUnitTestCase {
+	private string $directory;
+
+	/** Every two-letter code, which is what a build hands these as the wiki's language list. */
+	private function known(): callable {
+		return static function (string $code): bool {
+			return preg_match('/^[a-z]{2}$/', $code) === 1;
+		};
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->directory = sys_get_temp_dir() . '/wikven-translation-source-' . getmypid() . '-' . uniqid();
+		mkdir($this->directory, 0777, true);
+	}
+
+	protected function tearDown(): void {
+		$this->remove($this->directory);
+		parent::tearDown();
+	}
+
+	private function remove(string $path): void {
+		if (is_dir($path)) {
+			foreach (array_diff(scandir($path) ?: [], ['.', '..']) as $entry) {
+				$this->remove("$path/$entry");
+			}
+			rmdir($path);
+			return;
+		}
+		if (is_file($path)) {
+			unlink($path);
+		}
+	}
+
+	/** Write a file under the source directory, making the directories it sits in. */
+	private function write(string $relative, string $text): void {
+		$path = "$this->directory/$relative";
+		if (!is_dir(dirname($path))) {
+			mkdir(dirname($path), 0777, true);
+		}
+		file_put_contents($path, $text);
+	}
+
+	private function translatable(string $title): string {
+		return "<translate>\n<!--T:1-->\n$title.\n</translate>";
+	}
+
+	/** A translation is a sibling file named for its language and carrying the source's markers. */
+	private function translation(string $text): string {
+		return "<!--T:1-->\n$text.";
+	}
+
+	/**
+	 * The language list is read from the files because there is no setting to read: a second list
+	 * would be one to fall out of step with the tree.
+	 */
+	public function testTheLanguagesAreTheOnesTheTreeCarries() {
+		$this->write('Installation.wikitext', $this->translatable('Installation'));
+		$this->write('Installation/ko.wikitext', $this->translation('설치'));
+		$this->write('Installation/km.wikitext', $this->translation('ការដំឡើង'));
+		$this->write('Guide.wikitext', $this->translatable('Guide'));
+		$this->write('Guide/ko.wikitext', $this->translation('안내'));
+
+		$this->assertSame(
+			['km', 'ko'],
+			TranslationSource::languages($this->directory, $this->known())
+		);
+	}
+
+	/** A page nobody has translated yet contributes no language, and neither does an empty tree. */
+	public function testATreeWithNoTranslationsCarriesNoLanguages() {
+		$this->write('Installation.wikitext', $this->translatable('Installation'));
+
+		$this->assertSame([], TranslationSource::languages($this->directory, $this->known()));
+	}
+
+	/**
+	 * Whatever else a page's directory holds is the page's own: an image it uses, a subpage named
+	 * for something other than a language.
+	 */
+	public function testOnlyWikitextNamedForALanguageIsATranslation() {
+		$this->write('Installation.wikitext', $this->translatable('Installation'));
+		$this->write('Installation/ko.wikitext', $this->translation('설치'));
+		$this->write('Installation/diagram.png', 'not wikitext');
+		$this->write('Installation/Advanced.wikitext', 'a subpage of its own');
+		$this->write('Installation/nested/ko.wikitext', 'not a translation either');
+
+		$this->assertSame(
+			['ko'],
+			array_keys(TranslationSource::translationFiles(
+				"$this->directory/Installation.wikitext",
+				$this->known()
+			))
+		);
+	}
+
+	/**
+	 * The magic word is localized, so every spelling in the content language is checked -- and
+	 * where there is no wiki to ask, the English one still works. That is the case the maintenance
+	 * scripts run in.
+	 */
+	public function testTheEnglishMagicWordIsReadWithoutAWikiToAsk() {
+		$this->assertTrue(TranslationSource::hasFixedDisplayTitle('{{DISPLAYTITLE:Wikven}}'));
+		$this->assertFalse(TranslationSource::hasFixedDisplayTitle('Nothing sets a title here.'));
+	}
+}


### PR DESCRIPTION
The translation classes had their wiki-facing half under test and their file-facing half not. `TranslationSource::languages()` — the answer to "which languages does this site have", read from the files because there is no setting to read — had no test at all.

| | the line nothing walked |
| --- | --- |
| `TranslationSource` | `languages()` entirely; a page directory that is not there; a file in one that is not a translation |
| `TranslationSource` | the magic word read with no service container to ask, which is what a maintenance script has |
| `TranslationAdvice` | `usingMessages()` — the advice as the wiki renders it |
| `TranslationAdvice` | a finding about a file with no translations under it |
| `StalenessComputer` | a translation with no markers; a scaffold with nothing to add; a restamp of a page holding no comment |

Two of these are worth more than the line count says.

`TranslationSource`'s new unit test is deliberately a *unit* test: without a service container `MediaWikiServices::getInstance()` throws, which is the branch the class catches and the state `checkTranslations.php` and `scaffoldTranslations.php` run in. Nothing was covering it, and it is the one that decides whether `{{DISPLAYTITLE:}}` is seen at all outside a wiki.

`TranslationAdvice::usingMessages()` is what `checkTranslations.php` posts with. Its integration test renders a real comment through `wfMessage` and fails on `⧼`, so a key that never made it into `i18n/en.json` is caught here rather than in a comment on somebody's pull request.

`includes/` goes from 87.7% to 88.6% locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_