### PR TITLE
perf: stop rendering translation pages the build renders again

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -40,13 +40,14 @@ class BuildTranslations extends Maintenance {
 	/**
 	 * Jobs this script takes off the queue without running.
 	 *
-	 * The stats one recomputes what render() computes again anyway. The others serve translators --
-	 * a memory to suggest from, a state to review by -- which an export has nowhere to put.
+	 * The stats and the renders, render() does again below. The others serve translators -- a memory
+	 * to suggest from, a state to review by -- which an export has nowhere to put.
 	 *
 	 * @var string[]
 	 */
 	private const UNRUN_JOBS = [
 		'RebuildMessageGroupStatsJob',
+		'RenderTranslationPageJob',
 		'TtmServerMessageUpdateJob',
 		'MessageGroupStatesUpdaterJob'
 	];


### PR DESCRIPTION
Refs #720.

`build the translations` is the longest phase of a bake. Timed from inside, the queue drain that follows each page's marking is more than half of it, and one of the jobs it runs there is `RenderTranslationPageJob`.

That job renders a translated page. At the moment it runs, the page has just been marked and its translations have not been loaded yet, so it renders a page with nothing translated on it. The script's own render pass then does every page again at the end, once every page is marked and every unit is in place — which is why that pass exists.

## What this does

`RenderTranslationPageJob` joins the jobs the drain acks without running, beside the statistics job taken off for the same reason in #726.

Nothing is left unrendered. `getRenderJobs()` builds its list from the group's statistics as well as from the translation pages that already exist, a path Translate keeps for exactly the case where a translation exists and its page does not.

## Measured

A full bake of this site on a four-core machine, alternating runs from one fresh database:

| | main | this branch |
| --- | ---: | ---: |
| `build the translations` | 129.6s | **118.7s** |
| the whole bake | 177.7s | 163.9s |

All **794 files of the export are identical** to main's, compared tree against tree — the same check the smoke workflow makes of two bakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_