### PR TITLE
feat: stop the published site's branch from being deleted

### DIFF
--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -81,3 +81,30 @@ resource "github_repository_ruleset" "default" {
     }
   }
 }
+
+# gh-pages is the site itself: Deploy docs builds it from main, and pr-preview writes each open
+# pull request's preview into a subfolder beside it. Nothing recreates the branch on its own, so a
+# deletion is the published site gone until somebody notices and re-runs the workflow, and every
+# open preview with it.
+#
+# Deletion is all this blocks. The deploy action force-pushes by default, which is what lets a docs
+# deploy and a preview reach this branch without waiting on each other, so non_fast_forward would
+# trade a live site for a protected one. No bypass actors either: nothing here has cause to delete
+# it, and the rule stops no push.
+resource "github_repository_ruleset" "pages" {
+  name        = "gh-pages"
+  repository  = github_repository.this.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["refs/heads/gh-pages"]
+      exclude = []
+    }
+  }
+
+  rules {
+    deletion = true
+  }
+}


### PR DESCRIPTION
The one ruleset this repository has covers the default branch. `gh-pages` — which is the published site, and holds every open pull request's preview beside it — has none.

Nothing recreates that branch on its own. Deleted, the site is 404 until a docs change lands on `main` or somebody runs `Deploy docs` by hand, and the previews under `pr-preview/` are gone until each pull request is pushed to again.

## Deletion, and nothing else

`deletion = true` is the whole rule. It stops no push, so it needs no bypass actors, and neither `Deploy docs` nor `PR preview` deletes the branch — the preview teardown on close is a commit that removes a subfolder.

The obvious companion, blocking force-pushes, is deliberately left out. `JamesIves/github-pages-deploy-action` sets `force: true` by default, and the two workflows that write to this branch are in different concurrency groups: a docs deploy and a preview can be pushing at the same time, and the force-push is what makes that land rather than fail. Turning it off to satisfy a rule would trade a working deploy for a protected branch.

Requiring pull requests, or `update`, would break both workflows outright.

## Restricting who may push

There is a stronger shape — `update = true` with the GitHub Actions app as a bypass actor, so only a workflow can write the branch. Not proposed here: bypass actors are unreadable by CI's token in this repository (see the `dynamic` block in the existing ruleset), so it would mean every apply having to come from a local run with the right token, and an apply that got it wrong would stop the site deploying. Say the word if you want it anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_