### PR TITLE
ci: run the coverage job on a wiki that has MobileFrontend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,11 @@ env:
   # Mirrors .phan/config.php. Nothing is gained by cloning what phan will not parse.
   PHAN_DEPENDENCIES: Gadgets Translate
   # Translate refuses to install without UniversalLanguageSelector, and phan has no use for it --
-  # which is why Translate's own phan config does not name it either.
-  WIKI_DEPENDENCIES: Gadgets Translate UniversalLanguageSelector
+  # which is why Translate's own phan config does not name it either. MobileFrontend is here for the
+  # opposite reason: nothing reaches for its symbols, so phan has nothing to resolve, but Minerva
+  # leans on it and every build of this documentation site fetches it, which makes the branches
+  # behind ExtensionRegistry::isLoaded('MobileFrontend') live code on the site wikven is read on.
+  WIKI_DEPENDENCIES: Gadgets MobileFrontend Translate UniversalLanguageSelector
 
 # Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,19 @@ permissions: {}
 # appearing in extension.json would otherwise take the phan config's place without a word.
 env:
   # Mirrors .phan/config.php. Nothing is gained by cloning what phan will not parse.
-  PHAN_DEPENDENCIES: Gadgets Translate
+  PHAN_DEPENDENCIES: >-
+    Gadgets
+    Translate
   # Translate refuses to install without UniversalLanguageSelector, and phan has no use for it --
   # which is why Translate's own phan config does not name it either. MobileFrontend is here for the
   # opposite reason: nothing reaches for its symbols, so phan has nothing to resolve, but Minerva
   # leans on it and every build of this documentation site fetches it, which makes the branches
   # behind ExtensionRegistry::isLoaded('MobileFrontend') live code on the site wikven is read on.
-  WIKI_DEPENDENCIES: Gadgets MobileFrontend Translate UniversalLanguageSelector
+  WIKI_DEPENDENCIES: >-
+    Gadgets
+    MobileFrontend
+    Translate
+    UniversalLanguageSelector
 
 # Cancel superseded runs; pushes to main are left to finish, keeping a result per merged commit.
 concurrency:


### PR DESCRIPTION
MinervaNeue leans on MobileFrontend and every build of this documentation site fetches it, so what sits behind `ExtensionRegistry::isLoaded( 'MobileFrontend' )` is live code on the site wikven is read on — and no run of the suite could enter it, because no job installed the extension.

One name in `WIKI_DEPENDENCIES`, which only the coverage job reads. It is deliberately not in `PHAN_DEPENDENCIES`: nothing here reaches for a MobileFrontend symbol (the one service it asks for is named as a string), so phan has nothing to resolve and cloning it there would buy nothing.

With it installed, and the two tests in #706 that skip without it, `Hooks\Adder` goes from 87.0% to 99.1% — measured locally on MediaWiki REL1_46 with MobileFrontend, Translate and UniversalLanguageSelector. The one line left is the `return` for a wiki that does *not* have MobileFrontend, which nothing can walk on a wiki that does; the `phpunit` jobs, which install no extensions, are where that one runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_