### PR TITLE
build(deps): bump femiwiki/quibble-action from 2.1.1 to 2.1.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           persist-credentials: false
       - if: needs.changes.outputs.docs-only != 'true'
-        uses: femiwiki/quibble-action@4c99d26a916c8e8887a2622d26d979c26658106f  # v2.1.1
+        uses: femiwiki/quibble-action@b57e2f3f990ed61d512d283cfb80a31977f2e56d  # v2.1.2
         with:
           stage: phan
           dependencies: ${{ env.PHAN_DEPENDENCIES }}
@@ -203,7 +203,7 @@ jobs:
           persist-credentials: false
       - id: quibble
         if: needs.changes.outputs.docs-only != 'true'
-        uses: femiwiki/quibble-action@4c99d26a916c8e8887a2622d26d979c26658106f  # v2.1.1
+        uses: femiwiki/quibble-action@b57e2f3f990ed61d512d283cfb80a31977f2e56d  # v2.1.2
         with:
           stage: coverage
           dependencies: ${{ env.WIKI_DEPENDENCIES }}


### PR DESCRIPTION
2.1.2 carries [femiwiki/quibble-action#93](https://github.com/femiwiki/quibble-action/pull/93), which clones a dependency whose directory MediaWiki core left empty.

A release branch of core carries its bundled extensions and skins as submodules — 39 of them on REL1_46, `extensions/Gadgets` among them — so a plain clone of core leaves an empty directory for each. 2.1.1 skipped any dependency whose directory merely existed, so on REL1_46 Gadgets was never cloned and every stage ran without it. On a cold installation cache that showed up as `phan (REL1_46)` reporting four `MediaWiki\Extension\Gadgets\*` classes as undeclared, while `phan (master)` — where core has no `.gitmodules` at all — passed. #730 is red on exactly that.

Dependabot would bring this in a week, under its cooldown. This is ahead of it because a required check is waiting on it.

Both pinned uses in `test.yml` move together, and nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_