### PR TITLE
perf: give the image the gmp its base conversions keep asking for

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,18 @@ FROM mediawiki:1.46.0-fpm-alpine@sha256:b0e9413c015268322cfb67908e5f92121372c740
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN apk add --no-cache rsvg-convert imagemagick-jpeg imagemagick-webp
 
+# base_convert without gmp is long division written in PHP, one round per digit, and a bake asks for
+# it constantly: every file lock names itself by a sha1 in base 36, and so does every generated id.
+# The base image builds the extensions a wiki serving readers needs, and this is not one of them.
+# Worth 2% of a bake, measured; bcmath, the middle path, is not here either.
+#
+# Compiled rather than installed: no package carries a gmp built for this PHP. The headers and the
+# toolchain come and go inside the one layer, leaving the shared library and the extension.
+RUN apk add --no-cache gmp \
+ && apk add --no-cache --virtual .gmp-build $PHPIZE_DEPS gmp-dev \
+ && docker-php-ext-install -j "$(nproc)" gmp \
+ && apk del --no-network .gmp-build
+
 # Fetched before wikven's own code is copied in, so an edit there does not bust the slow layers.
 
 # "Stable source" describes the bytes, not the service in front of them: GitHub served 500s for


### PR DESCRIPTION
`Wikimedia\base_convert` uses gmp when it is there, bcmath when it is not, and a long division written in PHP when neither is. The image has neither: the base image builds `calendar`, `intl`, `mbstring`, `mysqli` and `opcache`, which is what a wiki serving readers needs.

A bake asks for base conversion constantly. `LockManager` names every file lock by a sha1 in base 36, and `GlobalIdGenerator` converts every id it hands out.

## Measured

Four bakes, alternating, the same PHP with the extension loaded and not:

| | without | with |
| --- | ---: | ---: |
| the whole bake | 132.2 / 130.7s | **128.5 / 128.1s** |
| `build the translations` | 79.1 / 78.6s | 77.8 / 76.5s |
| `render the skins` | 27.0 / 27.5s | 26.4 / 26.1s |

About 3.1 seconds, near 2.4%. Both exports in each pair were the same tree, 803 files.

## Not the binary

Its PHP already carries bcmath, so it takes the middle path rather than the slow one, and gmp would still be faster. But libgmp is LGPL-3.0-or-later / GPL-2.0-or-later, and the binary links its libraries statically — which is a different question from the image, where the extension loads a shared library the image also ships. Given that Vulcain is already left out of the binary over its licence, that call is yours rather than mine; say the word and it is a one-word change to `binary.Dockerfile`.

Refs #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_