### PR TITLE
perf: parse the pages beside each other before importing them

### DIFF
--- a/includes/Build/SourceShard.php
+++ b/includes/Build/SourceShard.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Build;
+
+/**
+ * Which share of a list of files one of several parallel readers takes.
+ *
+ * Written "i/n" on a command line, so a shard that cannot be read as one is the whole list rather
+ * than none of it: a reader that took nothing would leave the work to be done serially later.
+ */
+class SourceShard {
+	/**
+	 * The share "i/n" names, as [index, count].
+	 *
+	 * @param string $shard "i/n", where 0 <= i < n.
+	 * @return array{0:int,1:int} The whole list, [0, 1], where $shard is not a share of one.
+	 */
+	public static function of(string $shard): array {
+		if (!preg_match('~^(\d+)/(\d+)$~', trim($shard), $parts)) {
+			return [0, 1];
+		}
+		$mine = (int)$parts[1];
+		$of = (int)$parts[2];
+		if ($of < 1 || $mine >= $of) {
+			return [0, 1];
+		}
+		return [$mine, $of];
+	}
+}

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -43,6 +43,13 @@ class Build extends Maintenance {
 	private const PASS_DATABASE_PREFIX = 'wikven-pass-';
 
 	/**
+	 * How many shares the parses ahead of the import are split into, before the machine has a say.
+	 *
+	 * passLimit() answers with the smaller of this and the processors a build may use.
+	 */
+	private const WARM_SHARDS = 8;
+
+	/**
 	 * Whether the job that builds the search index ran, which is what tells a bundle that failed to
 	 * build from a site that had nothing to index. Only the orchestrator queues it.
 	 */
@@ -76,6 +83,7 @@ class Build extends Maintenance {
 		$this->phase('clear the output directory', $this->clearOutputDirectory(...));
 		$this->phase('set the main page', $this->setMainPage(...));
 		$this->phase('import the images', $this->importImages(...), "$ip/maintenance/importImages.php");
+		$this->phase('warm the parse caches', $this->warmParseCaches(...), "$own/importWikitext.php");
 		$this->step('import the pages', ImportWikitext::class, "$own/importWikitext.php");
 		$this->phase('check the main page arrived', $this->assertMainPageExists(...));
 		$this->phase('write the licenses page', $this->setLicensesPage(...));
@@ -434,7 +442,7 @@ class Build extends Maintenance {
 	 * @param string[] $skins
 	 */
 	private function renderSkinPasses(array $skins): void {
-		$command = $this->skinPassCommand();
+		$command = $this->selfCommand(__FILE__);
 		$limit = $this->passLimit(count($skins));
 		$databases = $this->copyDatabasePerPass($skins);
 
@@ -474,11 +482,82 @@ class Build extends Maintenance {
 	}
 
 	/**
-	 * The argv that re-invokes this script for one skin, resolved once for every pass.
+	 * Parse every page before the import parses them one at a time.
 	 *
+	 * What a first parse costs is not the writing: the syntax highlighter runs pygments once per
+	 * code block. These reads share nothing but the cache they fill.
+	 *
+	 * @param string $script The import script, run in parse-only mode.
+	 */
+	private function warmParseCaches(string $script): void {
+		$shards = $this->passLimit(self::WARM_SHARDS);
+		if ($shards < 2) {
+			return;
+		}
+		$command = array_merge($this->selfCommand($script), ['--parse-only']);
+		$children = [];
+		for ($shard = 0; $shard < $shards; $shard++) {
+			$children[$shard] = $this->startChild(array_merge($command, ["--shard=$shard/$shards"]));
+		}
+		// Not fatal: a shard that failed costs the time it would have saved, and the import, which
+		// parses every page itself, is where a parse that cannot be done at all is a failure.
+		$failed = 0;
+		foreach ($children as $child) {
+			$failed += $this->waitForChild($child) === 0 ? 0 : 1;
+		}
+		if ($failed > 0) {
+			$this->error(
+				"Wikven: $failed of $shards parse(s) ahead of the import failed; it will do that work itself."
+			);
+		}
+		$this->output("Wikven: parsed the pages in $shards share(s) before importing them\n");
+	}
+
+	/**
+	 * Start one child with its output on a pipe, for a caller that reads it when the child is over.
+	 *
+	 * @param string[] $command
+	 * @return array{process:resource,pipes:array<int,?resource>}
+	 */
+	private function startChild(array $command): array {
+		$descriptors = [0 => STDIN, 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$pipes = [];
+		$process = proc_open($command, $descriptors, $pipes, $GLOBALS['IP'], getenv());
+		if ($process === false) {
+			$this->fatalError('Wikven: could not start ' . implode(' ', $command));
+		}
+		return ['process' => $process, 'pipes' => $pipes];
+	}
+
+	/**
+	 * Wait for one child, printing what it wrote to stderr.
+	 *
+	 * Its standard output is dropped: what these children say about their own progress is not this
+	 * log's, and anything that went wrong went to the other pipe.
+	 *
+	 * @param array{process:resource,pipes:array<int,?resource>} $child
+	 * @return int The child's exit code.
+	 */
+	private function waitForChild(array $child): int {
+		stream_get_contents($child['pipes'][1]);
+		$errors = trim((string)stream_get_contents($child['pipes'][2]));
+		foreach ($child['pipes'] as $pipe) {
+			fclose($pipe);
+		}
+		$exit = proc_close($child['process']);
+		if ($errors !== '') {
+			$this->error($errors);
+		}
+		return $exit;
+	}
+
+	/**
+	 * The argv that runs one of this build's own maintenance scripts in a fresh boot.
+	 *
+	 * @param string $script The script to run, as an absolute path.
 	 * @return string[]
 	 */
-	private function skinPassCommand(): array {
+	private function selfCommand(string $script): array {
 		$self = PHP_BINARY;
 		$prefix = [$self];
 		// Embedded FrankenPHP leaves PHP_BINARY empty; re-run the binary itself as "<self> php-cli".
@@ -489,7 +568,7 @@ class Build extends Maintenance {
 		if ($self === '' || !is_executable($self)) {
 			$this->fatalError('Wikven: cannot locate the PHP executable to render skins');
 		}
-		return array_merge($prefix, ['maintenance/run.php', __FILE__]);
+		return array_merge($prefix, ['maintenance/run.php', $script]);
 	}
 
 	/**

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -514,36 +514,33 @@ class Build extends Maintenance {
 	}
 
 	/**
-	 * Start one child with its output on a pipe, for a caller that reads it when the child is over.
+	 * Start one child with its errors on a pipe, read when it is over.
+	 *
+	 * Its output goes nowhere: a child's own progress is not this log's, and a pipe nobody drains
+	 * is one it stops writing into.
 	 *
 	 * @param string[] $command
-	 * @return array{process:resource,pipes:array<int,?resource>}
+	 * @return array{process:resource,errors:resource}
 	 */
 	private function startChild(array $command): array {
-		$descriptors = [0 => STDIN, 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$descriptors = [0 => STDIN, 1 => ['file', '/dev/null', 'w'], 2 => ['pipe', 'w']];
 		$pipes = [];
 		$process = proc_open($command, $descriptors, $pipes, $GLOBALS['IP'], getenv());
-		if ($process === false) {
+		if ($process === false || !isset($pipes[2])) {
 			$this->fatalError('Wikven: could not start ' . implode(' ', $command));
 		}
-		return ['process' => $process, 'pipes' => $pipes];
+		return ['process' => $process, 'errors' => $pipes[2]];
 	}
 
 	/**
-	 * Wait for one child, printing what it wrote to stderr.
+	 * Wait for one child, printing anything it complained about.
 	 *
-	 * Its standard output is dropped: what these children say about their own progress is not this
-	 * log's, and anything that went wrong went to the other pipe.
-	 *
-	 * @param array{process:resource,pipes:array<int,?resource>} $child
+	 * @param array{process:resource,errors:resource} $child
 	 * @return int The child's exit code.
 	 */
 	private function waitForChild(array $child): int {
-		stream_get_contents($child['pipes'][1]);
-		$errors = trim((string)stream_get_contents($child['pipes'][2]));
-		foreach ($child['pipes'] as $pipe) {
-			fclose($pipe);
-		}
+		$errors = trim((string)stream_get_contents($child['errors']));
+		fclose($child['errors']);
 		$exit = proc_close($child['process']);
 		if ($errors !== '') {
 			$this->error($errors);

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -6,6 +6,7 @@ use Maintenance;
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\ContentHandler;
 use MediaWiki\Context\RequestContext;
+use MediaWiki\Extension\Wikven\Build\SourceShard;
 use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
 use MediaWiki\Extension\Wikven\Source\SourceFile;
 use MediaWiki\Import\WikiRevision;
@@ -24,6 +25,39 @@ class ImportWikitext extends Maintenance {
 	public function __construct() {
 		parent::__construct();
 		$this->addDescription('Import *.wikitext files from the given path');
+		$this->addOption(
+			'parse-only',
+			'Parse the pages and save nothing, to leave what a parse caches where the import finds it.'
+		);
+		$this->addOption('shard', 'Which share of the pages to take, as "i/n". Only with --parse-only.', false, true);
+	}
+
+	/**
+	 * Parse this shard's pages, saving nothing.
+	 *
+	 * A parse of a page nobody has saved still fills the caches a parse fills; the expensive one is
+	 * the syntax highlighter, which runs pygments once per code block.
+	 *
+	 * @param string[] $files
+	 * @param string $sourceDirectory
+	 */
+	private function parseOnly(array $files, string $sourceDirectory): void {
+		[$mine, $of] = SourceShard::of((string)$this->getOption('shard', '0/1'));
+		$renderer = $this->getServiceContainer()->getContentRenderer();
+		$parsed = 0;
+		foreach ($files as $index => $filename) {
+			if (( $index % $of ) !== $mine) {
+				continue;
+			}
+			$title = Title::newFromText($this->filenameToTitle($filename, $sourceDirectory));
+			if (!$title) {
+				continue;
+			}
+			$text = (string)file_get_contents($filename);
+			$renderer->getParserOutput(ContentHandler::makeContent($text, $title), $title);
+			$parsed++;
+		}
+		$this->output("Wikven: parsed $parsed page(s) to fill what a parse caches\n");
 	}
 
 	/**
@@ -35,8 +69,14 @@ class ImportWikitext extends Maintenance {
 		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
 		RequestContext::getMain()->setUser($user);
 
+		$files = $this->wikitextFiles($sourceDirectory);
+		if ($this->hasOption('parse-only')) {
+			$this->parseOnly($files, $sourceDirectory);
+			return true;
+		}
+
 		$failed = [];
-		foreach ($this->wikitextFiles($sourceDirectory) as $filename) {
+		foreach ($files as $filename) {
 			$title = Title::newFromText($this->filenameToTitle($filename, $sourceDirectory));
 			if (!$title) {
 				$this->output('Invalid title: ' . basename($filename) . "\n");

--- a/tests/phpunit/unit/SourceShardTest.php
+++ b/tests/phpunit/unit/SourceShardTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\Build\SourceShard;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Build\SourceShard
+ */
+class SourceShardTest extends MediaWikiUnitTestCase {
+	public function testReadsAShareOfSeveral(): void {
+		$this->assertSame([0, 4], SourceShard::of('0/4'));
+		$this->assertSame([3, 4], SourceShard::of(' 3/4 '));
+	}
+
+	/**
+	 * Anything else is one reader taking everything, which is the answer that leaves no page unparsed.
+	 *
+	 * @dataProvider provideWholeList
+	 */
+	public function testAnythingElseIsTheWholeList(string $shard): void {
+		$this->assertSame([0, 1], SourceShard::of($shard));
+	}
+
+	public static function provideWholeList(): array {
+		return [
+			'empty' => [''],
+			'not a share' => ['half'],
+			'no total' => ['2'],
+			'past the end' => ['4/4'],
+			'nothing to share between' => ['0/0'],
+			'negative' => ['-1/4']
+		];
+	}
+}


### PR DESCRIPTION
Refs #720.

`import the pages` is 30 seconds of a bake and the database setting in #725 did not move it, so its cost is not the writing. It is the parse — and specifically what a page's *first* parse fills.

Parsing this site's pages three times in one process, on a wiki with the extensions the docs site loads:

```
1st  19.4s
2nd   1.2s
3rd   1.2s
```

Ninety-four per cent of it is cache-filling, and the expensive filler is the syntax highlighter: it runs `pygments` once per `<syntaxhighlight>` block and remembers the answer under the block's own hash. One spawn measured 226 ms; `docs/` holds 81 blocks; 81 × 226 ms is the 18 seconds above. The most expensive pages are, in order, the ones with the most code blocks.

## What this does

Those parses only read. They share nothing but the cache they fill, so they need not be done one at a time — unlike the import's writes, which one SQLite file serializes whatever else is true.

So the build gains a phase before the import: one shard of the pages per process, run through the import script itself in a new `--parse-only` mode, as many at once as `WIKVEN_BUILD_JOBS` and the processors allow (`WIKVEN_BUILD_JOBS=1` skips it, and the import parses as it always did). The import then finds what it would have waited for.

A shard that fails is reported and not fatal: what it costs is the time it would have saved, and the import parses every page itself regardless.

`skinPassCommand()` becomes `selfCommand($script)`, since the child is now sometimes a different script of this build's own.

## Measured

A full bake of this site on a four-core machine, alternating runs from one fresh database:

| | main | this branch |
| --- | ---: | ---: |
| `warm the parse caches` | — | 5.2s |
| `import the pages` | 20.1s | 6.1s |
| the two together | 20.1s | **11.3s** |
| `build the translations` | 119.0s | 120.1s |
| `render the skins` | 21.2s | 21.7s |
| **the whole bake** | **168.2s** | **161.0s** |

All **794 files of the export are identical** to main's, compared tree against tree. On a slower run of the same pair the import went 26.6s → 6.3s, so what the phase saves tracks what the import was paying.

The bake this was measured on is a local MediaWiki 1.46.0 with the extensions and skins the docs site lists, which is also how the pygments finding was found; its `import the pages` (20-27s) sits where CI's does (29-30s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_