### PR TITLE
test: put the head of an exported page under test

### DIFF
--- a/tests/phpunit/integration/MainHeadLinksTest.php
+++ b/tests/phpunit/integration/MainHeadLinksTest.php
@@ -2,9 +2,14 @@
 
 namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
+use MediaWiki\Content\ContentHandler;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Extension\Translate\PageTranslation\TranslatablePage;
 use MediaWiki\Extension\Wikven\Hooks\Main;
+use MediaWiki\Output\OutputPage;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
+use Wikimedia\AtEase\AtEase;
 use Wikimedia\TestingAccessWrapper;
 
 /**
@@ -172,5 +177,167 @@ class MainHeadLinksTest extends MediaWikiIntegrationTestCase {
 		$this->overrideConfigValue('WikvenLicensesPage', 'Licenses');
 		$this->overrideConfigValue('WikvenSourceDirectory', $source);
 		$this->overrideConfigValue('WikvenSiteUrl', 'https://example.org/docs');
+	}
+
+	/** An OutputPage for a page of the site, asking for the module styles a test names. */
+	private function outputFor(array $moduleStyles): OutputPage {
+		$context = new RequestContext();
+		$context->setTitle(Title::newFromText('Getting Started'));
+		$out = new OutputPage($context);
+		$out->addModuleStyles($moduleStyles);
+		return $out;
+	}
+
+	/**
+	 * The head of an exported page: the links that answer only inside a live MediaWiki go, and each
+	 * module's styles arrive as a file beside the page rather than as a load.php request.
+	 */
+	public function testTheHeadLosesItsApiLinksAndGainsItsStylesheets() {
+		$directory = $this->getNewTempDirectory();
+		$this->overrideConfigValues([
+			'WikvenHtmlDirectory' => $directory,
+			'WikvenAssetDirectory' => 'assets'
+		]);
+		$tags = [
+			'alternative-edit' => '<link rel="alternate" type="application/x-wiki">',
+			'opensearch' => '<link rel="search">',
+			'rsd' => '<link rel="EditURI">',
+			'universal-edit-button' => '<link rel="alternate">',
+			'meta-generator' => '<meta name="generator" content="MediaWiki">'
+		];
+		$out = $this->outputFor(['mediawiki.skinning.interface']);
+
+		$this->main()->onOutputPageAfterGetHeadLinksArray($tags, $out);
+
+		$this->assertSame(
+			['meta-generator', 'mediawiki.skinning.interface'],
+			array_keys($tags),
+			'the four links a static host cannot answer are gone, the module is linked'
+		);
+		$this->assertStringContainsString(
+			'assets/mediawiki.skinning.interface.css',
+			$tags['mediawiki.skinning.interface']
+		);
+		// The file the build writes the styles into has to be there for the pass that fills it.
+		$this->assertFileExists("$directory/assets/mediawiki.skinning.interface.css");
+	}
+
+	/**
+	 * What is not linked: a module nothing registered, and one whose styles belong to a reader
+	 * rather than to the page -- a static site has no reader to have them.
+	 */
+	public function testAModuleThatIsNobodysOrEverybodysOwnIsNotLinked() {
+		$this->overrideConfigValues([
+			'WikvenHtmlDirectory' => $this->getNewTempDirectory(),
+			'WikvenAssetDirectory' => 'assets'
+		]);
+		$tags = [];
+		$out = $this->outputFor(['wikven.no.such.module', 'user.styles']);
+
+		$this->main()->onOutputPageAfterGetHeadLinksArray($tags, $out);
+
+		$this->assertSame([], $tags);
+	}
+
+	/** Outside a build there is no static site to place the file in, and none is made. */
+	public function testAWikiThatIsNotBakingWritesNoStylesheetFile() {
+		$this->overrideConfigValue('WikvenHtmlDirectory', '');
+		$tags = [];
+
+		$this->main()->onOutputPageAfterGetHeadLinksArray($tags, $this->outputFor(['mediawiki.skinning.interface']));
+
+		$this->assertSame(['mediawiki.skinning.interface'], array_keys($tags));
+	}
+
+	/** A site with no licenses page has no family of copies for a page to belong to. */
+	public function testWithoutALicensesPageThereIsNoFamilyOfCopies() {
+		$this->overrideConfigValues([
+			'WikvenSiteUrl' => 'https://example.org/docs',
+			'WikvenLicensesPage' => ''
+		]);
+
+		$this->assertSame(
+			['link-canonical'],
+			array_keys($this->addressTags(Title::newFromText('Licenses')))
+		);
+	}
+
+	/** A page marked for translation, with one translation page written beside it. */
+	private function markedForTranslationInto(string $titleText, string $language): void {
+		$title = Title::newFromText($titleText);
+		$status = $this->editPage(
+			$title,
+			ContentHandler::makeContent("<translate>\n<!--T:1-->\nHi.\n</translate>", $title),
+			__METHOD__,
+			NS_MAIN,
+			$this->getTestSysop()->getUser()
+		);
+		TranslatablePage::newFromTitle($title)->addMarkedTag($status->value['revision-record']->getId());
+		$this->getExistingTestPage(Title::newFromText("$titleText/$language"));
+	}
+
+	/**
+	 * The other family: a page Translate marked. Whichever of the set is rendered, the set named is
+	 * the same, and the source page owns the language it was written in rather than its "/en" copy.
+	 *
+	 * @dataProvider provideTranslatedPagesOfOneSet
+	 */
+	public function testEveryPageOfATranslatedSetNamesTheWholeSet(string $rendered, string $canonical) {
+		$this->markTestSkippedIfExtensionNotLoaded('Translate');
+		$this->overrideConfigValue('WikvenSiteUrl', 'https://example.org/docs');
+		$this->markedForTranslationInto('Installation', 'ko');
+
+		$this->assertSame(
+			[
+				'canonical' => $canonical,
+				'en' => 'Installation.html',
+				'ko' => 'Installation/ko.html',
+				'x-default' => 'Installation.html'
+			],
+			$this->addressed(Title::newFromText($rendered))
+		);
+	}
+
+	public static function provideTranslatedPagesOfOneSet(): array {
+		return [
+			'the source page' => ['Installation', 'Installation.html'],
+			'a translation of it' => ['Installation/ko', 'Installation/ko.html']
+		];
+	}
+
+	/** A page Translate has never heard of is a page of one language, which says nothing. */
+	public function testAPageThatIsNotTranslatedNamesNoSet() {
+		$this->markTestSkippedIfExtensionNotLoaded('Translate');
+		$this->overrideConfigValue('WikvenSiteUrl', 'https://example.org/docs');
+
+		$this->assertSame(
+			['canonical' => 'Getting_Started.html'],
+			$this->addressed(Title::newFromText('Getting Started'))
+		);
+	}
+
+	/**
+	 * A directory the build cannot make is reported rather than printed into the page: the pass
+	 * that fills these files is the one to fail, where the reason is still known.
+	 */
+	public function testAnAssetDirectoryThatCannotBeMadeStillLeavesThePageAlone() {
+		$directory = $this->getNewTempDirectory();
+		file_put_contents("$directory/assets", 'a file, where the directory has to go');
+		$this->overrideConfigValues([
+			'WikvenHtmlDirectory' => $directory,
+			'WikvenAssetDirectory' => 'assets'
+		]);
+		$tags = [];
+		$out = $this->outputFor(['mediawiki.skinning.interface']);
+
+		// The failed mkdir warns on its way to the false the code reads, and PHPUnit fails on a warning.
+		AtEase::suppressWarnings();
+		try {
+			$this->main()->onOutputPageAfterGetHeadLinksArray($tags, $out);
+		} finally {
+			AtEase::restoreWarnings();
+		}
+
+		$this->assertSame(['mediawiki.skinning.interface'], array_keys($tags));
 	}
 }

--- a/tests/phpunit/integration/MainSetupAfterCacheTest.php
+++ b/tests/phpunit/integration/MainSetupAfterCacheTest.php
@@ -132,4 +132,32 @@ class MainSetupAfterCacheTest extends MediaWikiIntegrationTestCase {
 		$this->main()->onSetupAfterCache();
 		$this->assertArrayNotHasKey('wgULSImeSelectors', $GLOBALS);
 	}
+
+	/** A logo written the long way is dropped whole when its file is not there to name. */
+	public function testAnArrayFormLogoWhoseFileIsMissingIsDropped() {
+		$this->overrideConfigValue('WikvenSourceDirectory', $this->getNewTempDirectory());
+		$this->overrideConfigValue('WikvenLogos', ['icon' => ['src' => 'missing.png', 'width' => 50]]);
+		$this->setMwGlobals('wgLogos', []);
+
+		$this->main()->onSetupAfterCache();
+
+		$this->assertArrayNotHasKey('icon', $GLOBALS['wgLogos']);
+	}
+
+	/**
+	 * A file name is not a page name: the source tree can hold one MediaWiki has no title for, and
+	 * there is no upload URL to answer with.
+	 */
+	public function testALogoWhoseNameIsNoTitleIsDropped() {
+		$src = $this->getNewTempDirectory();
+		// A file name carrying a character a title cannot: "<" is one core refuses outright.
+		file_put_contents("$src/a<b.png", 'not a real png, just needs to exist');
+		$this->overrideConfigValue('WikvenSourceDirectory', $src);
+		$this->overrideConfigValue('WikvenLogos', ['1x' => 'a<b.png']);
+		$this->setMwGlobals('wgLogos', []);
+
+		$this->main()->onSetupAfterCache();
+
+		$this->assertArrayNotHasKey('1x', $GLOBALS['wgLogos']);
+	}
 }

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -4,6 +4,8 @@ namespace MediaWiki\Extension\Wikven\Tests\Integration;
 
 use MediaWiki\Extension\Wikven\Build\BuildFor;
 use MediaWiki\Extension\Wikven\Hooks\Main;
+use MediaWiki\FileRepo\File\File;
+use MediaWiki\FileRepo\RepoGroup;
 use MediaWiki\Skin\SkinTemplate;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
@@ -280,5 +282,83 @@ class MainTest extends MediaWikiIntegrationTestCase {
 		$links = ['views' => []];
 		$this->main()->onSkinTemplateNavigation__Universal($sktemplate, $links);
 		return $links['views'];
+	}
+
+	/** A link to another wiki is that wiki's to answer for; the export rewrites its own pages only. */
+	public function testAnInterwikiLinkIsLeftAlone() {
+		$url = 'https://www.mediawiki.org/wiki/Manual:Contents';
+		$title = Title::makeTitle(NS_MAIN, 'Manual:Contents', '', 'mediawikiwiki');
+		$this->main()->onGetLocalURL($title, $url, '');
+
+		$this->assertSame('https://www.mediawiki.org/wiki/Manual:Contents', $url);
+	}
+
+	/**
+	 * A file borrowed from Commons has no File: page here, so the link goes to the page the
+	 * repository keeps for it -- or nowhere, where the repository names none.
+	 *
+	 * @dataProvider provideForeignDescriptions
+	 */
+	public function testAForeignFileLinksToTheRepositoryThatHasIt(?string $description, string $expected) {
+		$file = $this->createMock(File::class);
+		$file->method('isLocal')->willReturn(false);
+		$file->method('getDescriptionUrl')->willReturn($description);
+		$repos = $this->createMock(RepoGroup::class);
+		$repos->method('findFile')->willReturn($file);
+		$this->setService('RepoGroup', $repos);
+
+		$url = '/index.php/File:Bakery_oven.jpg';
+		$this->main()->onGetLocalURL(Title::newFromText('File:Bakery oven.jpg'), $url, '');
+
+		$this->assertSame($expected, $url);
+	}
+
+	public static function provideForeignDescriptions(): array {
+		$commons = 'https://commons.wikimedia.org/wiki/File:Bakery_oven.jpg';
+		return [
+			'a repository with a description page' => [$commons, $commons],
+			'a repository with none' => [null, '/index.php/File:Bakery_oven.jpg'],
+			'a repository answering with nothing' => ['', '/index.php/File:Bakery_oven.jpg']
+		];
+	}
+
+	/**
+	 * Translate's banner and its "Translate" tab point at Special:Translate, which the export has no
+	 * page for. The query says which page and which language, and that is a file on the edit host.
+	 */
+	public function testATranslateLinkGoesToTheTranslationsOwnSourceFile() {
+		$this->overrideConfigValue('WikvenEditUrl', 'https://example.org/edit/$1');
+
+		$url = '/index.php/Special:Translate';
+		$this->main()->onGetFullURL(
+			Title::newFromText('Special:Translate'),
+			$url,
+			'group=page-Getting+Started&language=ko&action=page'
+		);
+
+		$this->assertSame('https://example.org/edit/Getting%20Started/ko.wikitext', $url);
+	}
+
+	/**
+	 * Without both halves of that query there is no file to name, so the link is left to the other
+	 * rules -- which have nothing for a special page either.
+	 *
+	 * @dataProvider provideTranslateQueriesThatNameNoFile
+	 */
+	public function testATranslateLinkNamingNoFileIsNotRewritten(string $query) {
+		$this->overrideConfigValue('WikvenEditUrl', 'https://example.org/edit/$1');
+
+		$url = '/index.php/Special:Translate';
+		$this->main()->onGetFullURL(Title::newFromText('Special:Translate'), $url, $query);
+
+		$this->assertSame('/index.php/Special:Translate', $url);
+	}
+
+	public static function provideTranslateQueriesThatNameNoFile(): array {
+		return [
+			'no language' => ['group=page-Getting+Started'],
+			'a group that is not a page' => ['group=core&language=ko'],
+			'nothing at all' => ['']
+		];
 	}
 }

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -327,6 +327,9 @@ class MainTest extends MediaWikiIntegrationTestCase {
 	 * page for. The query says which page and which language, and that is a file on the edit host.
 	 */
 	public function testATranslateLinkGoesToTheTranslationsOwnSourceFile() {
+		// Special:Translate is Translate's page: with the extension absent there is no such special
+		// page for a title to be, and nothing here to answer for.
+		$this->markTestSkippedIfExtensionNotLoaded('Translate');
 		$this->overrideConfigValue('WikvenEditUrl', 'https://example.org/edit/$1');
 
 		$url = '/index.php/Special:Translate';
@@ -346,6 +349,7 @@ class MainTest extends MediaWikiIntegrationTestCase {
 	 * @dataProvider provideTranslateQueriesThatNameNoFile
 	 */
 	public function testATranslateLinkNamingNoFileIsNotRewritten(string $query) {
+		$this->markTestSkippedIfExtensionNotLoaded('Translate');
 		$this->overrideConfigValue('WikvenEditUrl', 'https://example.org/edit/$1');
 
 		$url = '/index.php/Special:Translate';


### PR DESCRIPTION
`Hooks\Main` is the largest class in `includes/` and was the least covered: 62%, with 97 lines no test reached. Chief among them `onOutputPageAfterGetHeadLinksArray`, which decides what the head of every exported page says — and ran in no test at all.

| | the line nothing walked |
| --- | --- |
| `onOutputPageAfterGetHeadLinksArray` | the whole hook: the api links dropped, each module's styles linked as a file, the placeholder written for the pass that fills it |
| the same | a module whose styles belong to a reader rather than the page; a wiki that is not baking; an asset directory that cannot be made |
| `cluster()` | the family a page Translate marked belongs to, from both the source page and a translation |
| `exportTarget()` | an interwiki link; a file borrowed from a foreign repository; `Special:Translate` resolved to the translation's own source file |
| `resolveLogoUrl()` | a logo written the long way whose file is missing; a file name that is no page title |
| `licensesCluster()` | a site with no licenses page |

The `Special:Translate` and page-family tests are the ones worth the most: both are the difference between a link that works in the export and one that points at a page the export does not have. They skip where Translate is not installed — that is the `phpunit` jobs — and run in the `coverage` job, which installs it.

`Hooks\Main` goes from 62.2% to 97.3%, and `includes/` from 87.7% to 92.5% locally. What is left is four guards that cannot be reached from a test at all (a web request, a wiki without ULS, a module `getModuleStyles( true )` already filtered out) and the Citizen search wiring, which needs SifterSearch installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_