### PR TITLE
fix: stop the translation drain spinning on a queue that gives nothing

### DIFF
--- a/maintenance/buildTranslations.php
+++ b/maintenance/buildTranslations.php
@@ -256,6 +256,7 @@ class BuildTranslations extends Maintenance {
 				return;
 			}
 			sort($types);
+			$taken = 0;
 			foreach ($types as $type) {
 				$job = $group->pop($type);
 				while ($job) {
@@ -265,8 +266,15 @@ class BuildTranslations extends Maintenance {
 						$job->run();
 					}
 					$group->ack($job);
+					$taken++;
 					$job = $group->pop($type);
 				}
+			}
+			// A queue can name a type and then hand out nothing -- rows for a type whose queue is
+			// configured somewhere else, say. Without this the loop asks and asks forever.
+			if ($taken === 0) {
+				$this->error('Wikven: the job queue named ' . implode(', ', $types) . ' and gave nothing');
+				return;
 			}
 		}
 	}


### PR DESCRIPTION
`drainJobs()` asks the job queue group which types have jobs, pops each type until it comes back empty, and then asks again. It stops when nothing is named.

There is a state where something is named forever. A queue can report rows for a type whose queue is configured somewhere else — the `job` table holding `htmlCacheUpdate` rows while that type's queue is in memory, for instance — so `getQueuesWithJobs()` lists the type on every pass and `pop()` answers nothing on every pass. The loop asks and asks, and the build never finishes.

Nothing wikven ships configures a queue that way. This was reached by an experiment that did, while measuring #720, and it is cheap to rule out for good: a pass that took no job at all is not going to take one next time either, so name what was named and leave it.

A full bake is unchanged — the guard never fires on one, and all 803 files of the export are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_