### PR TITLE
feat: have serve say where the site it is serving can be read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,9 @@ jobs:
       - if: needs.changes.outputs.docs-only != 'true'
         run: go vet ./...
         working-directory: caddy
+      - if: needs.changes.outputs.docs-only != 'true'
+        run: go test ./...
+        working-directory: caddy
 
   # Run the extension's PHPUnit tests against a real MediaWiki: the 1.46 base the build ships on, and master.
   phpunit:

--- a/caddy/wikven.go
+++ b/caddy/wikven.go
@@ -5,6 +5,8 @@ package wikvencaddy
 import (
 	"errors"
 	"flag"
+	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,9 +42,12 @@ func init() {
 			if workdir == "" {
 				workdir = "."
 			}
-			return reexec("file-server",
-				"--root", filepath.Join(workdir, "dist"),
-				"--listen", fl.String("listen"))
+			root := filepath.Join(workdir, "dist")
+			listen := fl.String("listen")
+			// Before the server starts, because what follows is Caddy's log and the address is in
+			// it as the socket it bound -- ":8080", which is not one a browser can be given.
+			fmt.Printf("wikven: serving %s at %s\n", root, previewURL(listen))
+			return reexec("file-server", "--root", root, "--listen", listen)
 		},
 	})
 
@@ -70,6 +75,23 @@ func init() {
 			return reexec(append([]string{"php-cli", "translate.php"}, commandTail("translate")...)...)
 		},
 	})
+}
+
+// previewURL is the address to open for a listen address, as a reader would type it.
+//
+// A listen address names a socket to bind, and the three spellings of "every interface" -- an empty
+// host, 0.0.0.0, :: -- are not addresses to visit. To whoever is at the machine they are localhost.
+// An address this cannot read is handed back whole; it is the one the caller wrote.
+func previewURL(listen string) string {
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return listen
+	}
+	switch host {
+	case "", "0.0.0.0", "::":
+		host = "localhost"
+	}
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 // commandTail is everything the caller wrote after the named subcommand, verbatim.

--- a/caddy/wikven_test.go
+++ b/caddy/wikven_test.go
@@ -1,0 +1,22 @@
+package wikvencaddy
+
+import "testing"
+
+// The addresses Caddy's --listen takes, against the address a reader is given for each.
+func TestPreviewURL(t *testing.T) {
+	for listen, want := range map[string]string{
+		":8080":            "http://localhost:8080",
+		"0.0.0.0:8080":     "http://localhost:8080",
+		"[::]:8080":        "http://localhost:8080",
+		"localhost:3000":   "http://localhost:3000",
+		"127.0.0.1:3000":   "http://127.0.0.1:3000",
+		"[::1]:3000":       "http://[::1]:3000",
+		"example.test:80":  "http://example.test:80",
+		"unix//tmp/wikven": "unix//tmp/wikven",
+		"8080":             "8080",
+	} {
+		if got := previewURL(listen); got != want {
+			t.Errorf("previewURL(%q) = %q, want %q", listen, got, want)
+		}
+	}
+}


### PR DESCRIPTION
`wikven serve` printed Caddy's startup log and nothing else. The address in that log is the socket the server bound — `:8080` by default — which is not an address a browser will take, and nothing said which directory was being served either.

It now says both, before the server starts:

```
wikven: serving ./dist at http://localhost:8080
```

## What the address becomes

| `--listen` | printed |
| --- | --- |
| `:8080` (the default) | `http://localhost:8080` |
| `0.0.0.0:8080`, `[::]:8080` | `http://localhost:8080` |
| `127.0.0.1:3000` | `http://127.0.0.1:3000` |
| `[::1]:3000` | `http://[::1]:3000` |
| something with no port in it | printed as the caller wrote it |

The three spellings of *every interface* become `localhost` because that is what they are to whoever is sitting at the machine; a host given by name or by number is kept as given.

The `caddy` job gains `go test`, which it had nothing to run before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_