### PR TITLE
perf: tag the base page ready without writing it again

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -126,20 +126,21 @@ class BuildTranslations extends Maintenance {
 		User $user
 	): bool {
 		$services = $this->getServiceContainer();
+		$translate = TranslateServices::getInstance();
 
-		// importWikitext saved the base as an old revision, which bypasses the PageSaveComplete hook
-		// that writes the "ready for translation" tag. A normal edit restores it.
-		$page = $services->getWikiPageFactory()->newFromTitle($title);
-		$updater = $page->newPageUpdater($user);
-		$updater->setContent(SlotRecord::MAIN, ContentHandler::makeContent($sourceText, $title));
-		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Prepare for translation'), EDIT_FORCE_BOT);
-
-		$marker = TranslateServices::getInstance()->getTranslatablePageMarker();
+		$marker = $translate->getTranslatablePageMarker();
 		$record = $services->getPageStore()->getPageByReference($title, IDBAccessObject::READ_LATEST);
 		if (!$record) {
 			$this->output("Wikven: could not load {$title->getPrefixedText()} for translation; skipping\n");
 			return false;
 		}
+
+		// importWikitext saved the base as an old revision, bypassing the PageSaveComplete hook that
+		// tags a revision ready for translation. This is that hook's whole body, without a second
+		// revision of a page whose text has not changed.
+		TranslatablePage::newFromTitle($title)->addReadyTag($record->getLatest());
+		$translate->getTranslatablePageStore()->performStatusUpdate($title);
+
 		// A page Translate cannot parse -- an unclosed <translate>, two markers in one unit -- throws
 		// out of the marker. One page must not end the bake, so report it and leave it untranslated.
 		try {


### PR DESCRIPTION
Refs #720.

Marking a page for translation needs a *ready for translation* tag on its latest revision, and `importWikitext` does not leave one — it saves the base as an old revision, which bypasses the `PageSaveComplete` hook that writes the tag. The script got one the blunt way: re-save the page, with everything an ordinary edit costs, over text that had not changed.

Translate's hook is four lines, and both halves are public:

```php
TranslatablePage::newFromTitle( $wikiPage->getTitle() )->addReadyTag( $revisionRecord->getId() );
Services::getInstance()->getTranslatablePageStore()->performStatusUpdate( $wikiPage->getTitle() );
```

The script already holds the page record it needs for the revision id, already talks to both of those classes, and read the page's text off disk a moment earlier — so there is nothing the edit was establishing that is not already known here. `getMarkOperation()` asks only for the tag on the latest revision.

## Measured

The translations phase on a four-core machine, alternating runs from one fresh database: **76.6s → 73.7s**. A full bake with the change leaves all **803 files of the export identical** to main's, compared tree against tree.

One fewer revision per translatable page, twenty-three of them here. The export does not carry revision ids — it zeroes them and freezes the timestamps before rendering — and `hideBuildAuthors` has one row less to rewrite.

## Credit

Pointed at by the profile a Fable model ran on this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_