### PR TITLE
ci: catch a title that calls the repository a feature of wikven

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -50,12 +50,16 @@ jobs:
           header: pr-title-lint-error
           delete: true
 
-  # A change to the documentation alone is not a feature or a fix of wikven, but naming it one
-  # says it is: the title becomes the squash commit's subject, release-please reads that, and the
-  # change lands in the changelog and moves the version. So refuse the two types that do, and
-  # leave every other type alone -- this is not an opinion about what a docs-only change should
+  # A change to the repository rather than to the program is not a feature or a fix of wikven, but
+  # naming it one says it is: the title becomes the squash commit's subject, release-please reads
+  # that, and the change lands in the changelog and moves the version. So refuse the two types that
+  # do, and leave every other type alone -- this is not an opinion about what such a change should
   # be called, only about the two things it cannot be.
-  docs-only:
+  #
+  # It read the documentation alone until #744, a ruleset under .tf/ that called itself a feature
+  # and reached 1.1.0's changelog as one. release-please now skips those paths outright, but that
+  # is a net under the mistake; this is the place it gets caught, and told to whoever made it.
+  repository-only:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -87,18 +91,21 @@ jobs:
             exit 0
           fi
 
-          # Everything the documentation is made of: the wiki source the site is built from, every
-          # Markdown file (the readmes), and the licence text. A pull request touching one file
-          # outside this is a change to wikven and may call itself what it likes.
+          # Everything that is the repository and not the program: the wiki source the site is
+          # built from, every Markdown file (the readmes), the licence text, how GitHub itself is
+          # configured, and what CI runs. A pull request touching one file outside this is a change
+          # to wikven and may call itself what it likes.
+          #
+          # A superset of release-please's own exclude-paths, which can only name directories.
           while IFS= read -r file; do
             case "$file" in
-              docs/* | *.md | LICENSE) ;;
-              *) echo "wikven: '$file' is not documentation; '$type' is fine here."; exit 0 ;;
+              docs/* | *.md | LICENSE | .tf/* | .github/*) ;;
+              *) echo "wikven: '$file' is wikven's own; '$type' is fine here."; exit 0 ;;
             esac
           done < "$files"
 
-          echo "::error::wikven: this pull request changes documentation only, so it cannot be" \
-               "'$type'. A '$type' title becomes the squash commit's subject, which release-please" \
-               "reads: the change would be listed in the changelog and would move wikven's version," \
-               "and neither is true of it. Use 'docs:' instead."
+          echo "::error::wikven: this pull request changes the repository and not wikven, so it" \
+               "cannot be '$type'. A '$type' title becomes the squash commit's subject, which" \
+               "release-please reads: the change would be listed in the changelog and would move" \
+               "wikven's version, and neither is true of it. Use 'docs:', 'ci:' or 'chore:'."
           exit 1

--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -65,6 +65,7 @@ resource "github_repository_ruleset" "default" {
           "phpcs",
           "phpunit (REL1_46)",
           "phpunit (master)",
+          "repository-only",
           "rumdl",
           "semantic-pull-request",
           "smoke",


### PR DESCRIPTION
There already is a check for this. `semantic-pull-request.yml` carries a second job that refuses `feat:` and `fix:` on a pull request touching nothing but documentation, for exactly the reason #744 turned out to matter: the title becomes the squash commit's subject, and release-please reads it.

#744 went through it twice over.

**Its list was too narrow.** It read `docs/`, `*.md` and `LICENSE`. A ruleset under `.tf/` is none of those, so the job said the change was wikven's own and let `feat:` stand. Widened here to everything that is the repository rather than the program — the two above plus `.tf/` and `.github/`.

**It could not have blocked anything anyway.** The job is not in the required checks, so a red result leaves the pull request mergeable, and auto-merge would have merged it regardless. Added to the list in `.tf/ruleset.tf`.

Renamed `docs-only` → `repository-only`, since it no longer reads only documentation, and the required check has to name it.

#746 and #747 gave release-please `exclude-paths` for `.tf` and `docs`. That is a net under the mistake: the commit is dropped silently, and nobody learns anything. This is where it gets caught and said out loud, which is also why the check's list is wider than `exclude-paths` — the latter can only name directories, so `*.md` and `LICENSE` cannot appear in it.

## Exercised

The job's own script, lifted out of the workflow with `gh api` stubbed, against ten pull requests:

| title | files | result |
| --- | --- | --- |
| `feat: …` | `.tf/ruleset.tf` | refused |
| `feat: …` | `.github/workflows/a.yml` | refused |
| `feat: …` | `docs/a.wikitext`, `README.md` | refused |
| `feat: …` | `LICENSE` | refused |
| `fix(build): …` | `.tf/ruleset.tf` | refused |
| `feat!: …` | `.tf/ruleset.tf` | refused |
| `feat: …` | `includes/A.php` | allowed |
| `feat: …` | `docs/a.wikitext`, `includes/A.php` | allowed |
| `docs: …` | `.tf/ruleset.tf` | allowed |
| `ci: …` | `.tf/ruleset.tf` | allowed |

Run locally, and it has to be: the workflow triggers on `pull_request_target`, which runs the version on the base branch. The check reporting on this pull request is `docs-only` from `main` — the widened job first runs on whatever comes after this. The same goes for the required-check entry, which needs a `tofu apply`; until then `repository-only` reports without blocking.

Two consequences of that worth knowing about. Between merging and applying, `docs-only` no longer exists while nothing requires `repository-only`, so for that window neither name blocks. And this pull request cannot check its own title — it touches only `.github/` and `.tf/`, so `ci:` is what the new rule would allow, but the rule is not the one that ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn