### PR TITLE
perf: offer Translate only the languages the source is written in

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -87,6 +87,7 @@
 			"main"
 		],
 		"SifterSearchIndexPage": "indexer",
+		"TranslateSupportedLanguages": "narrower",
 		"PageContentLanguage": "declarer",
 		"GetMagicVariableIDs": "versioner",
 		"ParserGetVariableValueSwitch": "versioner"
@@ -112,6 +113,13 @@
 		},
 		"indexer": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Indexer"
+		},
+		"narrower": {
+			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Narrower",
+			"services": [
+				"MainConfig",
+				"LanguageNameUtils"
+			]
 		},
 		"reporter": {
 			"class": "MediaWiki\\Extension\\Wikven\\Hooks\\Reporter"

--- a/includes/Hooks/Narrower.php
+++ b/includes/Hooks/Narrower.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Hooks;
+
+use MediaWiki\Config\Config;
+use MediaWiki\Extension\Wikven\PageTranslation\TranslationSource;
+use MediaWiki\Languages\LanguageNameUtils;
+use MediaWiki\MainConfigNames;
+
+/**
+ * Which languages Translate offers, cut to the ones a source tree could be read in.
+ *
+ * Translate offers every language MediaWiki knows and keeps a statistics row for each, so a bake
+ * counted six hundred it has no file for.
+ *
+ * Translate declares SupportedLanguagesHook and this does not implement it: a class implementing
+ * an absent interface cannot load. MediaWiki dispatches by name.
+ *
+ * @see \MediaWiki\Extension\Translate\Utilities\SupportedLanguagesHook for the signature.
+ */
+class Narrower {
+	private Config $config;
+
+	private LanguageNameUtils $languageNameUtils;
+
+	/** @var ?string[] Kept for the calls after the first: the answer is a walk of the source tree. */
+	private ?array $offered = null;
+
+	public function __construct(Config $config, LanguageNameUtils $languageNameUtils) {
+		$this->config = $config;
+		$this->languageNameUtils = $languageNameUtils;
+	}
+
+	/**
+	 * Leave the languages the source tree writes in, and leave every language where it has none.
+	 *
+	 * @param string[] &$list Language names, keyed by code.
+	 * @param ?string $language The language the names are in; this reads only the codes.
+	 */
+	public function onTranslateSupportedLanguages(array &$list, ?string $language) {
+		$offered = $this->offered();
+		if ($offered === null) {
+			return;
+		}
+		$list = array_intersect_key($list, array_fill_keys($offered, true));
+	}
+
+	/**
+	 * The languages the source tree can be read in, or null where there is no source tree.
+	 *
+	 * A translation file for each, the wiki's own language, and the code Translate documents
+	 * messages under where one is set.
+	 *
+	 * @return ?string[]
+	 */
+	private function offered(): ?array {
+		if ($this->offered !== null) {
+			return $this->offered;
+		}
+		$source = rtrim((string)$this->config->get('WikvenSourceDirectory'), '/');
+		if ($source === '' || !is_dir($source)) {
+			return null;
+		}
+		$offered = TranslationSource::languages(
+			$source,
+			[$this->languageNameUtils, 'isKnownLanguageTag']
+		);
+		$offered[] = (string)$this->config->get(MainConfigNames::LanguageCode);
+		$documentation = (string)$this->config->get('TranslateDocumentationLanguageCode');
+		if ($documentation !== '') {
+			$offered[] = $documentation;
+		}
+		$this->offered = $offered;
+		return $offered;
+	}
+}

--- a/tests/phpunit/unit/NarrowerTest.php
+++ b/tests/phpunit/unit/NarrowerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Config\HashConfig;
+use MediaWiki\Extension\Wikven\Hooks\Narrower;
+use MediaWiki\Languages\LanguageNameUtils;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Hooks\Narrower
+ */
+class NarrowerTest extends MediaWikiUnitTestCase {
+	private string $directory;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->directory = sys_get_temp_dir() . '/wikven-narrower-' . getmypid() . '-' . uniqid();
+		mkdir($this->directory, 0777, true);
+	}
+
+	protected function tearDown(): void {
+		$this->remove($this->directory);
+		parent::tearDown();
+	}
+
+	private function remove(string $path): void {
+		if (is_dir($path)) {
+			foreach (array_diff(scandir($path) ?: [], ['.', '..']) as $entry) {
+				$this->remove("$path/$entry");
+			}
+			rmdir($path);
+			return;
+		}
+		if (is_file($path)) {
+			unlink($path);
+		}
+	}
+
+	private function write(string $relative, string $text): void {
+		$path = "$this->directory/$relative";
+		if (!is_dir(dirname($path))) {
+			mkdir(dirname($path), 0777, true);
+		}
+		file_put_contents($path, $text);
+	}
+
+	/** A page written in <translate>, and a translation of it carrying the same unit marker. */
+	private function translatedInto(string ...$languages): void {
+		$this->write('Page.wikitext', "<translate>\n<!--T:1-->\nHello.\n</translate>");
+		foreach ($languages as $language) {
+			$this->write("Page/$language.wikitext", "<!--T:1-->\nHello there.\n");
+		}
+	}
+
+	private function narrower(string $source, string $documentation = ''): Narrower {
+		$languageNameUtils = $this->createMock(LanguageNameUtils::class);
+		$languageNameUtils->method('isKnownLanguageTag')
+			->willReturnCallback(static function (string $code): bool {
+				return preg_match('/^[a-z]{2}$/', $code) === 1;
+			});
+		$config = new HashConfig([
+			'WikvenSourceDirectory' => $source,
+			'LanguageCode' => 'en',
+			'TranslateDocumentationLanguageCode' => $documentation
+		]);
+		return new Narrower($config, $languageNameUtils);
+	}
+
+	private function narrow(Narrower $narrower, array $list): array {
+		$narrower->onTranslateSupportedLanguages($list, 'en');
+		return $list;
+	}
+
+	private function everyLanguage(): array {
+		return ['en' => 'English', 'ko' => 'Korean', 'km' => 'Khmer', 'fr' => 'French'];
+	}
+
+	public function testKeepsTheLanguagesTheSourceIsTranslatedInto() {
+		$this->translatedInto('ko', 'km');
+		$narrowed = $this->narrow($this->narrower($this->directory), $this->everyLanguage());
+		$this->assertSame(['en', 'ko', 'km'], array_keys($narrowed));
+	}
+
+	public function testKeepsTheWikiLanguageWhereNothingIsTranslated() {
+		$this->write('Page.wikitext', "Plain.\n");
+		$narrowed = $this->narrow($this->narrower($this->directory), $this->everyLanguage());
+		$this->assertSame(['en' => 'English'], $narrowed);
+	}
+
+	public function testKeepsTheCodeMessagesAreDocumentedUnder() {
+		$this->translatedInto('ko');
+		$narrower = $this->narrower($this->directory, 'qqq');
+		$narrowed = $this->narrow($narrower, $this->everyLanguage() + ['qqq' => 'Documentation']);
+		$this->assertSame(['en', 'ko', 'qqq'], array_keys($narrowed));
+	}
+
+	public function testLeavesTheListAloneWithoutASourceTree() {
+		$narrowed = $this->narrow($this->narrower(''), $this->everyLanguage());
+		$this->assertSame($this->everyLanguage(), $narrowed);
+	}
+
+	public function testLeavesTheListAloneWhereTheSourceDirectoryIsNotThere() {
+		$narrowed = $this->narrow($this->narrower("$this->directory/gone"), $this->everyLanguage());
+		$this->assertSame($this->everyLanguage(), $narrowed);
+	}
+
+	public function testReadsTheSourceTreeOnce() {
+		$this->translatedInto('ko');
+		$narrower = $this->narrower($this->directory);
+		$this->narrow($narrower, $this->everyLanguage());
+		$this->translatedInto('ko', 'fr');
+		$this->assertSame(['en', 'ko'], array_keys($this->narrow($narrower, $this->everyLanguage())));
+	}
+}


### PR DESCRIPTION
Refs #720.

Translate offers every language MediaWiki knows — 566 of them — and keeps a statistics row for each one of every translatable page. Marking a page writes that whole set, and so does taking the counts again once its translations are loaded. This site is written in English and translated into two languages.

Timed from inside `build the translations`, those two passes over the language list were 16 seconds of the phase, and the per-unit save carried more of the same.

## What this does

Translate declares a hook for narrowing the list it offers. Wikven answers it with the languages a bake could be read in, all of them read from the source tree rather than declared: one for every translation file found under the source directory, the wiki's own language, and the code Translate documents messages under where one is set. A wiki with no source directory is left alone.

## What changes in the export

Every page, every stylesheet, and the search index are byte for byte main's.

One thing does change, and for the better: `ext.translate.languages` ships the name of every language MediaWiki knows to every visitor. It now ships the three this site has, so `modules-static.js` loses 12.6 KB in each of the three skin copies.

```
"supportedLanguages":{"en":"English","km":"ភាសាខ្មែរ","ko":"한국어"}
```

`composer test:bake` still passes, including *every language bar lists every language the source has* (414 entries).

## Measured

A full bake of this site on a four-core machine, alternating runs from one fresh database:

| | main | this branch |
| --- | ---: | ---: |
| `build the translations` | 129.6s | **110.3s** |
| the whole bake | 177.7s | 153.3s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_