### PR TITLE
fix: give the settings page the sentence written for it

### DIFF
--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -1247,10 +1247,14 @@ class Build extends Maintenance {
 			return;
 		}
 
+		// Where the choices are kept is the question a settings page with no account on it raises,
+		// so the page opens by answering it: this browser, this site, nobody signed in.
+		$text = $this->contentMsg('wikven-settings-intro') . "\n\n";
+
 		// Special:MobileOptions is an empty form its own script fills, so this page is the same
 		// empty form. Wikitext carries no <form> and that stylesheet's layout rules all name one,
 		// so fillMinervaMenu.php puts a real form inside this.
-		$text = "<div id=\"wikven-settings-form\"></div>\n";
+		$text .= "<div id=\"wikven-settings-form\"></div>\n";
 		if (count((array)$config->get('WikvenSkins')) > 1) {
 			$text .= $this->settingsSection(
 				'wikven-skins',


### PR DESCRIPTION
A message has been sitting in three files since #366, translated, documented, and shown to nobody.

```json
// i18n/en.json
"wikven-settings-intro": "These choices are kept in this browser. They apply to this site only, and no account is involved."

// i18n/qqq.json
"wikven-settings-intro": "Opening sentence of the generated settings page, explaining that a static
                          export keeps display choices in the reader's browser."

// i18n/ko.json
"wikven-settings-intro": "이 선택은 이 브라우저에 보관됩니다. 이 사이트에만 적용되며, 계정은 관여하지 않습니다."
```

`grep` finds it in those three files and nowhere else. `git log -S` finds one commit — the one that added it. It was never wired up.

So the page opens with an empty `<div>`, and a reader who lands on a settings page with no account on it is told nowhere where their choices go. That is the question the sentence answers, which is presumably why it was written.

Four lines in `setSettingsPage()` put it back where `qqq.json` says it belongs.

## What a bake does with it

Baked locally against a reference bake of `main`, the change reaches exactly sixteen files and no others: `Settings.html` in each of the three skins, and each skin's search index, which now carries the sentence.

The page itself gains three things, only one of them written here:

```html
+ <meta name="description" content="These choices are kept in this browser. …">
+ <meta property="og:description" content="These choices are kept in this browser. …">
+ "description":"These choices are kept in this browser. …"   ← the JSON-LD
+ <p>These choices are kept in this browser. They apply to this site only, and no account is involved.</p>
```

The build takes a page's description from its first paragraph, and the settings page had no first paragraph, so it has been shipping with no description at all — not in its `<meta>`, not in its Open Graph card, not in its structured data. One sentence fixes all four.

`fillMinervaMenu.php` puts a real `<form>` **inside** `#wikven-settings-form`, so a paragraph before that div does not disturb it. The e2e test that measures a paragraph's font size reads `Installation.html`, not this page.

### Where this sits

A bake writes no special pages, so `Special:MobileOptions` — where Minerva sends readers for how the site looks — does not exist in an export. `setSettingsPage()` generates an ordinary page to stand in its place, holding empty placeholders that MobileFrontend's own script fills in the browser. It is the one page in a wikven site whose wikitext is written by the build rather than by the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_