### PR TITLE
perf: stop rebuilding translation stats a bake goes on to recompute

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -37,6 +37,13 @@ require_once "$IP/maintenance/Maintenance.php";
  * display title" unit.
  */
 class BuildTranslations extends Maintenance {
+	/**
+	 * Translate's per-group statistics rebuild, which this script takes off the queue without
+	 * running: it recomputes for every language the numbers render() computes once every unit is in
+	 * place, and running it was a quarter of this phase.
+	 */
+	private const STATS_JOB = 'RebuildMessageGroupStatsJob';
+
 	public function __construct() {
 		parent::__construct();
 		$this->addDescription('Mark translatable pages and load their translations from source files.');
@@ -243,7 +250,11 @@ class BuildTranslations extends Maintenance {
 			foreach ($types as $type) {
 				$job = $group->pop($type);
 				while ($job) {
-					$job->run();
+					// Acked whether or not it ran: a stats job left on the queue is one the build's own
+					// runJobs phase would pick up later, which is the work this is declining to do.
+					if ($type !== self::STATS_JOB) {
+						$job->run();
+					}
 					$group->ack($job);
 					$job = $group->pop($type);
 				}


### PR DESCRIPTION
#720 asked what, inside `buildTranslations`, spends the 105 seconds. Timing each step of the loop on a local MediaWiki 1.46 against this site's twenty-two translatable pages (99.9s there; the phase is 105s on a CI runner):

```
    65.1s     22 x  drain the queue after each mark
    25.7s     22 x    job: RebuildMessageGroupStatsJob
    23.4s     22 x    job: UpdateTranslatablePageJob
    22.8s     22 x  load the translation units
     6.5s     22 x  refresh the group stats
     2.8s   1097 x    job: TtmServerMessageUpdateJob
     2.6s     22 x  render the translated pages
     2.1s     45 x    job: RenderTranslationPageJob
     1.7s   2482 x    job: htmlCacheUpdate
     1.2s     22 x  mark for translation
     1.0s     22 x  save the base page
     0.5s   1097 x    job: MessageGroupStatesUpdaterJob
     0.3s      1 x  drain the queue once, after the loop
     0.2s     22 x    job: RebuildMessageIndexJob
     0.0s     22 x  parse the units (getMarkOperation)
```

(Indented lines are jobs run inside the drain above them, so they are a breakdown of it, not more time.)

Most of that is work the phase exists to do: `UpdateTranslatablePageJob` writes each page's source units, and `load the translation units` saves the 1097 translated ones. One line is not. `RebuildMessageGroupStatsJob` is queued by every unit save, deduplicated to one per group, and each run recomputes that group's numbers for every language the wiki knows — 568 of them — one language at a time. A second later, `render()` recomputes exactly those groups with `FLAG_NO_CACHE | FLAG_IMMEDIATE_WRITES`, and that is where the figures a build ships have always come from: the job's answer is overwritten before anything reads it.

So `drainJobs()` acks it without running it. Nothing else moves, and the source of truth for the stats is the same call it was before this patch — this only stops paying for the same numbers twice. Acked rather than left on the queue, because a job left there is one the build's own `run the jobs` phase would pick up instead, which is the same 26 seconds two phases later.

## What it costs and what it changes

Running the script as it now stands, from the same imported database as the baseline:

| | before | after |
| --- | ---: | ---: |
| `buildTranslations` | 99.9s | 71.3s |

and, comparing the two databases afterwards:

* every one of the 12,496 `translate_groupstats` rows identical — group, language, total, translated, fuzzy, proofread;
* all 1239 pages identical, by content hash and length;
* nothing of that job type left on the queue for the phase that follows.

The order the script works in is untouched: the units are still all loaded before any page renders, and `Title::clearCaches()` still runs between them, so #460 and #464 stay answered.

The stats being right is worth a word, since this deletes a write of them. It is not a new dependency — a bake's numbers came from `render()` before this change too, the job's write having been overwritten every time. Wiping `translate_groupstats` and re-rendering shows what a missing row looks like, for what it is worth: a language bar entry drops from `mw-pt-progress--complete` to `--low`.

## What is left

`buildTranslations` is still the biggest phase, at roughly 74 of a 125-second bake. What remains under it is real work — writing 1097 translation units and the source units for 22 pages — so #720 stays open with that measurement rather than a suspicion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_