### PR TITLE
fix: let Citizen's preferences panel keep its own spacing

### DIFF
--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -33,6 +33,9 @@ class BuildScripts extends Maintenance {
 	 */
 	private const RUNTIME_MODULES = ['ext.tabberNeue.icons'];
 
+	/** The bundle's own module that carries what onDemand() holds back. Registered by its impl. */
+	private const ON_DEMAND_MODULE = 'ext.Wikven.onDemand';
+
 	public function __construct() {
 		parent::__construct();
 		$this->addDescription('Dump the static JS bundle (startup + module closure) for the generated pages.');
@@ -71,15 +74,17 @@ class BuildScripts extends Maintenance {
 		// Same for the modules core decides on by looking at the rendered page rather than by
 		// queueing them, which is collapsibles and sortable tables. See LazyModules.
 		$seeds = array_merge($seeds, $this->collectLazyModules($htmlDir, $readyConfig));
-		// Same for Citizen's preferences panel, lazy-loaded when the dropdown is first opened. Unseeded
-		// it reports "Couldn't load preferences". Vue and its Codex components come along with it.
+		// Citizen's preferences panel is no seed: a wiki serves it once the dropdown opens, after all
+		// the page queued, and the bundle keeps it there (onDemand()). Unseeded it reports "Couldn't
+		// load preferences"; Vue and Codex come with it.
+		$onDemand = [];
 		$preferences = 'skins.citizen.preferences';
 		if (
 			$defaultSkin === 'citizen'
 			&& $config->get('CitizenEnablePreferences')
 			&& $rl->isModuleRegistered($preferences)
 		) {
-			$seeds[] = $preferences;
+			$onDemand[] = $preferences;
 		}
 		foreach (self::RUNTIME_MODULES as $runtimeModule) {
 			if ($rl->isModuleRegistered($runtimeModule)) {
@@ -95,7 +100,9 @@ class BuildScripts extends Maintenance {
 		file_put_contents("$outDir/startup-static.js", $startup, LOCK_EX);
 
 		// 4. Dump the closure in combined mode so every module self-executes.
-		$bundle = $this->dump($rl, $closure, $languageCode, $defaultSkin, null, []);
+		$bundle =
+			$this->dump($rl, $closure, $languageCode, $defaultSkin, null, [])
+			. $this->onDemand($rl, $onDemand, $closure, $languageCode, $defaultSkin);
 		file_put_contents("$outDir/modules-static.js", $bundle, LOCK_EX);
 
 		// Combined bundle embeds icon CSS pointing at load.php images. The bundle injects its CSS into
@@ -245,6 +252,45 @@ class BuildScripts extends Maintenance {
 		$resolved['jquery'] = true;
 		$resolved['mediawiki.base'] = true;
 		return array_keys($resolved);
+	}
+
+	/**
+	 * Modules a reader's own action loads, held back until the page's have run.
+	 *
+	 * Seeded like the rest they ran early, and ULS's later copy of Codex undid the radio spacing
+	 * Citizen's panel restates at equal specificity.
+	 *
+	 * @param ResourceLoader $rl
+	 * @param string[] $modules The modules to hold back.
+	 * @param string[] $closure The page's own closure, already dumped.
+	 * @param string $lang
+	 * @param string $skin
+	 * @return string JavaScript to append to the bundle; '' when nothing is left to hold back.
+	 */
+	private function onDemand(
+		ResourceLoader $rl,
+		array $modules,
+		array $closure,
+		string $lang,
+		string $skin
+	): string {
+		$later = array_values(array_diff($this->resolveClosure($rl, $modules, $lang, $skin), $closure));
+		if ($later === []) {
+			return '';
+		}
+		// mw.loader.using is mediawiki.base's, which has not run when the bundle does. A module of the
+		// bundle's own executes once the base modules have; its callback fires whether the page's
+		// modules ran or failed, as a wiki serves these either way.
+		return (
+			"\nmw.loader.impl(function(){return["
+			. json_encode(self::ON_DEMAND_MODULE)
+			. ',function(){var run=function(){'
+			. $this->dump($rl, $later, $lang, $skin, null, [])
+			. '};mw.loader.using('
+			. json_encode($closure)
+			. ',run,run);}];});'
+			. "\n"
+		);
 	}
 
 	private function dump(

--- a/tests/e2e/citizen.spec.js
+++ b/tests/e2e/citizen.spec.js
@@ -301,3 +301,28 @@ test("without JavaScript the toolbox still lists the skins, lined up", async ({
 	);
 	await context.close();
 });
+
+test("Citizen's preferences panel keeps the spacing it asks for", async ({
+	page,
+}) => {
+	await page.goto(PAGE);
+	await page.locator("#citizen-preferences-details summary").click();
+
+	// The panel restates Codex's radio spacing at equal specificity, so the copy of Codex injected
+	// last decides. Bundled among the page's modules it ran before ULS's copy: every segment then
+	// fell 6px short of its track and the theme cards' labels sat off-centre. A wiki serves the
+	// panel after the page's modules, and the bundle holds it back the same way.
+	const segment = page
+		.locator(".citizen-preferences-segmented .cdx-radio")
+		.first();
+	await expect(segment).toBeVisible({ timeout: 15000 });
+	await expect(segment).toHaveCSS("margin-bottom", "0px");
+
+	// The theme cards, for as long as Citizen draws them as cards rather than v4's circles.
+	const card = page
+		.locator(".citizen-preferences-radio .cdx-radio__label")
+		.first();
+	if (await card.count()) {
+		await expect(card).toHaveCSS("padding-left", "0px");
+	}
+});


### PR DESCRIPTION
## What was wrong

On a wikven export the Citizen preferences panel is laid out differently from the same panel on a wiki running Citizen (compare starcitizen.tools): the text-size and width segments do not fill their track and their samples sit off-centre, and the theme cards' labels are pushed to the right.

Measured in Chromium on the published docs site:

| Element | Expected | Export |
| --- | --- | --- |
| `.citizen-preferences-segmented .cdx-radio` margin-bottom | 0 | 6px |
| `.citizen-preferences-radio .cdx-radio__label` padding-left | 0 | 26px |

## Why

Citizen's panel restates Codex's radio rules (`.cdx-radio:not(.cdx-radio--inline)`, `.cdx-radio__label`) at equal specificity, so whichever copy of Codex is injected last decides. Two modules in the bundle carry a copy of the Codex component CSS: `skins.citizen.preferences` and `ext.uls.compactlinks`, each through `codexComponents`.

On a wiki the panel module is fetched when the dropdown first opens, after everything the page queued, so its rules land last and win. `buildScripts.php` seeded it with the page's modules instead, so it executed in whatever order `mw.loader`'s propagation passes gave, which put ULS's copy of Codex after the panel's overrides.

## What changes

* `maintenance/buildScripts.php` no longer seeds `skins.citizen.preferences` into the page's closure. The panel and whatever only it depends on are dumped after the page's bundle, inside a module of the bundle's own (`ext.Wikven.onDemand`) whose script implements them once `mw.loader.using` reports the page's closure as run. `mw.loader.using` is used rather than a dependency list so the panel still arrives when a page module fails, as it would on a wiki. The wrapper module exists because `mw.loader.using` belongs to `mediawiki.base`, which has not executed when the bundle runs.
* `tests/e2e/citizen.spec.js` opens the panel and asserts the segment margin and, while Citizen still draws theme cards, the card label padding.

Only the preferences panel is held back. The other on-demand modules (`jquery.makeCollapsible`, `jquery.tablesorter`, `ext.tabberNeue.icons`, the search module) are requested by page modules during their own execution, so they have to be implemented before those run and stay where they are.

## Verification

* Reproduced the defect and the fix in headless Chromium against a local mirror of the published site, by rewriting `modules-static.js` the way the new code does: the panel loads without any `load.php` request, the segments fill their track, and Citizen's rules now win in the matched-styles dump.
* The new e2e test fails against the current bundle (`margin-bottom` 6px) and passes against the rewritten one.
* `php tests/comments/assert-comments.php includes maintenance tests`, `composer phpcs`, `mago format --check`, `mago lint`, and `biome check` are clean.
* Not run here: a full bake (needs the MediaWiki image), so CI is the first real build with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017djpHuCvhnntbCwVz973Wc

---
_Generated by [Claude Code](https://claude.ai/code/session_017djpHuCvhnntbCwVz973Wc)_