### PR TITLE
ci: keep the repository's own settings out of the release notes

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,6 +5,7 @@
 			"release-type": "simple",
 			"include-component-in-tag": false,
 			"draft": true,
+			"exclude-paths": [".tf"],
 			"extra-files": [
 				{ "type": "json", "path": "extension.json", "jsonpath": "$.version" },
 				{ "type": "generic", "path": "actions/bake/action.yml" },


### PR DESCRIPTION
#744 landed as `feat:`. It is not one: `.tf/` says how GitHub is configured, and a reader of the release notes has no wiki that behaves differently for it. release-please read the label it was given and put it under **Features** in #618.

## What can and cannot be corrected

A merged commit's type cannot be changed — `main` takes no rewrite, and release-please offers nothing that retypes an earlier commit. `Release-As:` is the one footer that reaches back, and it would change nothing here anyway: ten other `feat:` commits since 1.0.0 already settle the minor bump, so 1.1.0 is 1.1.0 either way. The mistake cost a changelog line, not a version.

What the configuration does offer is `exclude-paths`, which drops a commit whose every file sits under one of the named paths — before the type is ever read. So this is not a correction of one commit but of the rule that let it through: nothing under `.tf/` reaches a release again, however it is labelled.

## Effect

release-please re-reads the range on every run, so #618 loses the entry on the next one. Of every commit since 1.0.0, exactly one touches nothing but `.tf/` — #744 — so that is the only line that moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_