### PR TITLE
perf: let a bake's boots share what the first one compiled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,27 @@ RUN composer config --global policy.advisories.block false \
 # would otherwise be found by a site whose sitemap had gone missing.
 RUN php -r 'require "/var/www/html/vendor/autoload.php"; if (!class_exists("GuzzleHttp\\Psr7\\Uri") || !class_exists("GuzzleHttp\\Psr7\\UriResolver")) { fwrite(STDERR, "MediaWiki no longer vendors guzzlehttp/psr7; SiteUrl needs it\n"); exit(1); }'
 
+# A bake is not one PHP process. The entrypoint runs four, and the build starts one child per parse
+# shard and one per skin, each compiling MediaWiki from source over again: opcache ships enabled for
+# the web and off for the command line. The file cache is what separate processes share.
+#
+# Its directory has to exist before PHP starts, or opcache drops the setting without a word. Last of
+# the RUNs, so the image ships that directory empty and a bake fills it with its own compiles.
+#
+# The sizes are the base image's, raised: a bake's heaviest process holds 50MB of opcodes and 2,100
+# files, and a site loads extensions of its own on top. Its revalidate_freq goes back to zero: 60
+# seconds suits a web process that outlives the files it serves, and a bake writes PHP to disk after
+# PHP has started -- the extensions it fetches, and the line the entrypoint appends to
+# LocalSettings.php. Named to sort after opcache-recommended.ini, conf.d being read in order.
+RUN mkdir -p /var/cache/wikven-opcache \
+ && printf '%s\n' \
+      'opcache.enable_cli=1' \
+      'opcache.file_cache=/var/cache/wikven-opcache' \
+      'opcache.revalidate_freq=0' \
+      'opcache.memory_consumption=256' \
+      'opcache.max_accelerated_files=10000' \
+      > /usr/local/etc/php/conf.d/zz-wikven-opcache.ini
+
 COPY ./ /var/www/html/extensions/Wikven
 COPY includes/WikvenSettings.php /var/www/html/
 COPY bin/entrypoint /usr/local/bin/entrypoint


### PR DESCRIPTION
One bake starts PHP about fifteen times: four from the entrypoint, one per parse shard, one per skin. Every one of them compiled MediaWiki's PHP from source again, because `opcache.enable_cli` is off by default and the image set no `php.ini` at all.

Separate processes cannot share opcache's shared memory, but they can share its file cache. This turns that on.

## Measured

Four bakes each way, alternating, this site on a four-core machine, with the file cache emptied before every run so each starts as cold as a fresh container:

| | off | on |
| --- | ---: | ---: |
| the whole bake | 141.3 / 138.6 / 135.7 / 139.0s | **133.5 / 129.9 / 131.5 / 130.7s** |
| `build the translations` | 86.2 / 83.2 / 81.8 / 84.4s | 80.9 / 78.0 / 80.4 / 78.6s |
| `render the skins` | 28.8 / 28.5 / 27.9 / 28.5s | 26.6 / 26.5 / 25.8 / 26.9s |

138.7s to 131.4s on average — about 5%. Every export was byte for byte the same tree, 803 files, compared against the run beside it and against a reference.

## The settings

`enable_cli` and `file_cache` are the change. The other three are the base image's `opcache-recommended.ini` adjusted for a bake rather than a web server:

* the sizes are raised because a bake's heaviest process holds 50MB of opcodes across 2,100 files, and a site loads extensions of its own on top of that;
* `revalidate_freq` goes back to zero. Sixty seconds suits a process that outlives the files it serves; a bake writes PHP to disk after PHP has started, both the extensions it fetches and the line the entrypoint appends to `LocalSettings.php`.

`validate_timestamps` stays on for the same reason.

## Not here

The binary. Its PHP is a static build inside FrankenPHP, and where that reads a `php.ini` from has to be established by trying it. #740 stays open for that.

Refs #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_