### PR TITLE
perf: stop running two jobs a static export has no reader for

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -38,11 +38,18 @@ require_once "$IP/maintenance/Maintenance.php";
  */
 class BuildTranslations extends Maintenance {
 	/**
-	 * Translate's per-group statistics rebuild, which this script takes off the queue without
-	 * running: it recomputes for every language the numbers render() computes once every unit is in
-	 * place, and running it was a quarter of this phase.
+	 * Jobs this script takes off the queue without running.
+	 *
+	 * The stats one recomputes what render() computes again anyway. The others serve translators --
+	 * a memory to suggest from, a state to review by -- which an export has nowhere to put.
+	 *
+	 * @var string[]
 	 */
-	private const STATS_JOB = 'RebuildMessageGroupStatsJob';
+	private const UNRUN_JOBS = [
+		'RebuildMessageGroupStatsJob',
+		'TtmServerMessageUpdateJob',
+		'MessageGroupStatesUpdaterJob'
+	];
 
 	public function __construct() {
 		parent::__construct();
@@ -250,9 +257,9 @@ class BuildTranslations extends Maintenance {
 			foreach ($types as $type) {
 				$job = $group->pop($type);
 				while ($job) {
-					// Acked whether or not it ran: a stats job left on the queue is one the build's own
-					// runJobs phase would pick up later, which is the work this is declining to do.
-					if ($type !== self::STATS_JOB) {
+					// Acked whether or not it ran: one left on the queue is one the build's own runJobs
+					// phase would pick up later, which is the work this is declining to do.
+					if (!in_array($type, self::UNRUN_JOBS, true)) {
 						$job->run();
 					}
 					$group->ack($job);


### PR DESCRIPTION
Refs #720.

Saving a translation unit queues two jobs, and this site saves 1097 units, so the bake runs 2194 of them:

* `TtmServerMessageUpdateJob` keeps the translation memory that Special:Translate suggests from while a translator is typing.
* `MessageGroupStatesUpdaterJob` moves the workflow state a translation is reviewed by.

Both are for a person translating in a wiki. An export has no editing at all — no Special:Translate, no review — so neither has anywhere to land. They join `RebuildMessageGroupStatsJob` in the list `drainJobs()` acks without running, which is also what stops the build's own `run the jobs` phase from picking them up a phase later.

## Measured

Alternating runs from one imported database, on a local MediaWiki 1.46:

| `buildTranslations` | pair 1 | pair 2 | pair 3 | pair 4 | mean |
| --- | ---: | ---: | ---: | ---: | ---: |
| main | 86.5s | 84.3s | 83.9s | 86.1s | 85.2s |
| this branch | 84.2s | 81.6s | 81.4s | 83.1s | **82.6s** |

−3.1%, and every pair falls between 2.3s and 3.0s apart, which is what four pairs are for: the difference is smaller than this machine's drift between sessions.

Afterwards all 1239 pages are identical by content hash and length, and all 12,496 `translate_groupstats` rows are identical, against a run of main from the same starting database.

The other change measured beside this one, the database's own sync setting, is [#725](https://github.com/chaotic-ground/wikven/pull/725) rather than another commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_