### PR TITLE
perf: let the binary's bake share its compiled PHP too

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -284,6 +284,26 @@ jobs:
             exit 1
           fi
 
+      # caddy/wikven.go writes opcache settings into the working directory and points PHP at them
+      # through PHP_INI_SCAN_DIR, so that a bake's fifteen-odd PHP processes share what the first
+      # one compiled instead of each compiling MediaWiki again. Whether PHP reads them is a claim
+      # about where a static build looks for its configuration, and the baked site looks the same
+      # either way.
+      #
+      # The file cache is the evidence. It stays empty unless opcache was both enabled for the
+      # command line and told where to write, so a build that stopped honouring the variable is a
+      # red check here rather than a slower bake nobody notices.
+      - name: The bake's opcache settings reached PHP
+        run: |
+          set -euo pipefail
+          cached=$(find work/.cache/opcache -name '*.bin' 2>/dev/null | wc -l)
+          if [ "$cached" -eq 0 ]; then
+            echo "::error::the bake compiled nothing into work/.cache/opcache; see phpEnv in caddy/wikven.go"
+            cat work/.cache/php/opcache.ini || true
+            exit 1
+          fi
+          echo "the bake left $cached compiled files for its own processes to share"
+
       # The licenses page a build writes names what it ran on, and under the binary that includes
       # the server the binary is. caddy/wikven.go reads FrankenPHP and Caddy out of the Go build
       # info and hands them to the build in WIKVEN_RUNTIME, so nothing writes those versions down.

--- a/caddy/wikven.go
+++ b/caddy/wikven.go
@@ -65,7 +65,7 @@ func init() {
 		Long: "Builds WIKVEN_WORKDIR/src into WIKVEN_WORKDIR/dist " +
 			"(WIKVEN_WORKDIR defaults to the current directory).",
 		Func: func(_ caddycmd.Flags) (int, error) {
-			return reexec("php-cli", "build.php")
+			return reexec(phpEnv(workdir()), "php-cli", "build.php")
 		},
 	})
 
@@ -79,16 +79,12 @@ func init() {
 			"directory) over HTTP, on :8080 by default, for local preview.",
 		Flags: serveFlags,
 		Func: func(fl caddycmd.Flags) (int, error) {
-			workdir := os.Getenv("WIKVEN_WORKDIR")
-			if workdir == "" {
-				workdir = "."
-			}
-			root := filepath.Join(workdir, "dist")
+			root := filepath.Join(workdir(), "dist")
 			listen := fl.String("listen")
 			// Before the server starts, because what follows is Caddy's log and the address is in
 			// it as the socket it bound -- ":8080", which is not one a browser can be given.
 			fmt.Printf("wikven: serving %s at %s\n", root, previewURL(listen))
-			return reexec("file-server", "--root", root, "--listen", listen)
+			return reexec(nil, "file-server", "--root", root, "--listen", listen)
 		},
 	})
 
@@ -113,9 +109,70 @@ func init() {
 			"scaffold and stamp write into the source tree; check only reads it.",
 		Flags: translateFlags,
 		Func: func(_ caddycmd.Flags) (int, error) {
-			return reexec(append([]string{"php-cli", "translate.php"}, commandTail("translate")...)...)
+			args := append([]string{"php-cli", "translate.php"}, commandTail("translate")...)
+			return reexec(phpEnv(workdir()), args...)
 		},
 	})
+}
+
+// The opcache settings a bake runs under, with the file cache's directory left to be filled in.
+//
+// A bake is not one PHP process: this command re-execs into one, and that one starts a child per
+// parse shard and per skin. Each would compile MediaWiki from source over again, opcache shipping
+// enabled for the web and off for the command line, and the file cache is what they share.
+//
+// revalidate_freq is zero rather than a web server's minute because a bake writes PHP to disk
+// after PHP has started -- the extensions it fetches, the require_once it appends to the
+// LocalSettings.php it just installed -- and the embed root those land in outlives the run.
+const opcacheSettings = `; Written by wikven at the start of every run; an edit here does not survive one.
+opcache.enable_cli=1
+opcache.file_cache=%s
+opcache.revalidate_freq=0
+opcache.memory_consumption=256
+opcache.max_accelerated_files=10000
+`
+
+// workdir is the directory a run reads src/ and writes dist/ under.
+func workdir() string {
+	if dir := os.Getenv("WIKVEN_WORKDIR"); dir != "" {
+		return dir
+	}
+	return "."
+}
+
+// phpEnv writes the settings above under the working directory's own cache and returns the
+// environment that points PHP at them, or nothing where they could not be written.
+//
+// Nothing is a bake that compiles more and runs slower, which is every bake before this one; it is
+// not a reason to refuse one, and the caller cannot do anything about it either way.
+//
+// The image says this in a file under conf.d. That is not open to the binary, whose PHP looks for
+// a php.ini in the directory it was run in -- the caller's, not ours -- so the settings go where
+// this can write and the environment does the pointing. PHP_INI_SCAN_DIR rather than PHPRC because
+// it adds to what PHP finds instead of replacing it, leaving a php.ini the caller wrote alone, and
+// because a child process inherits it: the children are where a shared cache pays.
+func phpEnv(dir string) []string {
+	// Absolute, because these paths outlive this process's idea of where it is: the build starts its
+	// shard and skin passes from the embed root, and a relative one would send each of them looking
+	// somewhere else -- which is every process the shared cache exists for.
+	root, err := filepath.Abs(dir)
+	if err != nil {
+		return nil
+	}
+	conf := filepath.Join(root, ".cache", "php")
+	cache := filepath.Join(root, ".cache", "opcache")
+	// The cache directory has to be there before PHP starts. opcache handed a file_cache that is
+	// not a directory drops the setting silently -- no warning, no error, and no cache.
+	if os.MkdirAll(conf, 0o777) != nil || os.MkdirAll(cache, 0o777) != nil {
+		return nil
+	}
+	settings := fmt.Sprintf(opcacheSettings, cache)
+	if os.WriteFile(filepath.Join(conf, "opcache.ini"), []byte(settings), 0o666) != nil {
+		return nil
+	}
+	// An empty value ahead of the separator is what tells PHP to keep scanning where it was built
+	// to; a value the caller set is theirs, and stays ahead of this one so this file is read last.
+	return []string{"PHP_INI_SCAN_DIR=" + os.Getenv("PHP_INI_SCAN_DIR") + ":" + conf}
 }
 
 // previewURL is the address to open for a listen address, as a reader would type it.
@@ -152,8 +209,9 @@ func commandTail(name string) []string {
 	return nil
 }
 
-// reexec runs this same binary with the given args, wiring stdio and the current environment.
-func reexec(args ...string) (int, error) {
+// reexec runs this same binary with the given args, wiring stdio and the current environment plus
+// the entries given here.
+func reexec(extraEnv []string, args ...string) (int, error) {
 	self, err := os.Executable()
 	if err != nil {
 		return 1, err
@@ -162,7 +220,7 @@ func reexec(args ...string) (int, error) {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), runtimeEnv()...)
+	cmd.Env = append(append(os.Environ(), runtimeEnv()...), extraEnv...)
 	if err := cmd.Run(); err != nil {
 		// Propagate the child's own exit code, so a caller scripting on `wikven build` -- a
 		// Makefile, a CI job, a deploy script -- can tell a refusal from a success.

--- a/caddy/wikven_test.go
+++ b/caddy/wikven_test.go
@@ -1,6 +1,12 @@
 package wikvencaddy
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
 
 // The addresses Caddy's --listen takes, against the address a reader is given for each.
 func TestPreviewURL(t *testing.T) {
@@ -18,5 +24,96 @@ func TestPreviewURL(t *testing.T) {
 		if got := previewURL(listen); got != want {
 			t.Errorf("previewURL(%q) = %q, want %q", listen, got, want)
 		}
+	}
+}
+
+// A working directory gets the settings written into it, and PHP is pointed at where they went.
+func TestPHPEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PHP_INI_SCAN_DIR", "")
+
+	conf := filepath.Join(dir, ".cache", "php")
+	env := phpEnv(dir)
+	if want := []string{"PHP_INI_SCAN_DIR=:" + conf}; !slices.Equal(env, want) {
+		t.Errorf("phpEnv(%q) = %q, want %q", dir, env, want)
+	}
+
+	// The file cache goes where PHP will look for it, and it is there before PHP starts: opcache
+	// given a file_cache that is not a directory drops the setting without saying so.
+	cache := filepath.Join(dir, ".cache", "opcache")
+	if info, err := os.Stat(cache); err != nil || !info.IsDir() {
+		t.Errorf("the file cache directory %q is not there: %v", cache, err)
+	}
+	written, err := os.ReadFile(filepath.Join(conf, "opcache.ini"))
+	if err != nil {
+		t.Fatalf("reading the settings back: %v", err)
+	}
+	for _, want := range []string{"opcache.enable_cli=1", "opcache.file_cache=" + cache} {
+		if !strings.Contains(string(written), want) {
+			t.Errorf("the settings do not carry %q:\n%s", want, written)
+		}
+	}
+}
+
+// A scan directory the caller chose is kept, and read before the one written above.
+func TestPHPEnvKeepsTheCallersScanDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PHP_INI_SCAN_DIR", "/etc/theirs")
+
+	want := []string{"PHP_INI_SCAN_DIR=/etc/theirs:" + filepath.Join(dir, ".cache", "php")}
+	if env := phpEnv(dir); !slices.Equal(env, want) {
+		t.Errorf("phpEnv(%q) = %q, want %q", dir, env, want)
+	}
+}
+
+// Nowhere to write is a bake that compiles more, not a bake that refuses.
+func TestPHPEnvSaysNothingWhenItCannotWrite(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(blocked, nil, 0o666); err != nil {
+		t.Fatalf("making the obstruction: %v", err)
+	}
+	if env := phpEnv(blocked); env != nil {
+		t.Errorf("phpEnv(%q) = %q, want nothing", blocked, env)
+	}
+}
+
+// The working directory a run uses: what was asked for, or where it was run.
+func TestWorkdir(t *testing.T) {
+	t.Setenv("WIKVEN_WORKDIR", "/somewhere")
+	if got := workdir(); got != "/somewhere" {
+		t.Errorf("workdir() = %q, want %q", got, "/somewhere")
+	}
+	t.Setenv("WIKVEN_WORKDIR", "")
+	if got := workdir(); got != "." {
+		t.Errorf("workdir() = %q, want %q", got, ".")
+	}
+}
+
+// The default working directory is a relative one, and what PHP is told has to survive a child
+// started from somewhere else.
+func TestPHPEnvIsAbsolute(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("PHP_INI_SCAN_DIR", "")
+	// Asked for rather than kept from above: a temporary directory can be reached through a link,
+	// and what this compares against is the path a process there actually reports.
+	here, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("asking where we are: %v", err)
+	}
+
+	env := phpEnv(".")
+	if len(env) != 1 {
+		t.Fatalf("phpEnv(\".\") = %q, want one entry", env)
+	}
+	path := strings.TrimPrefix(strings.TrimPrefix(env[0], "PHP_INI_SCAN_DIR="), ":")
+	if !filepath.IsAbs(path) {
+		t.Errorf("phpEnv(\".\") points PHP at %q, which is not an absolute path", path)
+	}
+	settings, err := os.ReadFile(filepath.Join(path, "opcache.ini"))
+	if err != nil {
+		t.Fatalf("reading the settings back: %v", err)
+	}
+	if !strings.Contains(string(settings), "opcache.file_cache="+filepath.Join(here, ".cache", "opcache")) {
+		t.Errorf("the file cache is not where the run can find it:\n%s", settings)
 	}
 }


### PR DESCRIPTION
#741 gave the image CLI OPcache with a file cache its fifteen-odd PHP processes share. The binary was left out because where a static PHP reads a `php.ini` from had to be found out rather than assumed. It has been:

> **Static binary** — `php.ini`: The directory in which `frankenphp run` or `frankenphp php-server` is executed, then `/etc/frankenphp/php.ini`; additional configuration files: `/etc/frankenphp/php.d/*.ini`
> — [FrankenPHP's configuration documentation](https://frankenphp.dev/docs/config/)

Neither is ours to write. The directory the binary is run in belongs to whoever ran it, and `/etc` belongs to the machine. So `caddy/wikven.go` — which is already the thing that runs before PHP starts, and already hands the bake `WIKVEN_RUNTIME` — writes the settings into `<workdir>/.cache/php/` and points PHP at them with `PHP_INI_SCAN_DIR`.

`PHP_INI_SCAN_DIR` rather than `PHPRC` for two reasons: it adds to what PHP finds instead of replacing it, so a `php.ini` the caller wrote is left alone; and a child process inherits it, which is the whole point — the shards and the skin passes are where a shared cache pays, and they are started by PHP, not by this code.

The paths are absolute. The build runs its shard and skin passes from the embed root rather than the working directory, so a relative one would send each of them somewhere else.

## Measured

The docs site, baked with the binary this branch builds, four times, alternating. The settings were turned off by leaving a file where `caddy/wikven.go` wants a directory, so an "off" bake is one from before this branch; each run started from a fresh working directory, so the file cache was empty every time.

| | off | on |
| --- | ---: | ---: |
| the whole bake | 88.4 / 88.6s | **87.5 / 87.4s** |
| `build the translations` | 46.2 / 46.6s | 46.5 / 46.1s |
| `render the skins` | 23.0 / 22.6s | 21.9 / 21.9s |

**About 1.1 seconds, near 1.2%** — a quarter of what the image got, and all of it in the skin passes. The exports were identical, and the switch itself was checked: an "off" bake left no compiled files behind, an "on" bake left 2,401.

The shape of that is worth reading. In the image the translations phase gained 5 seconds too, because opcache there was off outright and turning it on brought the optimizer with it. Here that phase does not move, which says the binary's PHP was already running opcache in-process; what this adds is only the part separate processes share, and the only place a bake starts other processes for long enough to notice is the three skin passes.

So it is a second, not five. It is still free, it changes nothing about the output, and it makes the two products behave the same way — and `revalidate_freq` is not only about speed here: the binary's embed root outlives a run, and a bake rewrites `LocalSettings.php` inside it after PHP has started.

Closes #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn