### PR TITLE
perf: keep the job queue on the database the build already has open

### DIFF
--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -62,6 +62,17 @@ $wgMainCacheType = CACHE_DB;
 // taken mid-build never looks stale (#333). Costs a parse per skin instead of one per bake.
 $wgParserCacheType = CACHE_NONE;
 
+// The installer gives the job queue a database of its own, named by a server entry. A queue told
+// about a server caches its connection on the queue object, and JobQueueGroup::get() makes a new
+// one per call.
+
+// So every push, pop and ack opened the file and threw it away. Without the entry the queue is on
+// the wiki's own database, whose connection is kept; the separate file only keeps web traffic off
+// it.
+if (isset($GLOBALS['wgJobTypeConf']['default']['server'])) {
+	unset($GLOBALS['wgJobTypeConf']['default']['server']);
+}
+
 // MediaWiki's installer writes synchronous=NORMAL for the object cache, the localisation cache and
 // the job queue; the wiki's own file, which a bake commits into thousands of times, it leaves at
 // FULL. That one is a scratch file too.


### PR DESCRIPTION
Refs #720.

MediaWiki's installer gives the job queue a database of its own, and names it with a `server` entry:

```php
$wgJobTypeConf['default'] = [
	'class' => 'JobQueueDB',
	'server' => [ 'type' => 'sqlite', 'dbname' => "{$wgDBname}_jobqueue", … ]
];
```

That entry is what makes the queue expensive in a bake. `JobQueueGroup::get()` builds a fresh `JobQueue` object for every call, and a `JobQueueDB` told about a server caches its connection **on that object**. So every push, every pop and every ack opened the file, ran its pragmas, built an `FSLockManager` and threw all three away again — and a bake makes about a thousand edits, each pushing three or four jobs.

Without the entry the queue is the `job` table in the wiki's own database, whose connection the load balancer holds for the length of the build. What the separate file is for is keeping a web server's job traffic off the wiki's database; a bake is one process, writing alone.

## Measured

A full bake of this site on a four-core machine, alternating runs from one fresh database:

| | main | this branch |
| --- | ---: | ---: |
| `build the translations` | 93.4s | **85.4s** |
| the whole bake | 138.3s | **130.0s** |

All **803 files of the export are identical** to main's, compared tree against tree.

## Credit

Found by a second pass over the profile that a Fable model ran on this phase — the cost was inside what #720 had written off as "queue polling overhead", and it is not the polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_