### PR TITLE
ci: say the bake assertions are PHP, which they have always been

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -123,10 +123,7 @@ jobs:
           exit "$status"
 
       # What a finished site has to be true of is written down in tests/bake/, one method of the
-      # Checks class per fact, against expectations tests/bake/docs.php holds for this site. It used
-      # to be 471 lines of shell and embedded Python in this file, which meant the only way to run
-      # it was to push: changing one check in #663 took parsing this workflow's YAML and extracting
-      # the heredoc back out to a file, to run it against two bakes that were already on disk.
+      # Checks class per fact, against expectations tests/bake/docs.php holds for this site.
       #
       # A contributor with a bake runs the same checks with `composer test:bake`. What is added here
       # is only what a runner has and a laptop does not: the logs the two bakes wrote, the second

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -122,11 +122,11 @@ jobs:
           echo '::endgroup::'
           exit "$status"
 
-      # What a finished site has to be true of is written down in tests/bake/, one Python function
-      # per fact, against expectations tests/bake/docs.toml holds for this site. It used to be 471
-      # lines of shell and embedded Python in this file, which meant the only way to run it was to
-      # push: changing one check in #663 took parsing this workflow's YAML and extracting the
-      # heredoc back out to a file, to run it against two bakes that were already on disk.
+      # What a finished site has to be true of is written down in tests/bake/, one method of the
+      # Checks class per fact, against expectations tests/bake/docs.php holds for this site. It used
+      # to be 471 lines of shell and embedded Python in this file, which meant the only way to run
+      # it was to push: changing one check in #663 took parsing this workflow's YAML and extracting
+      # the heredoc back out to a file, to run it against two bakes that were already on disk.
       #
       # A contributor with a bake runs the same checks with `composer test:bake`. What is added here
       # is only what a runner has and a laptop does not: the logs the two bakes wrote, the second


### PR DESCRIPTION
A comment in `smoke.yml` is contradicted by the step it sits on top of, four lines down.

**The comment:**

> What a finished site has to be true of is written down in `tests/bake/`, one **Python function** per fact, against expectations **`tests/bake/docs.toml`** holds for this site. It used to be 471 lines of shell and embedded Python in this file, which meant the only way to run it was to push: changing one check in #663 took parsing this workflow's YAML and extracting the heredoc back out to a file, to run it against two bakes that were already on disk.

**The step:**

```bash
php tests/bake/assert-bake.php \
  --expect tests/bake/docs.php --source docs \
  ...
```

**The directory:**

```
$ ls tests/bake/
Check.php  Checks.php  Runner.php  Site.php  assert-bake.php  docs.php
```

PHP, and `docs.php`. What the comment describes as a function per fact is a method per fact on the `Checks` class — `sitemap()`, `ogUrl()`, `noindex()`, `ogImage()` and the rest, each returning the problems it found.

The second sentence goes with it. What this used to be before #663 is not something a reader of the step needs, and it is the reason the first sentence went stale in the first place: the description and its own history were written as one paragraph, so the description read as history too.

Two lines where there were five.

### Where this sits

`tests/bake/` is one of the four kinds of test the repository has. It is the one that reads a site **after** it has been baked and says whether it is complete and self-contained: no `load.php` left in the CSS, a search bundle in every skin, a sitemap that names the right address. `docs.php` holds the answers that are this site's rather than wikven's, so the same entry point can read any bake. A contributor with a bake in `dist/` runs the same checks with `composer test:bake`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn