### PR TITLE
ci: say which merge method the repository actually allows

### DIFF
--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -34,7 +34,8 @@ resource "github_repository_ruleset" "default" {
     non_fast_forward = true
     update           = false
 
-    # Merge commits are the only allowed merge method, so linear history must not be required.
+    # Squash is the only merge method the repository allows, so main is linear however this is
+    # set: requiring it would forbid nothing that can happen here.
     required_linear_history = false
     required_signatures     = false
 


### PR DESCRIPTION
A comment in `.tf/ruleset.tf` says the wrong thing, and the file that contradicts it is the one next to it.

**The comment** (`.tf/ruleset.tf`):

> Merge commits are the only allowed merge method, so linear history must not be required.

**The settings** (`.tf/repository.tf`):

```hcl
allow_merge_commit          = false
allow_rebase_merge          = false
allow_squash_merge          = true
```

Squash is the only one allowed — and it is the one every merge in this repository's recent history used. So the comment is wrong twice over: about which method, and about what follows. Squash puts a single commit on top of `main`, which is linear by construction, so requiring linear history would forbid nothing that can happen.

`required_linear_history = false` is left exactly as it is. Only the sentence above it changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_