### PR TITLE
perf: stop purging a cache a bake does not have

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -40,14 +40,15 @@ class BuildTranslations extends Maintenance {
 	/**
 	 * Jobs this script takes off the queue without running.
 	 *
-	 * The stats and the renders, render() does again below. The others serve translators -- a memory
-	 * to suggest from, a state to review by -- which an export has nowhere to put.
+	 * The stats and the renders, render() does again below. The purge has no cache to purge; a
+	 * later phase overwrites what it touches. The rest serve translators an export lacks.
 	 *
 	 * @var string[]
 	 */
 	private const UNRUN_JOBS = [
 		'RebuildMessageGroupStatsJob',
 		'RenderTranslationPageJob',
+		'htmlCacheUpdate',
 		'TtmServerMessageUpdateJob',
 		'MessageGroupStatesUpdaterJob'
 	];


### PR DESCRIPTION
Refs #720.

The queue drain after each page's marking runs an `htmlCacheUpdate` job. What that job does is invalidate the parser cache for everything linking to the page that changed, and bump `page_touched` while it is there.

A bake has no parser cache: `WikvenSettings.php` sets `$wgParserCacheType` to `CACHE_NONE`. So the invalidation is of nothing, and the timestamps it writes are overwritten by `freeze the page timestamps` before any phase reads one — the search index included, which runs before that and re-renders every page it has no cache entry for, which on a fresh bake is all of them.

It joins the jobs the drain acks without running.

## Measured

A full bake of this site on a four-core machine, alternating runs from one fresh database:

| | main | this branch |
| --- | ---: | ---: |
| `build the translations` | 85.2s | **80.8s** |

All **803 files of the export are identical** to main's, compared tree against tree. The same change measured 3.1s on an earlier base, with the export identical there too — this is the second time it has been measured and the second time nothing moved but the clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_