### PR TITLE
ci: stop running the test matrix for a change only docs/ can see

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,12 +23,10 @@ on:
         type: string
         required: true
 
+# Only what every job here needs. What the build itself needs to publish is granted on that job
+# alone, now that it is not the only one in the workflow.
 permissions:
   contents: read
-  packages: write
-  # The OIDC token exchanged for a quay.io robot token below. ghcr takes GITHUB_TOKEN instead, so
-  # this is the only registry credential in the job, and it lasts an hour.
-  id-token: write
 
 # Cancel superseded runs; pushes to main (including release-please's workflow_call) are left alone.
 concurrency:
@@ -36,9 +34,49 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
+  # A change under docs/ cannot reach the image, so the build below is gated on there being one
+  # (#714). The job still runs and still reports: it is a required check, and one that never reports
+  # leaves a pull request unmergeable for good, which is why the pull_request trigger above carries
+  # no path filter. Same job, same reasoning and the same failing closed as test.yml's, which says
+  # it at length.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs-only: ${{ steps.paths.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+      - id: paths
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          docs_only=false
+          if [ "$EVENT" = pull_request ]; then
+            files=$(git diff --name-only HEAD^1 HEAD)
+            if [ -n "$files" ] && ! printf '%s\n' "$files" | grep -qv '^docs/'; then
+              docs_only=true
+            fi
+            printf '%s\n' "$files" | sed 's/^/changed: /'
+          fi
+          echo "only docs/ changed: $docs_only"
+          echo "docs-only=$docs_only" >> "$GITHUB_OUTPUT"
+
   docker-image:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      # The OIDC token exchanged for a quay.io robot token below. ghcr takes GITHUB_TOKEN instead,
+      # so this is the only registry credential in the job, and it lasts an hour.
+      id-token: write
+    needs: changes
+    # Runs whatever the job above concluded, including nothing: see it for why.
+    if: ${{ !cancelled() }}
     env:
       # Publishing is this repository, on main, with a tag to publish under: a fork, a pull request
       # and an untagged push to main all build the image and stop there. Every step below that logs
@@ -53,13 +91,16 @@ jobs:
       # identity. What it authenticates with is minted per run by the exchange step.
       QUAY_ROBOT: chaotic-ground+wikven_ci
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
 
-      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         if: env.PUBLISH == 'true'
@@ -99,6 +140,7 @@ jobs:
       # released version lives in .release-please-manifest.json, and the release build checks out the
       # very commit that bumps it.
       - name: Decide whether this build takes :latest
+        if: needs.changes.outputs.docs-only != 'true'
         env:
           TAG: ${{ inputs.tag }}
         run: |
@@ -117,6 +159,7 @@ jobs:
       # which GHCR does not link the published package back to this repository.
       - name: Compute image tags and labels
         id: meta
+        if: needs.changes.outputs.docs-only != 'true'
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           # Every tag rule below is multiplied across both images, so one build publishes both
@@ -138,6 +181,7 @@ jobs:
             type=raw,value=main,enable=${{ env.PUBLISH != 'true' }}
 
       - name: Build and push the image
+        if: needs.changes.outputs.docs-only != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,33 +41,84 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
-  # Compile the Caddy plugin so a Go build error is caught on the PR, not later in the binary build.
-  caddy:
+  # Everything below reads code, and a change under docs/ cannot reach a line of it: fifteen
+  # runner-minutes spent on a pull request that could not have moved one assertion (#714). This job
+  # answers whether anything outside docs/ changed, and the jobs below gate their expensive steps on
+  # it. The jobs still run and still report -- they are required checks, and a required check that
+  # never reports leaves a pull request unmergeable for good, which is why this workflow has no path
+  # filter of its own.
+  #
+  # Every way of not knowing runs the tests. Only a diff that was read, and holds nothing outside
+  # docs/, answers yes; a job whose steps read `!= 'true'` runs them on an answer that never came,
+  # and each one below runs even if this job failed outright, for the same reason. The mistake this
+  # can make is skipping a test somebody needed.
+  changes:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
+    outputs:
+      docs-only: ${{ steps.paths.outputs.docs-only }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+          # A pull request is checked out as the merge of its head into its base, so the base is
+          # the first parent and the diff against it is the pull request itself. Two is all it takes
+          # to have both ends of that diff.
+          fetch-depth: 2
+      - id: paths
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          docs_only=false
+          if [ "$EVENT" = pull_request ]; then
+            files=$(git diff --name-only HEAD^1 HEAD)
+            if [ -n "$files" ] && ! printf '%s\n' "$files" | grep -qv '^docs/'; then
+              docs_only=true
+            fi
+            printf '%s\n' "$files" | sed 's/^/changed: /'
+          fi
+          echo "only docs/ changed: $docs_only"
+          echo "docs-only=$docs_only" >> "$GITHUB_OUTPUT"
+
+  # Compile the Caddy plugin so a Go build error is caught on the PR, not later in the binary build.
+  caddy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: changes
+    # Runs whatever the job above concluded, including nothing: see it for why.
+    if: ${{ !cancelled() }}
+    steps:
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: caddy/go.mod
           cache-dependency-path: caddy/go.sum
-      - run: go build ./...
+      - if: needs.changes.outputs.docs-only != 'true'
+        run: go build ./...
         working-directory: caddy
-      - run: go vet ./...
+      - if: needs.changes.outputs.docs-only != 'true'
+        run: go vet ./...
         working-directory: caddy
 
   # Run the extension's PHPUnit tests against a real MediaWiki: the 1.46 base the build ships on, and master.
   phpunit:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: changes
+    # Runs whatever the job above concluded, including nothing: see it for why.
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
         mediawiki-version: [REL1_46, master]
     steps:
       - name: Check out MediaWiki core
+        if: needs.changes.outputs.docs-only != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: wikimedia/mediawiki
@@ -75,20 +126,24 @@ jobs:
           path: mediawiki
           persist-credentials: false
       - name: Check out Wikven into the extension tree
+        if: needs.changes.outputs.docs-only != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: mediawiki/extensions/Wikven
           persist-credentials: false
-      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
         with:
           php-version: "8.3"
           extensions: mbstring, intl, calendar, sqlite3, pdo_sqlite, gd, dom, xml, fileinfo
           tools: composer
       - name: Install MediaWiki dependencies
+        if: needs.changes.outputs.docs-only != 'true'
         working-directory: mediawiki
         run: composer install --no-interaction --no-progress
       # --with-developmentsettings loads what Quibble loads; it turns on $wgEnableJavaScriptTest, which #392 needed.
       - name: Install MediaWiki (SQLite)
+        if: needs.changes.outputs.docs-only != 'true'
         working-directory: mediawiki
         run: |
           mkdir -p "$RUNNER_TEMP/wikidb"
@@ -99,9 +154,11 @@ jobs:
             --with-developmentsettings \
             TestWiki Admin
       - name: Enable Wikven
+        if: needs.changes.outputs.docs-only != 'true'
         working-directory: mediawiki
         run: echo "wfLoadExtension( 'Wikven' );" >> LocalSettings.php
       - name: Run PHPUnit
+        if: needs.changes.outputs.docs-only != 'true'
         working-directory: mediawiki
         run: composer phpunit:entrypoint -- extensions/Wikven/tests/phpunit/
 
@@ -109,15 +166,20 @@ jobs:
   phan:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: changes
+    # Runs whatever the job above concluded, including nothing: see it for why.
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
         mediawiki-version: [REL1_46, master]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: femiwiki/quibble-action@4c99d26a916c8e8887a2622d26d979c26658106f  # v2.1.1
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: femiwiki/quibble-action@4c99d26a916c8e8887a2622d26d979c26658106f  # v2.1.1
         with:
           stage: phan
           dependencies: ${{ env.PHAN_DEPENDENCIES }}
@@ -128,14 +190,19 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: changes
+    # Runs whatever the job above concluded, including nothing: see it for why.
+    if: ${{ !cancelled() }}
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - id: quibble
+        if: needs.changes.outputs.docs-only != 'true'
         uses: femiwiki/quibble-action@4c99d26a916c8e8887a2622d26d979c26658106f  # v2.1.1
         with:
           stage: coverage
@@ -153,7 +220,10 @@ jobs:
           # Coverage tooling lives only on MediaWiki master.
           mediawiki-version: master
           quibble-docker-image: quibble-bookworm-php83
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+      # A change that ran no tests has no report to upload. codecov's checks are not required ones
+      # (.tf/ruleset.tf lists the ones that are), so nothing waits on a report that never comes.
+      - if: needs.changes.outputs.docs-only != 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: ${{ steps.quibble.outputs.coverage }}/clover.xml
           use_oidc: true


### PR DESCRIPTION
Closes #714.

`test.yml` and `docker-image.yml` run on every pull request with no path filter, because they are required checks and a required check that never reports leaves a pull request unmergeable for good. The cost is that a change under `docs/` — which cannot reach a line of what they run — ran phpunit twice, phan twice, the coverage build, the Caddy build and an image build: about fifteen runner-minutes.

## The gate

Each of the two workflows gains a `changes` job. It checks out two commits and reads the pull request's own diff: a pull request is checked out as the merge of its head into its base, so the base is the first parent and `git diff HEAD^1 HEAD` is exactly what the pull request changes. No token, no API, nothing to page through.

The jobs below it keep running and keep reporting — `caddy`, `coverage`, `docker-image`, `phan`, `phpunit` are the required checks, and none of them stops being one. What is gated is their steps. A docs-only pull request gets the same green checks, in about twenty seconds each.

## Every way of not knowing runs the tests

The answer is "only docs" **only** when a diff was read and holds nothing outside `docs/`. Everything else runs them:

* the steps read `if: needs.changes.outputs.docs-only != 'true'`, so an answer that never arrived — an output that is empty because the job never set it — runs the step;
* `git diff` failing writes nothing and leaves the answer `false`, and the step still exits 0, so the gate reports rather than dying;
* every gated job carries `if: ${{ !cancelled() }}`, so a `changes` job that failed outright does not take the tests with it. Without that, a failed gate would skip the required jobs, and a skipped required check counts as a pass — the tests would go quiet in the one case where nobody knows why;
* a push to main runs everything, gate or no gate.

The mistake this can make is skipping a test somebody needed, so it is the mistake it cannot make quietly.

Checked against a scratch repository with real merge commits: a docs-only merge answers `true`, a merge touching one PHP file answers `false`, a push answers `false`, and a repository with no first parent prints git's error, answers `false` and exits 0.

## Two smaller things

`codecov` is not uploaded for a run with no tests, which is fine: `.tf/ruleset.tf` lists the required checks and codecov's are not among them, so nothing waits for a report that is not coming.

`docker-image.yml`'s `packages: write` and `id-token: write` move from the workflow to the job that publishes. They were workflow-level when the workflow had one job; with a second job they would be granted to a job that checks out a diff, which is also what zizmor says about them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_