### PR TITLE
feat: have the binary introduce itself rather than Caddy

### DIFF
--- a/caddy/wikven.go
+++ b/caddy/wikven.go
@@ -11,10 +11,51 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/caddyserver/caddy/v2"
 	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 )
 
+// What `wikven` on its own answers with.
+//
+// Caddy builds the root command from these two, and without them it introduces itself: a page
+// about an extensible server platform, telling the reader to run `caddy run`. Every word of it is
+// true of the program underneath and none of it is about the one they have.
+//
+// Caddy's own commands and examples stay under this. A plugin cannot take either off the root
+// command -- registering a command is the whole of the interface -- so the text says whose they
+// are rather than leaving a reader to try them.
+const (
+	binaryName = "wikven"
+
+	longDescription = `Wikven builds a static website out of a directory of wikitext, by running the
+MediaWiki it carries and keeping what that renders.
+
+Three commands are wikven's own:
+
+	- 'wikven build' renders src/ into dist/.
+	- 'wikven serve' serves dist/ for local preview.
+	- 'wikven translate' marks, scaffolds, stamps or checks translations.
+
+Both directories are read under WIKVEN_WORKDIR, which is the directory you run
+in unless you set it. So a first site is:
+
+	$ mkdir src && echo 'Hello, World!' > src/index.wikitext
+	$ wikven build
+	$ wikven serve
+
+The examples and the other commands below are Caddy's, the web server this
+binary is built on. They are shown because they ship with it, not because
+wikven has anything to do with them.
+
+Documentation: https://chaotic-ground.github.io/wikven/
+`
+)
+
 func init() {
+	// Read when Caddy builds the root command, which is after every init() has run.
+	caddy.CustomBinaryName = binaryName
+	caddy.CustomLongDescription = longDescription
+
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name:  "build",
 		Usage: " ",


### PR DESCRIPTION
`wikven` with nothing after it printed Caddy's own front page — an essay about an extensible server platform, telling the reader to run `caddy run`, pointing at caddyserver.com. Every word of it is true of the program underneath and none of it is about the one the reader has. The usage line said `caddy`, and so did the error for a command it does not know.

Caddy reads two variables when it constructs the root command, which is after every `init()` has run. Setting them makes the page wikven's:

```
Wikven builds a static website out of a directory of wikitext, by running the
MediaWiki it carries and keeping what that renders.

Three commands are wikven's own:

	- 'wikven build' renders src/ into dist/.
	- 'wikven serve' serves dist/ for local preview.
	- 'wikven translate' marks, scaffolds, stamps or checks translations.

Both directories are read under WIKVEN_WORKDIR, which is the directory you run
in unless you set it. So a first site is:

	$ mkdir src && echo 'Hello, World!' > src/index.wikitext
	$ wikven build
	$ wikven serve

The examples and the other commands below are Caddy's, the web server this
binary is built on. They are shown because they ship with it, not because
wikven has anything to do with them.

Documentation: https://chaotic-ground.github.io/wikven/

Usage:
  wikven [command]
```

`wikven serve --help` now reads `Usage: wikven serve [--listen <addr>]`, and an unknown command answers `unknown command "nope" for "wikven"`.

## What stays

Caddy's own commands and its examples are still listed under that text. A plugin cannot take either off the root command — registering a command is the whole of the interface Caddy offers — so the text names whose they are instead, rather than leaving a reader to try `caddy reload` and find out.

## Checked

Against a real Caddy root command: a throwaway `main` calling `caddycmd.Main()` with this module linked in, run with no arguments, with `serve --help`, and with an unknown command. The output above is that binary's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_