### PR TITLE
test: render the images a page asks load.php for

### DIFF
--- a/tests/phpunit/integration/AssetLocalizerTest.php
+++ b/tests/phpunit/integration/AssetLocalizerTest.php
@@ -3,8 +3,10 @@
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
 use MediaWiki\Extension\Wikven\Output\AssetLocalizer;
+use MediaWiki\ResourceLoader\ImageModule;
 use MediaWiki\ResourceLoader\ResourceLoader;
 use MediaWikiIntegrationTestCase;
+use Wikimedia\AtEase\AtEase;
 
 /**
  * @covers \MediaWiki\Extension\Wikven\Output\AssetLocalizer
@@ -151,5 +153,159 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 			rawurldecode(substr($m[1], strlen('data:image/svg+xml,'))),
 			'and it still decodes back to the asset'
 		);
+	}
+
+	/** An image module of our own, so the test does not ride on what core happens to ship. */
+	private function registerImageModule(ResourceLoader $rl): void {
+		$images = $this->getNewTempDirectory();
+		file_put_contents("$images/arrow.svg", '<svg xmlns="http://www.w3.org/2000/svg">arrow</svg>');
+		$rl->register('wikven.testImages', [
+			'class' => ImageModule::class,
+			'prefix' => 'wikven-test',
+			'localBasePath' => $images,
+			// A skin asks for the variant its palette needs, and the request carries it.
+			'images' => ['arrow' => ['file' => 'arrow.svg', 'variants' => ['invert']]],
+			// Keyed twice: a variant list is looked up by skin, with 'default' only marking that the
+			// list is keyed that way rather than standing in for a skin that is missing from it.
+			'variants' => [
+				'default' => ['invert' => ['color' => '#fff']],
+				'vector' => ['invert' => ['color' => '#fff']]
+			]
+		]);
+	}
+
+	/** A stylesheet holding one url(), written where the pass would write it. */
+	private function stylesheet(string $directory, string $url): string {
+		$path = "$directory/styles.css";
+		file_put_contents($path, ".a{background:url($url)}\n");
+		return $path;
+	}
+
+	/**
+	 * The other half of this class: a url() answered by load.php is a request to a server the export
+	 * does not have, so the image is rendered once and written beside the stylesheet.
+	 */
+	public function testAnImageServedByLoadPhpIsRenderedIntoTheOutput() {
+		$rl = $this->resourceLoaderRootedAt($this->getNewTempDirectory());
+		$this->registerImageModule($rl);
+		$directory = $this->getNewTempDirectory();
+		$css = $this->stylesheet(
+			$directory,
+			'/load.php?modules=wikven.testImages&image=arrow&format=original&version=1a2b3'
+		);
+
+		AssetLocalizer::localizeAssets($rl, $directory, [$css], 'en', 'vector');
+
+		$out = file_get_contents($css);
+		$this->assertStringNotContainsString('load.php', $out);
+		$this->assertSame(1, preg_match('~url\(\./(img-[0-9a-f]{12}\.svg)\)~', $out, $rewritten));
+		$this->assertStringContainsString('arrow', file_get_contents("$directory/{$rewritten[1]}"));
+	}
+
+	/** A JS bundle's CSS resolves against the page rather than the file, so its images are embedded. */
+	public function testAnImageServedByLoadPhpIsInlinedForABundle() {
+		$rl = $this->resourceLoaderRootedAt($this->getNewTempDirectory());
+		$this->registerImageModule($rl);
+		$directory = $this->getNewTempDirectory();
+		$css = $this->stylesheet(
+			$directory,
+			'\\u0027/load.php?modules=wikven.testImages\\u0026image=arrow\\u0026format=original\\u0027'
+		);
+
+		AssetLocalizer::localizeAssets($rl, $directory, [$css], 'en', 'vector', true);
+
+		$out = file_get_contents($css);
+		$this->assertStringContainsString('url(data:image/svg+xml', $out);
+		$this->assertStringNotContainsString('load.php', $out);
+		$this->assertSame([], glob("$directory/img-*"), 'nothing is written beside a bundle');
+	}
+
+	/**
+	 * What is left where the reference cannot be turned into an image: a request naming no module,
+	 * and one naming a module that answers with something other than an image.
+	 *
+	 * @dataProvider provideReferencesThatAreNotImages
+	 */
+	public function testAReferenceThatIsNotAnImageIsLeftWhereItIs(string $url) {
+		$rl = $this->resourceLoaderRootedAt($this->getNewTempDirectory());
+		$this->registerImageModule($rl);
+		$directory = $this->getNewTempDirectory();
+		$css = $this->stylesheet($directory, $url);
+
+		AssetLocalizer::localizeAssets($rl, $directory, [$css], 'en', 'vector');
+
+		$this->assertStringContainsString($url, file_get_contents($css));
+		$this->assertSame([], glob("$directory/img-*"));
+	}
+
+	public static function provideReferencesThatAreNotImages(): array {
+		return [
+			'no module named' => ['/load.php?image=arrow&format=original'],
+			'a module that is not images' => ['/load.php?modules=startup&image=arrow&only=scripts'],
+			// Whatever a stylesheet said, it is not a URL anything can read a query out of.
+			'not a URL at all' => ['http://:80x/load.php?modules=wikven.testImages&image=arrow']
+		];
+	}
+
+	/** A file the pass listed but cannot read is passed over, leaving the others to be rewritten. */
+	public function testAFileThatCannotBeReadIsPassedOver() {
+		$rl = $this->resourceLoaderRootedAt($this->getNewTempDirectory());
+		$this->registerImageModule($rl);
+		$directory = $this->getNewTempDirectory();
+		$css = $this->stylesheet(
+			$directory,
+			'/load.php?modules=wikven.testImages&image=arrow&format=original'
+		);
+
+		// The read warns on its way to the false this is about, and PHPUnit fails a test that warns.
+		AtEase::suppressWarnings();
+		try {
+			AssetLocalizer::localizeAssets($rl, $directory, ["$directory/gone.css", $css], 'en', 'vector');
+		} finally {
+			AtEase::restoreWarnings();
+		}
+
+		$this->assertStringNotContainsString('load.php', file_get_contents($css));
+	}
+
+	/** A skin asking for a variant gets that variant, not the plain image under its name. */
+	public function testAVariantIsRenderedAsTheVariant() {
+		$rl = $this->resourceLoaderRootedAt($this->getNewTempDirectory());
+		$this->registerImageModule($rl);
+		$directory = $this->getNewTempDirectory();
+		$css = $this->stylesheet(
+			$directory,
+			'/load.php?modules=wikven.testImages&image=arrow&variant=invert&format=original'
+		);
+
+		AssetLocalizer::localizeAssets($rl, $directory, [$css], 'en', 'vector');
+
+		$this->assertSame(1, preg_match('~url\(\./(img-[0-9a-f]{12}\.svg)\)~', file_get_contents($css), $out));
+		$this->assertStringContainsString('#fff', file_get_contents("$directory/{$out[1]}"));
+	}
+
+	/**
+	 * A dumped stylesheet is the site's own MediaWiki:Common.css as much as it is a skin's, so a
+	 * url() is not a path to read a file at until it is shown to be under the install.
+	 */
+	public function testADirectPathThatIsNotAFileUnderTheInstallIsLeftAlone() {
+		$mwRoot = $this->getNewTempDirectory();
+		mkdir("$mwRoot/skins/Vector/images", 0777, true);
+		file_put_contents("$mwRoot/skins/Vector/images/empty.svg", '');
+		$rl = $this->resourceLoaderRootedAt($mwRoot);
+		$directory = $this->getNewTempDirectory();
+		$css = "$directory/styles.css";
+		$text =
+			implode("\n", [
+				'.a{background:url(/skins/../../etc/shadow.svg)}',
+				'.b{background:url(/skins/Vector/images/gone.svg)}',
+				'.c{background:url(/skins/Vector/images/empty.svg)}'
+			]) . "\n";
+		file_put_contents($css, $text);
+
+		AssetLocalizer::localizeAssets($rl, $directory, [$css], 'en', 'vector');
+
+		$this->assertSame($text, file_get_contents($css));
+		$this->assertSame([], glob("$directory/img-*"));
 	}
 }


### PR DESCRIPTION
`AssetLocalizer` rewrites two kinds of `url()` in dumped CSS: a direct path under `skins/`, and one answered by `load.php`. Only the first was tested, and the second is the one that matters more — a `load.php?image=` left in a stylesheet is a request to a server the export does not have, so the icon is simply missing.

It now has tests for the image written beside the stylesheet, the same image embedded as a `data:` URI for a bundle, a variant, the three ways a reference turns out not to be an image (including a `url()` whose query cannot be parsed at all), a file the pass listed but cannot read, and a direct path that escapes the install or points at an empty file.

The tests register an image module of their own rather than reaching for whatever image module core happens to ship, so nothing here moves when core rearranges its icons.

`AssetLocalizer` goes from 59.8% to 100%, and `includes/` from 87.7% to 89.4% locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn