### PR TITLE
feat: have a bake say where its time went

### DIFF
--- a/includes/Build/BuildTimes.php
+++ b/includes/Build/BuildTimes.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Build;
+
+/**
+ * What each phase of a build took, and the report the build prints of it when it is over.
+ *
+ * The clock stays with the caller: this is handed durations, so it answers the same in a test as
+ * in a bake.
+ */
+class BuildTimes {
+	/** @var array<string,float> Seconds, by phase, in the order the phases first ran. */
+	private array $phases = [];
+
+	/** Remember what a phase took. A phase named twice adds up, having run twice. */
+	public function add(string $phase, float $seconds): void {
+		$this->phases[$phase] = ( $this->phases[$phase] ?? 0.0 ) + $seconds;
+	}
+
+	/**
+	 * Every phase in the order it ran, under what the whole of $what took.
+	 *
+	 * In that order rather than longest first: this is read to find where a build went quiet, and
+	 * that is a place in the sequence.
+	 *
+	 * @param string $what What the phases add up to, e.g. "the build" or "the minerva pass".
+	 * @return string Empty where no phase ran, so a caller can print it unconditionally.
+	 */
+	public function report(string $what): string {
+		if ($this->phases === []) {
+			return '';
+		}
+		$times = array_map([self::class, 'seconds'], $this->phases);
+		$width = max(array_map('strlen', $times));
+		$lines = ['Wikven: ' . $what . ' took ' . self::seconds(array_sum($this->phases)) . ', spent as'];
+		foreach ($times as $phase => $seconds) {
+			$lines[] = '  ' . str_pad($seconds, $width, ' ', STR_PAD_LEFT) . "  $phase";
+		}
+		return implode("\n", $lines) . "\n";
+	}
+
+	/** One duration, to the tenth of a second a phase is worth reading to. */
+	public static function seconds(float $seconds): string {
+		return number_format($seconds, 1) . 's';
+	}
+}

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -9,6 +9,7 @@ use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\ContentHandler;
 use MediaWiki\Extension\Wikven\Build\BuildConcurrency;
 use MediaWiki\Extension\Wikven\Build\BuildFor;
+use MediaWiki\Extension\Wikven\Build\BuildTimes;
 use MediaWiki\Extension\Wikven\Build\SkinPass;
 use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
 use MediaWiki\Extension\Wikven\Source\SourceAuthors;
@@ -47,8 +48,12 @@ class Build extends Maintenance {
 	 */
 	private bool $searchIndexRan = false;
 
+	/** What each phase of this process took, printed when it is over. */
+	private BuildTimes $times;
+
 	public function __construct() {
 		parent::__construct();
+		$this->times = new BuildTimes();
 		$this->addDescription('Run the full wikven static-site build in a single process.');
 	}
 
@@ -66,41 +71,62 @@ class Build extends Maintenance {
 
 		// Before the output directory is emptied, because a site this build cannot render is better
 		// told so with its last bake still in place.
-		$this->assertEverythingListedIsHere();
-		$this->checkLuaAgainstThisBuild();
-		$this->clearOutputDirectory();
-		$this->setMainPage();
-		$this->importImages("$ip/maintenance/importImages.php");
-		$this->step(ImportWikitext::class, "$own/importWikitext.php");
-		$this->assertMainPageExists();
-		$this->setLicensesPage();
-		$this->setSettingsPage();
-		$this->dropDeadPlaceLinks();
-		$this->dropDeadCategoryLink();
+		$this->phase('check what the site listed', $this->assertEverythingListedIsHere(...));
+		$this->phase('check the Lua', $this->checkLuaAgainstThisBuild(...));
+		$this->phase('clear the output directory', $this->clearOutputDirectory(...));
+		$this->phase('set the main page', $this->setMainPage(...));
+		$this->phase('import the images', $this->importImages(...), "$ip/maintenance/importImages.php");
+		$this->step('import the pages', ImportWikitext::class, "$own/importWikitext.php");
+		$this->phase('check the main page arrived', $this->assertMainPageExists(...));
+		$this->phase('write the licenses page', $this->setLicensesPage(...));
+		$this->phase('write the settings page', $this->setSettingsPage(...));
+		$this->phase('drop the dead place links', $this->dropDeadPlaceLinks(...));
+		$this->phase('drop the dead category link', $this->dropDeadCategoryLink(...));
 		// Materialize content translations before RunJobs so rendered translation pages get exported.
-		$this->step(BuildTranslations::class, "$own/buildTranslations.php");
-		$this->runJobs("$ip/maintenance/runJobs.php");
+		$this->step('build the translations', BuildTranslations::class, "$own/buildTranslations.php");
+		$this->phase('run the jobs', $this->runJobs(...), "$ip/maintenance/runJobs.php");
 		// Categories are written by the links update each edit queues, which runJobs above runs, so
 		// this is the first point they are known -- and it is before the passes.
-		$this->assertNamedCategoriesAreEmpty();
+		$this->phase('check the categories', $this->assertNamedCategoriesAreEmpty(...));
 		// Every page the export will hold now exists and nothing writes another revision after
 		// this, so this is where each page can be told when it was last edited, and by whom.
-		$this->stampSourceHistory();
-		$this->hideBuildAuthors();
-		$this->forgetCachedRevisionRows();
+		$this->phase('stamp the source history', $this->stampSourceHistory(...));
+		$this->phase('hide the build authors', $this->hideBuildAuthors(...));
+		$this->phase('forget the cached revision rows', $this->forgetCachedRevisionRows(...));
 		// The content is final here, so this is the last write the database needs and the passes
 		// below can be readers of it.
-		$this->freezePageTouched();
+		$this->phase('freeze the page timestamps', $this->freezePageTouched(...));
 		// The search index is built by now, by the job runJobs() holds back to the end, and every
 		// pass below copies it. Settled here so the one copy they all take is stable.
-		$this->stabilizeSearchIndex();
+		$this->phase('settle the search index', $this->stabilizeSearchIndex(...));
 
 		$config = $this->getConfig();
 		$skins = (array)$config->get('WikvenSkins');
 		if (!$skins) {
 			$skins = [(string)$config->get('DefaultSkin')];
 		}
-		$this->renderSkinPasses(array_values($skins));
+		$this->phase('render the skins', $this->renderSkinPasses(...), array_values($skins));
+		$this->output($this->times->report('the build'));
+	}
+
+	/**
+	 * Run one phase of this process, remembering what it took.
+	 *
+	 * Every phase rather than the ones a guess calls slow: what this is for is the stretch nobody
+	 * expected, and a guess is what left it unmeasured.
+	 *
+	 * @param string $name What the phase does, as the report names it.
+	 * @param callable $work
+	 * @param mixed ...$arguments Handed to $work.
+	 * @return mixed What $work answered, for the phases whose answer is read.
+	 */
+	private function phase(string $name, callable $work, mixed ...$arguments) {
+		$started = hrtime(true);
+		try {
+			return $work(...$arguments);
+		} finally {
+			$this->times->add($name, ( hrtime(true) - $started ) / 1e9);
+		}
 	}
 
 	/**
@@ -486,7 +512,14 @@ class Build extends Maintenance {
 		// Non-blocking, so reading a quiet pass never holds up a talkative one.
 		stream_set_blocking($pipes[1], false);
 		stream_set_blocking($pipes[2], false);
-		return ['process' => $process, 'pipes' => $pipes, 'output' => [1 => '', 2 => '']];
+		// Started here rather than timed inside the pass, so what it says includes the boot a pass
+		// needs before it can say anything at all.
+		return [
+			'process' => $process,
+			'pipes' => $pipes,
+			'output' => [1 => '', 2 => ''],
+			'started' => hrtime(true)
+		];
 	}
 
 	/**
@@ -571,7 +604,8 @@ class Build extends Maintenance {
 	 * @param int $exit
 	 */
 	private function reportPass(string $skin, array $pass, int $exit): void {
-		$this->output("--- $skin pass" . ( $exit === 0 ? '' : " failed (exit $exit)" ) . " ---\n");
+		$took = BuildTimes::seconds(( hrtime(true) - $pass['started'] ) / 1e9);
+		$this->output("--- $skin pass" . ( $exit === 0 ? '' : " failed (exit $exit)" ) . ", $took ---\n");
 		$this->output($pass['output'][1]);
 		if ($pass['output'][2] !== '') {
 			$this->error(rtrim($pass['output'][2], "\n"));
@@ -661,27 +695,33 @@ class Build extends Maintenance {
 
 		// Before anything renders or is dumped: the bundle path reaches the client inside the script
 		// bundle buildScripts writes below, so this pass has to be pointed at its own copy first.
-		$searchBundle = $this->pointSearchAtThisCopy();
+		$searchBundle = $this->phase('point the search at this copy', $this->pointSearchAtThisCopy(...));
 
-		$this->step(RebuildFileCache::class, "$ip/maintenance/rebuildFileCache.php", ['overwrite' => true]);
+		$this->step('render the pages', RebuildFileCache::class, "$ip/maintenance/rebuildFileCache.php", [
+			'overwrite' => true
+		]);
 		// RebuildFileCache renders in the content language; re-render translations in their own.
-		$this->step(RetranslateChrome::class, "$own/retranslateChrome.php");
+		$this->step('re-render the translations', RetranslateChrome::class, "$own/retranslateChrome.php");
 		// Every page is rendered by now: drop what each one recorded about the request that made it.
-		$this->step(StripBuildStamps::class, "$own/stripBuildStamps.php");
-		$this->step(BuildStyles::class, "$own/buildStyles.php");
+		$this->step('strip the build stamps', StripBuildStamps::class, "$own/stripBuildStamps.php");
+		$this->step('build the styles', BuildStyles::class, "$own/buildStyles.php");
 		// Opt-in: bake ULS webfonts into a static stylesheet rewriteScripts links below.
-		$this->step(BakeWebfonts::class, "$own/bakeWebfonts.php");
-		$this->step(BuildScripts::class, "$own/buildScripts.php");
-		$this->step(RewriteScripts::class, "$own/rewriteScripts.php");
+		$this->step('bake the webfonts', BakeWebfonts::class, "$own/bakeWebfonts.php");
+		$this->step('build the scripts', BuildScripts::class, "$own/buildScripts.php");
+		$this->step('rewrite the scripts', RewriteScripts::class, "$own/rewriteScripts.php");
 		// Minerva takes no navigation from the sidebar, so its menu is filled in the rendered pages.
-		$this->step(FillMinervaMenu::class, "$own/fillMinervaMenu.php");
-		$this->step(StoreImages::class, "$own/storeImages.php");
+		$this->step('fill the Minerva menu', FillMinervaMenu::class, "$own/fillMinervaMenu.php");
+		$this->step('store the images', StoreImages::class, "$own/storeImages.php");
 		$named = $this->nameCachedPages("$own/rename.php");
 		// Rename has expanded translation pages into "<Page>/<lang>.html"; resolve MyLanguage links now.
-		$this->step(ResolveTranslationLinks::class, "$own/resolveTranslationLinks.php");
+		$this->step(
+			'resolve the translation links',
+			ResolveTranslationLinks::class,
+			"$own/resolveTranslationLinks.php"
+		);
 		// After the pages have their final names and links, so what the sitemap names is what the
 		// site serves. Writes nothing unless the site said where it will be published.
-		$this->step(BuildSitemap::class, "$own/buildSitemap.php");
+		$this->step('build the sitemap', BuildSitemap::class, "$own/buildSitemap.php");
 
 		// SkippedHistoryAction leaves RebuildFileCache nothing to write here, so this finds nothing
 		// on a normal bake; it stays as the guard for a pass over an output directory that already
@@ -696,9 +736,10 @@ class Build extends Maintenance {
 
 		// Last, so nothing above walks the bundle looking for pages to rewrite.
 		if ($searchBundle !== null) {
-			$this->copySearchBundle($searchBundle);
+			$this->phase('copy the search bundle', $this->copySearchBundle(...), $searchBundle);
 		}
 
+		$this->output($this->times->report('the ' . getenv('WIKVEN_BUILD_SKIN') . ' pass'));
 		// After everything, because that is the whole of what it says; see SkinPass.
 		$this->output(SkinPass::wrote($named) . "\n");
 	}
@@ -905,7 +946,7 @@ class Build extends Maintenance {
 	 * way to come by it; see SkinPass.
 	 */
 	private function nameCachedPages(string $file): int {
-		$rename = $this->step(Rename::class, $file);
+		$rename = $this->step('name the pages', Rename::class, $file);
 		// createChild() is typed to Maintenance, and this is the one step whose answer is read.
 		return $rename instanceof Rename ? $rename->named : 0;
 	}
@@ -915,14 +956,19 @@ class Build extends Maintenance {
 	 *
 	 * The child is handed back for the one caller that wants a number out of it; every other one
 	 * runs the step for its effect and drops it.
+	 *
+	 * @param string $name What the timing report calls this step.
+	 * @param string $class
+	 * @param string $file
+	 * @param array $options
 	 */
-	private function step(string $class, string $file, array $options = []): Maintenance {
+	private function step(string $name, string $class, string $file, array $options = []): Maintenance {
 		$child = $this->createChild($class, $file);
-		foreach ($options as $name => $value) {
-			$child->setOption($name, $value);
+		foreach ($options as $option => $value) {
+			$child->setOption($option, $value);
 		}
 		// A child returning false signals failure (e.g. a page didn't import); abort the build.
-		if ($child->execute() === false) {
+		if ($this->phase($name, $child->execute(...)) === false) {
 			$this->fatalError("Wikven: $class reported failures; aborting the build.");
 		}
 		return $child;

--- a/tests/phpunit/unit/BuildTimesTest.php
+++ b/tests/phpunit/unit/BuildTimesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\Build\BuildTimes;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Build\BuildTimes
+ */
+class BuildTimesTest extends MediaWikiUnitTestCase {
+	/**
+	 * The report is read to find where a build went quiet, so the phases stay in the order they
+	 * ran and the numbers line up under each other.
+	 */
+	public function testThePhasesAreReportedInTheOrderTheyRan() {
+		$times = new BuildTimes();
+		$times->add('import the pages', 26.04);
+		$times->add('write the licenses page', 88.2);
+		$times->add('run the jobs', 4.5);
+
+		$this->assertSame(
+			"Wikven: the build took 118.7s, spent as\n"
+			. "  26.0s  import the pages\n"
+			. "  88.2s  write the licenses page\n"
+			. "   4.5s  run the jobs\n",
+			$times->report('the build')
+		);
+	}
+
+	/** A phase that ran twice is one line holding both, which is what a reader wants of a loop. */
+	public function testAPhaseNamedTwiceAddsUp() {
+		$times = new BuildTimes();
+		$times->add('render a skin', 1.5);
+		$times->add('render a skin', 2.25);
+
+		$this->assertStringContainsString("3.8s  render a skin\n", $times->report('the pass'));
+		$this->assertStringContainsString('the pass took 3.8s', $times->report('the pass'));
+	}
+
+	/** A build that recorded nothing prints nothing, so the caller needs no test of its own. */
+	public function testNoPhasesIsNoReport() {
+		$this->assertSame('', ( new BuildTimes() )->report('the build'));
+	}
+}


### PR DESCRIPTION
Fixes #713.

A bake ends with the list of what it spent its time on:

```
Wikven: the build took 151.9s, spent as
   0.4s  check what the site listed
   0.1s  check the Lua
   0.1s  clear the output directory
   0.6s  set the main page
   1.9s  import the images
  26.0s  import the pages
   0.0s  check the main page arrived
  44.7s  write the licenses page
  ...
  18.2s  render the skins
```

Every phase, not the ones a guess calls slow — a guess is what left eighty-eight seconds of a preview unmeasured in the first place. (The numbers above are a shape, from exercising the class; the real ones arrive with this pull request's own preview.)

A skin pass gets the same list of its own, which the orchestrator prints under the pass's heading, and that heading now says what the pass took: `--- citizen pass, 17.2s ---`. Timed from the moment the pass is started rather than inside it, so it counts the MediaWiki boot a pass needs before it can say anything — and the difference between that number and the pass's own list is exactly the boot.

## How

`BuildTimes` holds durations by phase and renders the report; the clock stays in `build.php`, so the class answers the same in a test as in a bake. Phases keep the order they ran rather than sorting longest-first: this is read to find where a build went quiet, and that is a place in the sequence.

`step()` takes the phrase the report should call it by and times the child itself. Everything else in `execute()` and in a pass goes through `phase()`, which takes a first-class callable and hands back what it answered. Nothing is nested, so nothing is counted twice.

The report is printed before a pass's `wrote N page(s)`, which stays the last line a pass writes, as `SkinPass` describes it.

`composer test:comments`, `composer phpcs`, `mago format --check`, `mago lint` and the PHPUnit suite (831 tests) are clean, and phan was run against a real MediaWiki tree here — its only findings are the four pre-existing Gadgets ones that come of not having Gadgets installed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_