### PR TITLE
ci: keep the documentation site out of the release notes too

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,7 +5,7 @@
 			"release-type": "simple",
 			"include-component-in-tag": false,
 			"draft": true,
-			"exclude-paths": [".tf"],
+			"exclude-paths": [".tf", "docs"],
 			"extra-files": [
 				{ "type": "json", "path": "extension.json", "jsonpath": "$.version" },
 				{ "type": "generic", "path": "actions/bake/action.yml" },


### PR DESCRIPTION
`.tf/` was excluded in #746 because a release does not deliver it. `docs/` is the same case for a different reason: `deploy-docs.yml` publishes it the moment a change reaches `main`, so by the time a version is tagged that change has been live on the site for days. A release has nothing to claim there, whatever type the commit carries.

## Nothing moves

Of the commits since 1.0.0 that touch `docs/` and nothing else, thirteen are `docs:` and one is `build(deps)`. Both are already hidden and neither bumps, so the pending 1.1.0 reads exactly as it does now. This only closes the gap a mislabelled commit would go through — which is the gap #744 went through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_