### PR TITLE
docs: say what the download services do, not what one did once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN apk add --no-cache gmp \
 
 # Fetched before wikven's own code is copied in, so an edit there does not bust the slow layers.
 
-# "Stable source" describes the bytes, not the service in front of them: GitHub served 500s for
-# hours on 2026-08-17, and codeload answers 429 under load. --retry-all-errors as well as --retry,
-# because curl counts a connection reset as non-transient and would not repeat it.
+# "Stable source" describes the bytes, not the service in front of them, which answers 429 under
+# load and sometimes nothing at all. --retry-all-errors as well as --retry, because curl counts a
+# connection reset as non-transient and would not repeat it.
 ARG CURL_RETRY="--retry 5 --retry-delay 2 --retry-all-errors"
 
 # And who is asking: curl signs with its own version, naming the library rather than the project.


### PR DESCRIPTION
The comment beside `CURL_RETRY` in the `Dockerfile` dates an outage:

> GitHub served 500s for hours on **2026-08-17**, and codeload answers 429 under load.

A reader wondering why the image retries its downloads does not need the afternoon; they need what those services do on any day. The second half of that sentence already said it in the present tense, so the fix is to finish the thought and drop the date.

```diff
-# "Stable source" describes the bytes, not the service in front of them: GitHub served 500s for
-# hours on 2026-08-17, and codeload answers 429 under load. --retry-all-errors as well as --retry,
-# because curl counts a connection reset as non-transient and would not repeat it.
+# "Stable source" describes the bytes, not the service in front of them, which answers 429 under
+# load and sometimes nothing at all. --retry-all-errors as well as --retry, because curl counts a
+# connection reset as non-transient and would not repeat it.
```

The clause that matters is untouched: `--retry-all-errors` on top of `--retry`, because curl reads a connection reset as permanent and will not try that one again on its own.

### Where this sits

`CURL_RETRY` is a build argument the `Dockerfile` passes to every `curl` in it — SifterSearch's release tarball, Translate's and UniversalLanguageSelector's source archives. Those are pinned by tag or commit, so the *bytes* never change; what can fail is the host handing them over. Three lines above it, `CURL_AGENT` is the other half of the same idea: the image says who is asking.

Same clean-up as #751 and #754, in the one file outside CI that had it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_