### PR TITLE
ci: take the afternoons out of the workflow comments

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -56,9 +56,8 @@ jobs:
   # do, and leave every other type alone -- this is not an opinion about what such a change should
   # be called, only about the two things it cannot be.
   #
-  # It read the documentation alone until #744, a ruleset under .tf/ that called itself a feature
-  # and reached 1.1.0's changelog as one. release-please now skips those paths outright, but that
-  # is a net under the mistake; this is the place it gets caught, and told to whoever made it.
+  # release-please skips these paths as well, which is a net under the mistake. This is the place it
+  # is caught and said to whoever made it.
   repository-only:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -40,11 +40,8 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    # Every job in this repository carries one of these, and this is the job that earned them. On
-    # 2026-08-18 the runner's Ubuntu mirror stopped answering during `playwright install
-    # --with-deps`; apt fell back to archive.ubuntu.com, fetched the release files and then sat
-    # there. With no timeout the job waited out GitHub's six-hour default before anyone was told
-    # anything. The mirror is not ours to fix; how long we wait to hear about it is.
+    # Every job in this repository carries one of these: a runner that stops answering otherwise
+    # waits out GitHub's six-hour default before anybody is told anything.
     #
     # Three times what the job takes -- around ten minutes, two bakes and a browser install -- so a
     # stall is reported in minutes while a slow but healthy run never trips it.
@@ -218,15 +215,12 @@ jobs:
       #
       # And no --with-deps, which is the apt call. The runner image already carries Google Chrome,
       # Chromium, Edge and Firefox as installed packages, so the shared libraries the shell wants are
-      # on the machine before we ask for anything; --with-deps was buying nothing and paying for it.
-      # Twice -- 2026-08-18 and 2026-08-19 -- azure.archive.ubuntu.com answered nothing at all, apt
-      # fell back to archive.ubuntu.com, took the four InRelease files and then went quiet on the
-      # package indexes until the job was killed. A mirror that is not ours, on a path we do not need.
+      # on the machine before we ask for anything, and an apt call is a mirror that is not ours on a
+      # path we do not need.
       #
-      # Ran the suite locally against a real bake with nothing but the shell on disk: 57 passed. If
-      # either half were ever not enough -- a spec asking for a headed browser, or a library the image
-      # stops shipping -- Playwright says which executable or which .so it cannot find, so this cannot
-      # quietly test the wrong thing.
+      # If either half were ever not enough -- a spec asking for a headed browser, or a library the
+      # image stops shipping -- Playwright says which executable or which .so it cannot find, so this
+      # cannot quietly test the wrong thing.
       - name: Install the browser test tooling
         run: |
           npm ci


### PR DESCRIPTION
Following #751, the same thing in three more comments: most of their length goes on what went wrong once rather than on what is true now. In each, the rule that came out of it was already there in the next sentence.

Sixteen lines become nine. No behaviour changes.

## `smoke.yml` — the timeout

Five lines on one afternoon: a mirror that stopped answering, which file it had already fetched, where apt fell back to. What survives is the reason every job in the repository carries a timeout at all.

```diff
-    # Every job in this repository carries one of these, and this is the job that earned them. On
-    # 2026-08-18 the runner's Ubuntu mirror stopped answering during `playwright install
-    # --with-deps`; apt fell back to archive.ubuntu.com, fetched the release files and then sat
-    # there. With no timeout the job waited out GitHub's six-hour default before anyone was told
-    # anything. The mirror is not ours to fix; how long we wait to hear about it is.
+    # Every job in this repository carries one of these: a runner that stops answering otherwise
+    # waits out GitHub's six-hour default before anybody is told anything.
```

The paragraph under it — why thirty minutes and not ten — is untouched.

## `smoke.yml` — the browser install

The same mirror, twice more, by date. And a local run that passed once, which is a measurement rather than a fact about the code.

```diff
-      # on the machine before we ask for anything; --with-deps was buying nothing and paying for it.
-      # Twice -- 2026-08-18 and 2026-08-19 -- azure.archive.ubuntu.com answered nothing at all, apt
-      # fell back to archive.ubuntu.com, took the four InRelease files and then went quiet on the
-      # package indexes until the job was killed. A mirror that is not ours, on a path we do not need.
+      # on the machine before we ask for anything, and an apt call is a mirror that is not ours on a
+      # path we do not need.
```

The sentence about what Playwright says when either half is not enough stays: that is about any future run, not a past one.

## `semantic-pull-request.yml` — mine, from #748

I wrote this one three days ago and it has the same fault, so it goes the same way.

```diff
-  # It read the documentation alone until #744, a ruleset under .tf/ that called itself a feature
-  # and reached 1.1.0's changelog as one. release-please now skips those paths outright, but that
-  # is a net under the mistake; this is the place it gets caught, and told to whoever made it.
+  # release-please skips these paths as well, which is a net under the mistake. This is the place it
+  # is caught and said to whoever made it.
```

## What is deliberately left alone

Comments that explain **why the code is the way it is** — this repository has a word budget for them and they are the reason it passes. Only past-tense narration goes. A regression test's docblock naming the failure it catches stays: that is what the test is for, not a story about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_