### PR TITLE
perf: let the wiki's own database sync the way the three beside it do

### DIFF
--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -62,6 +62,26 @@ $wgMainCacheType = CACHE_DB;
 // taken mid-build never looks stale (#333). Costs a parse per skin instead of one per bake.
 $wgParserCacheType = CACHE_NONE;
 
+// MediaWiki's installer writes synchronous=NORMAL for the object cache, the localisation cache and
+// the job queue; the wiki's own file, which a bake commits into thousands of times, it leaves at
+// FULL. That one is a scratch file too.
+
+// Spelled as the server the installer would have built, because a connection variable is named on
+// a server entry. Guarded on the type: these are SQLite pragmas.
+if ($GLOBALS['wgDBtype'] === 'sqlite') {
+	$wgDBservers = [
+		[
+			'host' => $GLOBALS['wgDBserver'],
+			'user' => $GLOBALS['wgDBuser'],
+			'password' => $GLOBALS['wgDBpassword'],
+			'dbname' => $GLOBALS['wgDBname'],
+			'type' => $GLOBALS['wgDBtype'],
+			'load' => 1,
+			'variables' => ['synchronous' => 'NORMAL']
+		]
+	];
+}
+
 // Let pages opt out of indexing with __NOINDEX__ in any namespace.
 $wgExemptFromUserRobotsControl = [];
 


### PR DESCRIPTION
Refs #720.

A bake writes to one SQLite file, and SQLite locks the whole database for a writer — there is no table or row granularity to split along, and the skin passes only run beside each other because each is handed a copy and only reads from it. So the way to shorten the write phases is to make each write cost less.

MediaWiki's installer already decided how. It writes `synchronous = NORMAL` for every SQLite file it configures — the object cache, the localisation cache and the job queue (see core's `SqliteInstaller.php`) — and leaves the wiki's own at SQLite's default, `FULL`, which fsyncs the write-ahead log on every commit. A bake commits into that file thousands of times: every page imported, every translation unit written, every job run.

That file is as much a scratch file as its three siblings. The build makes it, the passes copy it, and a bake the machine interrupts is rerun, not recovered.

It has to be spelled as a whole server entry, because that is where a connection variable is named. The entry is built from the same globals the installer set, so it cannot drift from them, and it is guarded on `sqlite` because these are SQLite's pragmas.

## Measured

`buildTranslations` is the phase that writes most, so it is the one measured — alternating runs from one imported database, on a local MediaWiki 1.46:

| | run 1 | run 2 | mean |
| --- | ---: | ---: | ---: |
| main | 84.8s | 85.3s | 85.1s |
| this branch | 80.8s | 80.3s | **80.6s** |

−5.3%, on the one phase. The setting also covers importing the pages (29s of a bake) and running the jobs, which this measurement does not include — the bake's own timing report on this pull request's preview is where the whole of it shows.

A second change measured beside this one, skipping two jobs a static export has no reader for, is [#726](https://github.com/chaotic-ground/wikven/pull/726) rather than another commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn