### PR TITLE
docs: drop the line about what Scribunto's absence used to do

### DIFF
--- a/includes/Scribunto.php
+++ b/includes/Scribunto.php
@@ -7,8 +7,6 @@ namespace MediaWiki\Extension\Wikven;
  *
  * wikven's two products disagree: the image compiles luasandbox into its PHP, while the binary
  * reaches Lua only by shelling out, which it can on 64-bit x86 Linux and nowhere else.
- *
- * That used to be silent -- a page invoking a module rendered "{{#invoke:Greet|hello}}".
  */
 class Scribunto {
 	/** The extension a site lists to ask for Lua. */


### PR DESCRIPTION
The last line of `Scribunto`'s class docblock is about the time before the class:

```diff
  * Whether this build can render Lua, and what to say when it cannot.
  *
  * wikven's two products disagree: the image compiles luasandbox into its PHP, while the binary
  * reaches Lua only by shelling out, which it can on 64-bit x86 Linux and nowhere else.
- *
- * That used to be silent -- a page invoking a module rendered "{{#invoke:Greet|hello}}".
  */
```

It is saying twice over what is already there. The first line says the class exists to say something when Lua cannot be rendered, and the symptom it names is in the message the class returns, thirty lines down:

```php
. ' is not in extensions, so a {{#invoke:}} is left in the page as its own source text,'
```

A reader who wants to know what a reader sees finds it where the text is written, in the present tense, rather than in a docblock's account of how things once were.

### Where this sits

`Scribunto` is a small pure class asked two questions by `build.php`: is this a build that can render Lua at all (`problem()`), and is this a site that will notice (`warning()`). The split matters because wikven ships two products with different answers — the image compiles luasandbox into its PHP; the binary shells out to a Lua interpreter, which Scribunto bundles for 64-bit x86 Linux and nowhere else. A site with no `Module:` pages is told nothing either way.

Same clean-up as #751, #754 and #755. The comment budget reads 3.30 words a line against a ceiling of 4.00 afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn

---
_Generated by [Claude Code](https://claude.ai/code/session_019ghEx26MRm9V5CnCLrdUQn)_